### PR TITLE
Add public API

### DIFF
--- a/src/types/generatedWebfont.ts
+++ b/src/types/generatedWebfont.ts
@@ -1,0 +1,4 @@
+export type GeneratedWebfont = {
+    type: string;
+    href: string;
+};

--- a/src/types/publicApi.ts
+++ b/src/types/publicApi.ts
@@ -1,0 +1,5 @@
+import type { GeneratedWebfont } from './generatedWebfont';
+
+export interface PublicApi {
+    getGeneratedWebfonts(): GeneratedWebfont[];
+}


### PR DESCRIPTION
I was needed to add generated fonts to the `<link rel="preload" />`. Firstly, I was thinking about add this functionality to your plugin but then I decided that the public API is a better option and implemented it along with a custom plugin for my needs that rely on your plugin.