### PR TITLE
Implement Font Inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ The plugin has an API consisting of one required parameter and multiple optional
 -   **description**: Virtual module id which is used by Vite to import the plugin artifacts. E.g. the default value is "vite-svg-2-webfont.css" so "virtual:vite-svg-2-webfont.css" should be imported.
 -   **default** `'vite-svg-2-webfont.css'`
 
+### inline
+
+-   **type**: `boolean`
+-   **description**: Inline font assets in CSS using base64 encoding.
+-   **default** `false`
+
 ## Public API
 
 The plugin exposes a public API that can be used inside another plugins using [Rollup inter-plugin communication mechanism](https://rollupjs.org/plugin-development/#inter-plugin-communication).

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,13 +38,15 @@ export function viteSvgToWebfont<T extends GeneratedFontTypes = GeneratedFontTyp
     const virtualModuleId = getVirtualModuleId(moduleId);
     const resolvedVirtualModuleId = getResolvedVirtualModuleId(virtualModuleId);
 
-    const inline = options.inline
-        ? <U extends string | undefined>(css: U) =>
-              css?.replace(/url\(".*?\.([^?]+)\?[^"]+"\)/g, (_, type: T) => {
-                  const font = Buffer.from(generatedFonts?.[type] || []);
-                  return `url("data:${MIME_TYPES[type]};charset=utf-8;base64,${font.toString('base64')}")`;
-              }) as U
-        : <U>(css: U) => css;
+    const inline = <U extends string | undefined>(css: U) => {
+        if (!options.inline) {
+            return css;
+        }
+        return css?.replace(/url\(".*?\.([^?]+)\?[^"]+"\)/g, (_, type: T) => {
+            const font = Buffer.from(generatedFonts?.[type] || []);
+            return `url("data:${MIME_TYPES[type]};charset=utf-8;base64,${font.toString('base64')}")`;
+        }) as U;
+    };
 
     const generate = async (updateFiles?: boolean) => {
         if (updateFiles) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,8 @@ export function viteSvgToWebfont<T extends GeneratedFontTypes = GeneratedFontTyp
     const inline = options.inline
         ? <U extends string | undefined>(css: U) =>
               css?.replace(/url\(".*?\.([^?]+)\?[^"]+"\)/g, (_, type: T) => {
-                  const font = generatedFonts?.[type];
-                  const fontData = typeof font === 'string' ? btoa(font) : font?.toString('base64');
-                  return `url("data:${MIME_TYPES[type]};charset=utf-8;base64,${fontData}")`;
+                  const font = Buffer.from(generatedFonts?.[type] || []);
+                  return `url("data:${MIME_TYPES[type]};charset=utf-8;base64,${font.toString('base64')}")`;
               }) as U
         : <U>(css: U) => css;
 

--- a/src/optionParser.ts
+++ b/src/optionParser.ts
@@ -138,6 +138,11 @@ export interface IconPluginOptions<T extends GeneratedFontTypes = GeneratedFontT
      * @default 'vite-svg-2-webfont.css'
      */
     moduleId?: string;
+    /**
+     * Inline font assets in CSS using base64 encoding.
+     * @default false
+     */
+    inline?: boolean;
 }
 
 export function parseIconTypesOption<T extends GeneratedFontTypes = GeneratedFontTypes>({ types }: Pick<IconPluginOptions<T>, 'types'>): T[] {


### PR DESCRIPTION
Addressing my suggestion in https://github.com/atlowChemi/vite-svg-2-webfont/issues/19#issuecomment-1961071304, I've added an option which allows fonts to be inlined directly into CSS as base64. This is extremely useful when there is a requirement that icons should be displayed as soon as the app loads (no empty squares or shifting layouts).

Here is a regex breakdown used in this PR: https://regex101.com/r/dnExDu/1