### PR TITLE
Use a hash based on content instead of `guid`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,7 @@ node_modules/
 # Output of 'npm pack'
 *.tgz
 
+# ide
+.idea
+
 dist

--- a/src/__snapshots__/utils.test.ts.snap
+++ b/src/__snapshots__/utils.test.ts.snap
@@ -1,9 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`utils > guid > should generate a string 1`] = `"dddddddd"`;
-
-exports[`utils > guid > should generate a string 2`] = `"d"`;
-
-exports[`utils > guid > should generate a string 3`] = `"dddddddddd"`;
-
-exports[`utils > guid > should generate a string 4`] = `"dddddddddddddddddddd"`;

--- a/src/fixtures/vite.basic.config.ts
+++ b/src/fixtures/vite.basic.config.ts
@@ -5,5 +5,8 @@ import { viteSvgToWebfont } from '../../';
 const webfontFolder = resolve(__dirname, './webfont-test/svg');
 
 export default defineConfig({
+    build: {
+        assetsInlineLimit: 0,
+    },
     plugins: [viteSvgToWebfont({ context: webfontFolder })],
 });

--- a/src/fixtures/vite.basic.config.ts
+++ b/src/fixtures/vite.basic.config.ts
@@ -5,8 +5,5 @@ import { viteSvgToWebfont } from '../../';
 const webfontFolder = resolve(__dirname, './webfont-test/svg');
 
 export default defineConfig({
-    build: {
-        assetsInlineLimit: 0,
-    },
     plugins: [viteSvgToWebfont({ context: webfontFolder })],
 });

--- a/src/fixtures/vite.no-inline.config.ts
+++ b/src/fixtures/vite.no-inline.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vite';
+import configBasic from './vite.basic.config';
+
+export default mergeConfig(
+    configBasic,
+    defineConfig({
+        build: {
+            assetsInlineLimit: 0,
+        },
+    }),
+);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,7 +144,7 @@ describe('build', () => {
 
                 let m;
                 while ((m = regex.exec(cssContent)) !== null) {
-                    if (m && m.groups && 'mime' in m.groups && 'data' in m.groups) {
+                    if (m?.groups && 'mime' in m.groups && 'data' in m.groups) {
                         const typeMime = typeToMimeMap[type];
                         if (m.groups.mime === typeMime) {
                             expected = base64ToArrayBuffer(m.groups.data);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -152,4 +152,15 @@ describe('utils', () => {
             expect(calculatedHash).toEqual(hash);
         });
     });
+
+    describe.concurrent('base64ToArrayBuffer', () => {
+        const strings = ['vite-svg-2-webfont', 'test-string-1', 'test-string-2'];
+
+        it.each(strings)('should match "%s"', string => {
+            const stringAsBase64 = btoa(string);
+            const arrayBuffer = utils.base64ToArrayBuffer(stringAsBase64);
+            const decodedString = new TextDecoder('utf-8').decode(arrayBuffer);
+            expect(decodedString).toEqual(string);
+        });
+    });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -96,23 +96,6 @@ describe('utils', () => {
         });
     });
 
-    describe.concurrent('guid', () => {
-        it.concurrent('should generate a string', ({ expect }) => {
-            const spy = vi.spyOn(Math, 'random').mockReturnValue(0.2);
-            expect(utils.guid()).to.matchSnapshot();
-            expect(utils.guid(1)).to.matchSnapshot();
-            expect(utils.guid(10)).to.matchSnapshot();
-            expect(utils.guid(20)).to.matchSnapshot();
-            spy.mockRestore();
-        });
-        it.concurrent('should default to a string length of 8', ({ expect }) => {
-            expect(utils.guid()).to.have.lengthOf(8);
-        });
-        it.concurrent('should return a string of requested length', ({ expect }) => {
-            expect(utils.guid(16)).to.have.lengthOf(16);
-        });
-    });
-
     describe.concurrent('hasFileExtension', () => {
         it.concurrent('should return true for normal file', () => {
             expect(utils.hasFileExtension('example.svg')).to.be.true;
@@ -151,6 +134,22 @@ describe('utils', () => {
             await utils.ensureDirExistsAndWriteFile(content, file);
             expect(fs.mkdir).toBeCalledWith(dir, { mode: 0o777, recursive: true });
             expect(fs.writeFile).toBeCalledWith(file, content);
+        });
+    });
+
+    describe.concurrent('getBufferHash', () => {
+        const testData: [string, string][] = [
+            // [string, sha256 of string]
+            ['test data 1', '05e8fdb3598f91bcc3ce41a196e587b4592c8cdfc371c217274bfda2d24b1b4e'],
+            ['test data 2', '26637da1bd793f9011a3d304372a9ec44e36cc677d2bbfba32a2f31f912358fe'],
+            ['test data 3', 'b2ce6625a947373fe8d578dca152cf152a5bd8aeca805b2d3b1fb4a340e1a123'],
+            ['test data 4', '1e2b98ff6439d48d42ae71c0ea44f3c1e03665a34d1c368ac590aec5dadc48eb'],
+            ['test data 5', '225b2e6c5664bb388cc40c9abeb289f9569ebc683ed4fdd76fef8421c32369b5'],
+        ];
+
+        it.each(testData)('should generate a correct hash for "%s"', (data, hash) => {
+            const calculatedHash = utils.getBufferHash(Buffer.from(data));
+            expect(calculatedHash).toEqual(hash);
         });
     });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -157,7 +157,7 @@ describe('utils', () => {
         const strings = ['vite-svg-2-webfont', 'test-string-1', 'test-string-2'];
 
         it.each(strings)('should match "%s"', string => {
-            const stringAsBase64 = btoa(string);
+            const stringAsBase64 = Buffer.from(string).toString('base64');
             const arrayBuffer = utils.base64ToArrayBuffer(stringAsBase64);
             const decodedString = new TextDecoder('utf-8').decode(arrayBuffer);
             expect(decodedString).toEqual(string);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,16 +51,6 @@ export async function setupWatcher(folderPath: string, signal: AbortSignal, hand
     }
 }
 
-const alphabet = 'qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890';
-export function guid(length = 8) {
-    let result = '';
-    for (let i = 0; i < length; i++) {
-        const index = Math.floor(Math.random() * alphabet.length);
-        result += alphabet[index];
-    }
-    return result;
-}
-
 export function getBufferHash(buf: Buffer) {
     return createHash('sha256').update(buf).digest('hex');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,3 +73,12 @@ export function getTmpDir() {
 export function rmDir(path: string) {
     fsRm(path, { force: true, recursive: true }, () => {});
 }
+
+export function base64ToArrayBuffer(base64: string) {
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes.buffer;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,7 @@ export function rmDir(path: string) {
 }
 
 export function base64ToArrayBuffer(base64: string) {
-    const binaryString = atob(base64);
+    const binaryString = Buffer.from(base64, 'base64').toString('binary');
     const bytes = new Uint8Array(binaryString.length);
     for (let i = 0; i < binaryString.length; i++) {
         bytes[i] = binaryString.charCodeAt(i);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,10 @@
-import { constants } from 'fs';
-import { resolve, dirname } from 'path';
+import { constants, rm as fsRm, mkdtempSync } from 'fs';
+import { resolve, dirname, join as pathJoin } from 'path';
 import { watch, access, mkdir, writeFile } from 'fs/promises';
 import type { FileChangeInfo } from 'fs/promises';
 import type { GeneratedFontTypes } from '@vusion/webfonts-generator';
+import { tmpdir as osTmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 
 let watcher: ReturnType<typeof watch> | undefined;
 export const MIME_TYPES: Record<GeneratedFontTypes, string> = {
@@ -59,6 +61,10 @@ export function guid(length = 8) {
     return result;
 }
 
+export function getBufferHash(buf: Buffer) {
+    return createHash('sha256').update(buf).digest('hex');
+}
+
 export function hasFileExtension(fileName?: string | null | undefined) {
     const fileExtensionRegex = /(?:\.([^.]+))?$/;
     return Boolean(fileExtensionRegex.exec(fileName || '')?.[1]);
@@ -68,4 +74,12 @@ export async function ensureDirExistsAndWriteFile(content: string | Buffer, dest
     const options = { mode: 0o777, recursive: true };
     await mkdir(dirname(dest), options);
     await writeFile(dest, content);
+}
+
+export function getTmpDir() {
+    return mkdtempSync(pathJoin(osTmpdir(), '__vite-svg-2-webfont-'));
+}
+
+export function rmDir(path: string) {
+    fsRm(path, { force: true, recursive: true }, () => {});
 }


### PR DESCRIPTION
I was experiencing some problems with my project again and here's how I've solved it.

The problem is `vite-svg-2-webfont` breaks build idempotence: e.g. if I execute `vite build && mv dist _dist && vite build` and the compare the `_dist` and `dist` directories, it will be completely different - for every single file.

This is because we using hashing mechanism to name assets and chunks:
```javascript
build: {
  rollupOptions: {
    output: {
      assetFileNames: 'assets/[hash][extname]',
      chunkFileNames: 'assets/[hash].js',
      },
    },
  },
```

And the `vite-svg-2-webfont` is using `guid()` to make unique string for each build. This means that webfont reference inside a CSS will be different between two consequent builds, which means that the CSS file name will be changed because its content is changed, this means that CSS file reference will also be changed, and so on...

I was able to fix this behavior by just replacing the `guid()` call with some hashing algorithm but I decided to go further and fix another more problem: the build-time warnings.

Every time I was running `vite build` before, the missing assets warnings was thrown into a console, just a multiple lines like this:
```
/assets/material-design-icons-round-2fm2M2EJ.woff2 referenced in virtual:mdi-icons-round.css didn't resolve at build time, it will remain unchanged to be resolved at runtime
```

In this MR I refactored the build mechanisms so it will use normal Rollup build process. Due to its limitations while working with CSS and assets, I wasn't able to avoid some sharp corners, unfortunately, but it does the work anyway.

I will add some comments to clarify decisions in place.
