### PR TITLE
Added support for cssContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ The plugin has an API consisting of one required parameter and multiple optional
     -   `webfontsGenerator.templates.scss` – Default SCSS template path. It generates mixin `webfont-icon` to add icon styles. It is safe to use multiple generated files with mixins together.
 -   See [webfonts-generator#csstemplate](https://github.com/vusion/webfonts-generator#csstemplate)
 
+### cssContext
+
+-   See [webfonts-generator#cssContext](https://github.com/vusion/webfonts-generator#cssContext)
+
 ### cssFontsUrl
 
 -   **type**: `string`

--- a/src/optionParser.test.ts
+++ b/src/optionParser.test.ts
@@ -396,6 +396,16 @@ describe('optionParser', () => {
             expect(resExplicit.cssTemplate).to.eq(cssTemplate);
         });
 
+        it.concurrent('sets cssContext only if defined in options', () => {
+            const resDefault = optionParser.parseOptions({ context });
+            expect('cssContext' in resDefault).to.be.false;
+            const cssContext = () => {
+                throw new Error("Shouldn't be called!");
+            };
+            const resExplicit = optionParser.parseOptions({ context, cssContext });
+            expect(resExplicit.cssContext).to.eq(cssContext);
+        });
+
         it.concurrent('concatenates dest to cssTemplate', () => {
             const dest = '/root';
             const cssTemplate = 'cssTemplate';

--- a/src/optionParser.ts
+++ b/src/optionParser.ts
@@ -2,7 +2,7 @@ import { resolve } from 'path';
 import { globSync } from 'glob';
 import { hasFileExtension } from './utils';
 import { InvalidWriteFilesTypeError, NoIconsAvailableError } from './errors';
-import type { WebfontsGeneratorOptions, GeneratedFontTypes } from '@vusion/webfonts-generator';
+import type { WebfontsGeneratorOptions, GeneratedFontTypes, CSSTemplateContext } from '@vusion/webfonts-generator';
 
 const FILE_TYPE_OPTIONS = ['html', 'css', 'fonts'] as const;
 type FileType = (typeof FILE_TYPE_OPTIONS)[number];
@@ -66,6 +66,10 @@ export interface IconPluginOptions<T extends GeneratedFontTypes = GeneratedFontT
      * - `templates.scss` – Default SCSS template path. It generates mixin `webfont-icon` to add icon styles. It is safe to use multiple generated files with mixins together.
      */
     cssTemplate?: string;
+    /**
+     *
+     */
+    cssContext?: (context: CSSTemplateContext, options: WebfontsGeneratorOptions<T>, handlebars: typeof import('handlebars')) => void;
     /**
      * Fonts path used in CSS file.
      * @default options.cssDest
@@ -221,6 +225,7 @@ export function parseOptions<T extends GeneratedFontTypes = GeneratedFontTypes>(
         cssDest: resolveFileDest(options.dest, options.cssDest, options.fontName, 'css'),
         htmlDest: resolveFileDest(options.dest, options.htmlDest, options.fontName, 'html'),
         ...(options.cssTemplate && { cssTemplate: resolve(options.dest, options.cssTemplate) }),
+        ...(options.cssContext && { cssContext: options.cssContext }),
         ...(options.cssFontsUrl && { cssFontsUrl: resolve(options.dest, options.cssFontsUrl) }),
         ...(options.htmlTemplate && { htmlTemplate: resolve(options.dest, options.htmlTemplate) }),
         ...(typeof options.fixedWidth !== 'undefined' && { fixedWidth: options.fixedWidth }),


### PR DESCRIPTION
This should add support for cssContext as an option, which is a documented webfonts-generator feature