### PR TITLE
Introduce new option `allowWriteFilesInBuild`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ node_modules/
 .idea
 
 dist
+src/fixtures/webfont-test/artifacts/*

--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ The plugin has an API consisting of one required parameter and multiple optional
 -   **description**: Inline font assets in CSS using base64 encoding.
 -   **default** `false`
 
+### allowWriteFilesInBuild
+
+-   **type**: `boolean`
+-   **description**: Allow outputting assets (HTML, CSS, and Fonts) during build. [see](https://github.com/atlowChemi/vite-svg-2-webfont/issues/32#issuecomment-2203187501)
+-   **default** `false`
+
 ## Public API
 
 The plugin exposes a public API that can be used inside another plugins using [Rollup inter-plugin communication mechanism](https://rollupjs.org/plugin-development/#inter-plugin-communication).

--- a/src/fixtures/vite.allowWriteFilesInBuild.config.ts
+++ b/src/fixtures/vite.allowWriteFilesInBuild.config.ts
@@ -3,10 +3,19 @@ import { defineConfig } from 'vite';
 import { viteSvgToWebfont } from '../../';
 
 const webfontFolder = resolve(__dirname, './webfont-test/svg');
+const outputFolder = resolve(__dirname, './webfont-test/artifacts');
 
 export default defineConfig({
     build: {
         assetsInlineLimit: 0,
     },
-    plugins: [viteSvgToWebfont({ context: webfontFolder, allowWriteFilesInBuild: true, fontName: 'allowWriteFilesInBuild-test', generateFiles: true })],
+    plugins: [
+        viteSvgToWebfont({
+            dest: outputFolder,
+            generateFiles: true,
+            context: webfontFolder,
+            allowWriteFilesInBuild: true,
+            fontName: 'allowWriteFilesInBuild-test',
+        }),
+    ],
 });

--- a/src/fixtures/vite.allowWriteFilesInBuild.config.ts
+++ b/src/fixtures/vite.allowWriteFilesInBuild.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+import { viteSvgToWebfont } from '../../';
+
+const webfontFolder = resolve(__dirname, './webfont-test/svg');
+
+export default defineConfig({
+    build: {
+        assetsInlineLimit: 0,
+    },
+    plugins: [viteSvgToWebfont({ context: webfontFolder, allowWriteFilesInBuild: true, fontName: 'allowWriteFilesInBuild-test', generateFiles: true })],
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -202,7 +202,7 @@ describe('build allowWriteFilesInBuild', () => {
         await rmdir(new URL('webfont-test/artifacts', root), { recursive: true });
     });
 
-    it.concurrent.each([...types, 'html', 'css'])('has generated font of type %s', async type => {
+    it.concurrent.each(types)('has generated font of type %s', async type => {
         const filePath = new URL(`webfont-test/artifacts/allowWriteFilesInBuild-test.${type}`, root);
 
         await expect(access(filePath, constants.F_OK)).resolves.not.toThrow();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -203,7 +203,9 @@ describe('build allowWriteFilesInBuild', () => {
     });
 
     it.concurrent.each([...types, 'html', 'css'])('has generated font of type %s', async type => {
-        const filePath = new URL(`webfont-test/artifacts/allowWriteFilesInBuild-test.${type}`.toLowerCase(), root);
+        const fileName = `webfont-test/artifacts/allowWriteFilesInBuild-test.${type}`;
+        const fileNameCasing = !types.includes(type) ? fileName : fileName.toLowerCase();
+        const filePath = new URL(fileNameCasing, root);
 
         await expect(access(filePath, constants.F_OK)).resolves.not.toThrow();
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -204,7 +204,7 @@ describe('build allowWriteFilesInBuild', () => {
 
     it.concurrent.each([...types, 'html', 'css'])('has generated font of type %s', async type => {
         const fileName = `webfont-test/artifacts/allowWriteFilesInBuild-test.${type}`;
-        const fileNameCasing = !types.includes(type) ? fileName : fileName.toLowerCase();
+        const fileNameCasing = types.includes(type) ? fileName : fileName.toLowerCase();
         const filePath = new URL(fileNameCasing, root);
 
         await expect(access(filePath, constants.F_OK)).resolves.not.toThrow();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { constants } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { readFile, access } from 'node:fs/promises';
+import { readFile, access, rmdir } from 'node:fs/promises';
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { build, createServer, preview, normalizePath } from 'vite';
 import type { RollupOutput } from 'rollup';
@@ -196,6 +196,10 @@ describe('build allowWriteFilesInBuild', () => {
 
     beforeAll(async () => {
         await build(buildConfig);
+    });
+
+    afterAll(async () => {
+        rmdir(new URL('webfont-test/artifacts', root), { recursive: true });
     });
 
     it.concurrent.each([...types, 'html', 'css'])('has generated font of type %s', async type => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -202,8 +202,8 @@ describe('build allowWriteFilesInBuild', () => {
         await rmdir(new URL('webfont-test/artifacts', root), { recursive: true });
     });
 
-    it.concurrent.each(types)('has generated font of type %s', async type => {
-        const filePath = new URL(`webfont-test/artifacts/allowWriteFilesInBuild-test.${type}`, root);
+    it.concurrent.each([...types, 'html', 'css'])('has generated font of type %s', async type => {
+        const filePath = new URL(`webfont-test/artifacts/allowWriteFilesInBuild-test.${type}`.toLowerCase(), root);
 
         await expect(access(filePath, constants.F_OK)).resolves.not.toThrow();
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -199,12 +199,12 @@ describe('build allowWriteFilesInBuild', () => {
     });
 
     afterAll(async () => {
-        rmdir(new URL('webfont-test/artifacts', root), { recursive: true });
+        await rmdir(new URL('webfont-test/artifacts', root), { recursive: true });
     });
 
     it.concurrent.each([...types, 'html', 'css'])('has generated font of type %s', async type => {
         const filePath = new URL(`webfont-test/artifacts/allowWriteFilesInBuild-test.${type}`, root);
 
-        expect(access(filePath, constants.F_OK)).to.resolves.not.toThrow();
+        await expect(access(filePath, constants.F_OK)).resolves.not.toThrow();
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,20 +55,16 @@ export function viteSvgToWebfont<T extends GeneratedFontTypes = GeneratedFontTyp
         if (updateFiles) {
             processedOptions.files = parseFiles(options);
         }
-        if (isBuild) {
+        if (isBuild && !options.allowWriteFilesInBuild) {
             processedOptions.writeFiles = false;
         }
         generatedFonts = await webfontGenerator(processedOptions);
         const hasFilesToSave = !processedOptions.writeFiles && (processedOptions.css || processedOptions.html);
         if (!isBuild && hasFilesToSave) {
-            const promises: Promise<void>[] = [];
-            if (processedOptions.css) {
-                promises.push(ensureDirExistsAndWriteFile(inline(generatedFonts.generateCss()), processedOptions.cssDest));
-            }
-            if (processedOptions.html) {
-                promises.push(ensureDirExistsAndWriteFile(generatedFonts.generateHtml(), processedOptions.htmlDest));
-            }
-            await Promise.all(promises);
+            await Promise.all([
+                processedOptions.css && ensureDirExistsAndWriteFile(inline(generatedFonts.generateCss()), processedOptions.cssDest),
+                processedOptions.html && ensureDirExistsAndWriteFile(generatedFonts.generateHtml(), processedOptions.htmlDest),
+            ]);
         }
         if (updateFiles) {
             const module = _moduleGraph?.getModuleById(resolvedVirtualModuleId);

--- a/src/optionParser.ts
+++ b/src/optionParser.ts
@@ -145,6 +145,12 @@ export interface IconPluginOptions<T extends GeneratedFontTypes = GeneratedFontT
      * @default false
      */
     inline?: boolean;
+    /**
+     * Allow outputting assets (HTML, CSS, and Fonts) during build.
+     * @see {@link https://github.com/atlowChemi/vite-svg-2-webfont/issues/32#issuecomment-2203187501}
+     * @default false
+     */
+    allowWriteFilesInBuild?: boolean;
 }
 
 export function parseIconTypesOption<T extends GeneratedFontTypes = GeneratedFontTypes>({ types }: Pick<IconPluginOptions<T>, 'types'>): T[] {


### PR DESCRIPTION
This will allow writing fonts as well as HTML & CSS files during the build step.

Fixes: #32