### PR TITLE
Add centerVertically alias support for SVG format options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.defaultFormatter": "oxc.oxc-vscode",
     "oxc.fmt.configPath": "./vite.config.ts",
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.formatOnSaveMode": "file",
     "editor.codeActionsOnSave": {
         "source.fixAll.oxc": "explicit"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,17 @@ The plugin API consists of one required option and multiple optional options for
 - Default: `false`
 - Reference: [`svgicons2svgfont#centerHorizontally`](https://github.com/nfroidure/svgicons2svgfont#optionscenterhorizontally)
 
+## `centerVertically`
+
+- Type: `boolean`
+- Description: Center glyphs vertically based on their bounds
+- Default: `false`
+- Notes:
+    - This option is a convenience alias for `formatOptions.svg.centerVertically`
+    - If both `centerVertically` and `formatOptions.svg.centerVertically` are defined, `formatOptions.svg.centerVertically` takes precedence
+    - Any other properties inside `formatOptions.svg` are preserved
+- Reference: [`svgicons2svgfont#centerVertically`](https://github.com/nfroidure/svgicons2svgfont#optionscentervertically)
+
 ## `generateFiles`
 
 - Type: `boolean | string | string[]`

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ function getResolvedVirtualModuleId<T extends string>(virtualModuleId: T): `\0${
  */
 export function viteSvgToWebfont<T extends GeneratedFontTypes = GeneratedFontTypes>(options: IconPluginOptions<T>): Plugin<PublicApi> {
     const processedOptions = parseOptions(options);
-    const preloadFormats = parsePreloadFormatsOption(options).filter((type): type is T => processedOptions.types.includes(type));
+    const preloadFormats = parsePreloadFormatsOption<T>(options).filter((type): type is T => processedOptions.types.includes(type));
     let isBuild: boolean;
     let fileRefs: { [Ref in T]: string } | undefined;
     let _moduleGraph: ModuleGraph;

--- a/src/optionParser.test.ts
+++ b/src/optionParser.test.ts
@@ -505,6 +505,61 @@ describe('optionParser', () => {
             expect(resExplicitTrue.centerHorizontally).toEqual(true);
         });
 
+        it.concurrent('adds centerVertically to formatOptions.svg only if defined in options', () => {
+            const resDefault = optionParser.parseOptions({ context });
+            expect(resDefault.formatOptions).not.toHaveProperty('svg.centerVertically');
+            const resExplicitFalse = optionParser.parseOptions({ context, centerVertically: false });
+            expect(resExplicitFalse.formatOptions).toEqual({
+                svg: {
+                    centerVertically: false,
+                },
+            });
+            const resExplicitTrue = optionParser.parseOptions({ context, centerVertically: true });
+            expect(resExplicitTrue.formatOptions).toEqual({
+                svg: {
+                    centerVertically: true,
+                },
+            });
+        });
+
+        it.concurrent('preserves existing formatOptions.svg values when setting centerVertically', () => {
+            const formatOptions = {
+                svg: {
+                    fontHeight: 2048,
+                },
+                woff2: {
+                    custom: true,
+                },
+            };
+            const res = optionParser.parseOptions({ context, centerVertically: true, formatOptions });
+            expect(res.formatOptions).toEqual({
+                svg: {
+                    fontHeight: 2048,
+                    centerVertically: true,
+                },
+                woff2: {
+                    custom: true,
+                },
+            });
+        });
+
+        it.concurrent('does not override formatOptions.svg.centerVertically when both are defined', () => {
+            const res = optionParser.parseOptions({
+                context,
+                centerVertically: true,
+                formatOptions: {
+                    svg: {
+                        centerVertically: false,
+                    },
+                },
+            });
+            expect(res.formatOptions).toEqual({
+                svg: {
+                    centerVertically: false,
+                },
+            });
+        });
+
         it.concurrent('sets normalize only if defined in options', () => {
             const resDefault = optionParser.parseOptions({ context });
             expect('normalize' in resDefault).toEqual(false);

--- a/src/optionParser.ts
+++ b/src/optionParser.ts
@@ -48,6 +48,8 @@ export interface IconPluginOptions<T extends GeneratedFontTypes = GeneratedFontT
     fixedWidth?: boolean;
     /** Calculate the bounds of a glyph and center it horizontally. */
     centerHorizontally?: boolean;
+    /** Calculate the bounds of a glyph and center it vertically. */
+    centerVertically?: boolean;
     /**
      * Path for generated CSS file.
      * - Relative to the {@link dest} property, unless set to an absolute path.
@@ -70,7 +72,7 @@ export interface IconPluginOptions<T extends GeneratedFontTypes = GeneratedFontT
     /**
      *
      */
-    cssContext?: (context: CSSTemplateContext, options: WebfontsGeneratorOptions<T>, handlebars: typeof import('handlebars')) => void;
+    cssContext?: (context: CSSTemplateContext, options: WebfontsGeneratorOptions<NoInfer<T>>, handlebars: typeof import('handlebars')) => void;
     /**
      * Fonts path used in CSS file.
      * @default options.cssDest
@@ -109,7 +111,7 @@ export interface IconPluginOptions<T extends GeneratedFontTypes = GeneratedFontT
      * - woff - [ttf2woff](https://github.com/fontello/ttf2woff).
      * - eot - [ttf2eot](https://github.com/fontello/ttf2eot).
      */
-    formatOptions?: { [format in T]?: unknown };
+    formatOptions?: { [format in NoInfer<T>]?: unknown };
     /**
      * An array of globs, of the SVG files to add into the webfont
      * @default ['*.svg']
@@ -125,7 +127,7 @@ export interface IconPluginOptions<T extends GeneratedFontTypes = GeneratedFontT
      *
      * Only generated formats can be preloaded, so values outside {@link types} are ignored.
      */
-    preloadFormats?: T | T[];
+    preloadFormats?: NoInfer<T> | NoInfer<T>[];
     /**
      * Allows skipping preload tag injection for specific HTML entrypoints.
      */
@@ -236,6 +238,8 @@ export function parseOptions<T extends GeneratedFontTypes = GeneratedFontTypes>(
     const formats = parseIconTypesOption<T>(options);
     const files = parseFiles(options);
     const generateFilesOptions = parseGenerateFilesOption(options);
+    const formatOptions = options.formatOptions as NonNullable<WebfontsGeneratorOptions<T | 'svg'>['formatOptions']> | undefined;
+    const svgFormatOptions = formatOptions?.svg;
     options.dest ||= resolve(options.context, '..', 'artifacts');
     options.fontName ||= 'iconfont';
     return {
@@ -252,7 +256,15 @@ export function parseOptions<T extends GeneratedFontTypes = GeneratedFontTypes>(
         html: generateFilesOptions.html,
         css: generateFilesOptions.css,
         ligature: options.ligature ?? true,
-        formatOptions: options.formatOptions || {},
+        formatOptions: {
+            ...formatOptions,
+            ...(typeof options.centerVertically !== 'undefined' && {
+                svg: {
+                    centerVertically: options.centerVertically,
+                    ...(typeof svgFormatOptions === 'object' && svgFormatOptions),
+                },
+            }),
+        },
         dest: options.dest.endsWith('/') ? options.dest : `${options.dest}/`,
         writeFiles: generateFilesOptions.fonts,
         cssDest: resolveFileDest(options.dest, options.cssDest, options.fontName, 'css'),


### PR DESCRIPTION
## Summary
- add a top-level `centerVertically` option and map it to `formatOptions.svg.centerVertically`
- preserve existing `formatOptions.svg` values and let explicit nested config take precedence when both are set
- document the aliasing and precedence rules in the configuration docs
- tighten generic typing around `formatOptions` and `preloadFormats`
- extend parser coverage for the new option behavior

Fixes: #37 