### PR TITLE
fix(ci): make docs a reusable workflow, deploy on any release

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,7 @@
 name: Docs
 
 on:
-    push:
-        tags:
-            - v*
+    workflow_call:
     workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
         outputs:
             plugin-released: ${{ steps.release.outputs['packages/vite-svg-2-webfont--release_created'] }}
             plugin-tag: ${{ steps.release.outputs['packages/vite-svg-2-webfont--tag_name'] }}
+            any-released: ${{ steps.release.outputs.releases_created }}
         steps:
             - uses: googleapis/release-please-action@v4
               id: release
@@ -44,3 +45,13 @@ jobs:
               with:
                   tag_name: ${{ needs.release-please.outputs.plugin-tag }}
                   files: packages/vite-svg-2-webfont/*.tgz
+
+    deploy-docs:
+        name: Deploy docs
+        needs: [release-please]
+        if: needs.release-please.outputs.any-released == 'true'
+        uses: ./.github/workflows/docs.yaml
+        permissions:
+            contents: read
+            pages: write
+            id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ permissions:
     contents: write
     id-token: write
     issues: write
+    pages: write
     pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Changes docs workflow from tag-triggered to `workflow_call`
- Release workflow now calls docs deploy after any release-please release
- Docs still deployable manually via `workflow_dispatch`