### PR TITLE
docs: move README to package and add monorepo root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,54 +4,26 @@
   <img src="./packages/docs/public/logo.svg" alt="vite-svg-2-webfont logo" width="144" />
 </p>
 
-[![npm](https://img.shields.io/npm/v/vite-svg-2-webfont.svg?style=flat-square)](https://www.npmjs.com/package/vite-svg-2-webfont)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/atlowChemi/vite-svg-2-webfont/main.yaml?branch=main&style=flat-square)
-[![docs](https://img.shields.io/badge/docs-online-646cff?style=flat-square)](https://atlowChemi.github.io/vite-svg-2-webfont/)
-[![npm](https://img.shields.io/npm/dm/vite-svg-2-webfont.svg?style=flat-square)](https://www.npmjs.com/package/vite-svg-2-webfont)
-[![license](https://img.shields.io/github/license/atlowChemi/vite-svg-2-webfont.svg?style=flat-square)](https://github.com/atlowChemi/vite-svg-2-webfont/blob/master/LICENSE)
-[![npm bundle size](https://img.shields.io/bundlephobia/minzip/vite-svg-2-webfont?style=flat-square)](https://img.shields.io/bundlephobia/minzip/vite-svg-2-webfont?style=flat-square)
-[![node engine](https://img.shields.io/node/v/vite-svg-2-webfont?style=flat-square)](https://img.shields.io/node/v/vite-svg-2-webfont?style=flat-square)
-[![Package Quality](https://packagequality.com/shield/vite-svg-2-webfont.svg)](https://packagequality.com/#?package=vite-svg-2-webfont)
+<p align="center">
+  A Vite plugin that generates webfonts from SVG icon files and exposes a virtual stylesheet you can import into your application.
+</p>
 
-A Vite plugin that generates webfonts from SVG icon files and exposes a virtual stylesheet you can import into your application.
+<p align="center">
+  <a href="https://www.npmjs.com/package/vite-svg-2-webfont"><img src="https://img.shields.io/npm/v/vite-svg-2-webfont.svg?style=flat-square" alt="npm" /></a>
+  <a href="https://atlowChemi.github.io/vite-svg-2-webfont/"><img src="https://img.shields.io/badge/docs-online-646cff?style=flat-square" alt="docs" /></a>
+  <a href="https://github.com/atlowChemi/vite-svg-2-webfont/blob/master/LICENSE"><img src="https://img.shields.io/github/license/atlowChemi/vite-svg-2-webfont.svg?style=flat-square" alt="license" /></a>
+</p>
+
+## Packages
+
+| Package                                               | Description          |
+| ----------------------------------------------------- | -------------------- |
+| [`vite-svg-2-webfont`](./packages/vite-svg-2-webfont) | The core Vite plugin |
 
 ## Documentation
 
-Full documentation lives at [atlowChemi.github.io/vite-svg-2-webfont](https://atlowChemi.github.io/vite-svg-2-webfont/).
+Full documentation is available at [atlowChemi.github.io/vite-svg-2-webfont](https://atlowChemi.github.io/vite-svg-2-webfont/).
 
-- [Getting Started](https://atlowChemi.github.io/vite-svg-2-webfont/getting-started)
-- [Usage](https://atlowChemi.github.io/vite-svg-2-webfont/usage)
-- [Configuration](https://atlowChemi.github.io/vite-svg-2-webfont/configuration)
-- [Public API](https://atlowChemi.github.io/vite-svg-2-webfont/public-api)
+## License
 
-## Installation
-
-```bash
-npm install --save-dev vite-svg-2-webfont
-```
-
-## Quick Start
-
-```ts
-import { resolve } from 'node:path';
-import { defineConfig } from 'vite';
-import viteSvgToWebfont from 'vite-svg-2-webfont';
-
-export default defineConfig({
-    plugins: [
-        viteSvgToWebfont({
-            context: resolve(__dirname, 'icons'),
-        }),
-    ],
-});
-```
-
-```ts
-import 'virtual:vite-svg-2-webfont.css';
-```
-
-```html
-<i class="icon icon-add"></i>
-```
-
-In that example, `icon-add` is controlled by `classPrefix` and `icon` is controlled by `baseSelector`. See the [configuration reference](https://atlowChemi.github.io/vite-svg-2-webfont/configuration#classprefix) and [base selector option](https://atlowChemi.github.io/vite-svg-2-webfont/configuration#baseselector).
+[MIT](./LICENSE)

--- a/packages/vite-svg-2-webfont/README.md
+++ b/packages/vite-svg-2-webfont/README.md
@@ -1,0 +1,57 @@
+# vite-svg-2-webfont
+
+<p align="center">
+  <img src="../docs/public/logo.svg" alt="vite-svg-2-webfont logo" width="144" />
+</p>
+
+[![npm](https://img.shields.io/npm/v/vite-svg-2-webfont.svg?style=flat-square)](https://www.npmjs.com/package/vite-svg-2-webfont)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/atlowChemi/vite-svg-2-webfont/main.yaml?branch=main&style=flat-square)
+[![docs](https://img.shields.io/badge/docs-online-646cff?style=flat-square)](https://atlowChemi.github.io/vite-svg-2-webfont/)
+[![npm](https://img.shields.io/npm/dm/vite-svg-2-webfont.svg?style=flat-square)](https://www.npmjs.com/package/vite-svg-2-webfont)
+[![license](https://img.shields.io/github/license/atlowChemi/vite-svg-2-webfont.svg?style=flat-square)](https://github.com/atlowChemi/vite-svg-2-webfont/blob/master/LICENSE)
+[![npm bundle size](https://img.shields.io/bundlephobia/minzip/vite-svg-2-webfont?style=flat-square)](https://img.shields.io/bundlephobia/minzip/vite-svg-2-webfont?style=flat-square)
+[![node engine](https://img.shields.io/node/v/vite-svg-2-webfont?style=flat-square)](https://img.shields.io/node/v/vite-svg-2-webfont?style=flat-square)
+[![Package Quality](https://packagequality.com/shield/vite-svg-2-webfont.svg)](https://packagequality.com/#?package=vite-svg-2-webfont)
+
+A Vite plugin that generates webfonts from SVG icon files and exposes a virtual stylesheet you can import into your application.
+
+## Documentation
+
+Full documentation lives at [atlowChemi.github.io/vite-svg-2-webfont](https://atlowChemi.github.io/vite-svg-2-webfont/).
+
+- [Getting Started](https://atlowChemi.github.io/vite-svg-2-webfont/getting-started)
+- [Usage](https://atlowChemi.github.io/vite-svg-2-webfont/usage)
+- [Configuration](https://atlowChemi.github.io/vite-svg-2-webfont/configuration)
+- [Public API](https://atlowChemi.github.io/vite-svg-2-webfont/public-api)
+
+## Installation
+
+```bash
+npm install --save-dev vite-svg-2-webfont
+```
+
+## Quick Start
+
+```ts
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import viteSvgToWebfont from 'vite-svg-2-webfont';
+
+export default defineConfig({
+    plugins: [
+        viteSvgToWebfont({
+            context: resolve(__dirname, 'icons'),
+        }),
+    ],
+});
+```
+
+```ts
+import 'virtual:vite-svg-2-webfont.css';
+```
+
+```html
+<i class="icon icon-add"></i>
+```
+
+In that example, `icon-add` is controlled by `classPrefix` and `icon` is controlled by `baseSelector`. See the [configuration reference](https://atlowChemi.github.io/vite-svg-2-webfont/configuration#classprefix) and [base selector option](https://atlowChemi.github.io/vite-svg-2-webfont/configuration#baseselector).


### PR DESCRIPTION
## Summary
- Moved the full plugin README (badges, installation, quick start) into `packages/vite-svg-2-webfont/` so it ships with the published npm package
- Replaced the root README with a concise monorepo overview: logo, description, packages table, and links to docs site