### PR TITLE
fix(ci): auto-format release-please changelog on PR branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,32 @@ jobs:
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 
+            - name: Checkout release PR branch
+              if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
+
+            - name: Setup Vite+
+              if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
+              uses: voidzero-dev/setup-vp@v1
+              with:
+                  node-version-file: .node-version
+                  run-install: true
+                  cache: true
+
+            - name: Format changelog
+              if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
+              run: |
+                  vp check --fix || true
+                  if ! git diff --quiet; then
+                    git config user.name "github-actions[bot]"
+                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                    git add -A
+                    git commit -m "chore: format changelog"
+                    git push
+                  fi
+
     publish-plugin:
         name: Publish vite-svg-2-webfont
         needs: [release-please]

--- a/packages/vite-svg-2-webfont/CHANGELOG.md
+++ b/packages/vite-svg-2-webfont/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [6.1.1](https://github.com/atlowChemi/vite-svg-2-webfont/compare/vite-svg-2-webfont-v6.1.0...vite-svg-2-webfont-v6.1.1) (2026-04-12)
 
-
 ### Bug Fixes
 
-* use platform-independent path separators in option parsing ([#87](https://github.com/atlowChemi/vite-svg-2-webfont/issues/87)) ([f5f3f49](https://github.com/atlowChemi/vite-svg-2-webfont/commit/f5f3f49e61892068834a0ecc5df1265a0e149bb4))
+- use platform-independent path separators in option parsing ([#87](https://github.com/atlowChemi/vite-svg-2-webfont/issues/87)) ([f5f3f49](https://github.com/atlowChemi/vite-svg-2-webfont/commit/f5f3f49e61892068834a0ecc5df1265a0e149bb4))
 
 ## [6.1.0](https://github.com/atlowChemi/vite-svg-2-webfont/compare/vite-svg-2-webfont-v6.0.0...vite-svg-2-webfont-v6.1.0) (2026-04-12)
 


### PR DESCRIPTION
## Summary

- Fix existing CHANGELOG.md formatting (`*` → `-`, remove extra blank line) so `vp check` passes on main
- Add post-release-please steps in the release workflow that checkout the PR branch, run `vp check --fix`, and push back — so future release PRs are auto-formatted before merge

The root cause: `release-please-action` uses `GITHUB_TOKEN` which can't trigger other workflows, so CI never runs on the release PR. The formatting mismatch (`*` bullets, extra blank lines) only surfaces after merge to main.