### PR TITLE
fix(ci): skip hooks on release changelog format commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
                     git config user.name "github-actions[bot]"
                     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                     git add -A
-                    git commit -m "chore: format changelog"
+                    git commit --no-verify -m "chore: format changelog"
                     git push
                   fi
 


### PR DESCRIPTION
## Summary

- Add `--no-verify` to the bot's formatting commit in the release workflow
- The pre-commit hook runs `vp test` which fails on the release PR branch because the package isn't built
- Since the commit only touches CHANGELOG formatting, hooks are unnecessary here