### PR TITLE
ci: add cross-platform native build and multi-platform test matrix

### DIFF
--- a/.github/workflows/build-native.yaml
+++ b/.github/workflows/build-native.yaml
@@ -1,0 +1,137 @@
+name: Build Native Binaries
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+env:
+    DEBUG: 'napi:*'
+    MACOSX_DEPLOYMENT_TARGET: '10.13'
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+    contents: read
+
+jobs:
+    build:
+        name: Build ${{ matrix.target }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                target:
+                    - x86_64-unknown-linux-gnu
+                    - aarch64-unknown-linux-gnu
+                    - x86_64-unknown-linux-musl
+                    - aarch64-unknown-linux-musl
+                    - armv7-unknown-linux-gnueabihf
+                    - x86_64-apple-darwin
+                    - aarch64-apple-darwin
+                    - x86_64-pc-windows-msvc
+                    - aarch64-pc-windows-msvc
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Cache cargo registry
+              uses: actions/cache@v5
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                  key: cargo-${{ runner.os }}-${{ hashFiles('packages/webfont-generator/Cargo.lock') }}
+                  restore-keys: cargo-${{ runner.os }}-
+            - name: Cache build artifacts
+              uses: actions/cache@v5
+              with:
+                  path: |
+                      ./packages/webfont-generator/target
+                      ~/.napi-rs
+                  key: cargo-build-${{ matrix.target }}-${{ hashFiles('packages/webfont-generator/Cargo.lock') }}
+                  restore-keys: cargo-build-${{ matrix.target }}-
+
+            - name: Restore xwin SDK/CRT cache
+              id: xwin-cache-restore
+              if: contains(matrix.target, 'windows-msvc')
+              uses: actions/cache/restore@v5
+              with:
+                  path: ${{ github.workspace }}/.xwin
+                  key: xwin-${{ runner.os }}-windows-msvc-v1
+                  restore-keys: |
+                      xwin-${{ runner.os }}-windows-msvc-
+                      xwin-${{ runner.os }}-
+
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  targets: ${{ matrix.target }}
+
+            - uses: voidzero-dev/setup-vp@v1
+              with:
+                  node-version-file: .node-version
+                  run-install: true
+                  cache: true
+
+            - name: Install ziglang
+              if: matrix.target != 'x86_64-unknown-linux-gnu' && !contains(matrix.target, 'windows-msvc')
+              uses: mlugg/setup-zig@v2
+              with:
+                  version: 0.14.1
+
+            - name: Install cargo-zigbuild
+              if: matrix.target != 'x86_64-unknown-linux-gnu' && !contains(matrix.target, 'windows-msvc')
+              uses: taiki-e/install-action@v2
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  tool: cargo-zigbuild
+
+            - name: Install LLVM 20 tools (MSVC targets)
+              if: contains(matrix.target, 'windows-msvc')
+              run: |
+                  wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+                  echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-20 main" | sudo tee /etc/apt/sources.list.d/llvm-20.list
+                  sudo apt-get update && sudo apt-get install -y llvm-20 clang-20 lld-20
+                  sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
+                  sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+                  sudo update-alternatives --install /usr/bin/clang-cl clang-cl /usr/bin/clang-cl-20 100
+                  sudo update-alternatives --install /usr/bin/llvm-lib llvm-lib /usr/bin/llvm-lib-20 100
+                  sudo update-alternatives --install /usr/bin/lld-link lld-link /usr/bin/lld-link-20 100
+
+            - name: Install cargo-xwin
+              if: contains(matrix.target, 'windows-msvc')
+              uses: taiki-e/install-action@v2
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  tool: cargo-xwin
+
+            - name: Pre-download xwin artifacts
+              if: contains(matrix.target, 'windows-msvc')
+              run: cargo xwin cache xwin
+              env:
+                  XWIN_CACHE_DIR: ${{ github.workspace }}/.xwin
+
+            - name: Save xwin SDK/CRT cache
+              if: contains(matrix.target, 'windows-msvc') && success() && steps.xwin-cache-restore.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v5
+              with:
+                  path: ${{ github.workspace }}/.xwin
+                  key: xwin-${{ runner.os }}-windows-msvc-v1
+
+            - name: Build native module
+              working-directory: packages/webfont-generator
+              run: >
+                  npx napi build --release --platform --esm --js binding.js --dts binding.d.ts
+                  ${{ matrix.target != 'x86_64-unknown-linux-gnu' && format('--target {0} -x', matrix.target) || '' }}
+                  -- --locked
+              env:
+                  XWIN_CACHE_DIR: ${{ github.workspace }}/.xwin
+                  CFLAGS_x86_64_apple_darwin: -mmacosx-version-min=10.13
+                  CXXFLAGS_x86_64_apple_darwin: -mmacosx-version-min=10.13
+                  CFLAGS_aarch64_apple_darwin: -mmacosx-version-min=11.0
+                  CXXFLAGS_aarch64_apple_darwin: -mmacosx-version-min=11.0
+
+            - uses: actions/upload-artifact@v7
+              with:
+                  name: bindings-${{ matrix.target }}
+                  path: packages/webfont-generator/*.node
+                  if-no-files-found: error

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,9 +34,102 @@ jobs:
             - run: vp check
             - run: vp run @atlowchemi/webfont-generator#test
 
-    test:
-        name: test (node ${{ matrix.node_version }}, vite ${{ matrix.vite_major }})
+    build:
+        name: Build cross-platform bindings
         needs: [ci]
+        uses: ./.github/workflows/build-native.yaml
+
+    test-host:
+        name: test ${{ matrix.settings.target }} (node ${{ matrix.node }})
+        needs: [build]
+        strategy:
+            fail-fast: false
+            matrix:
+                settings:
+                    - target: aarch64-unknown-linux-gnu
+                      host: ubuntu-24.04-arm
+                      architecture: arm64
+                    - target: x86_64-apple-darwin
+                      host: macos-latest
+                      architecture: x64
+                    - target: aarch64-apple-darwin
+                      host: macos-latest
+                      architecture: arm64
+                    - target: x86_64-pc-windows-msvc
+                      host: windows-latest
+                      architecture: x64
+                    - target: aarch64-pc-windows-msvc
+                      host: windows-11-arm
+                      architecture: arm64
+                node: ['20', '22', '24']
+        runs-on: ${{ matrix.settings.host }}
+        steps:
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node }}
+                  cache: pnpm
+                  architecture: ${{ matrix.settings.architecture }}
+            - run: pnpm install --frozen-lockfile
+            - name: Download binding
+              uses: actions/download-artifact@v8
+              with:
+                  name: bindings-${{ matrix.settings.target }}
+                  path: packages/webfont-generator/
+            - name: Verify binding
+              shell: bash
+              run: ls packages/webfont-generator/*.node
+            - name: Build plugin
+              run: pnpm --filter vite-svg-2-webfont exec vp pack
+            - name: Run tests
+              run: pnpm exec vp test --run
+
+    test-docker:
+        name: test ${{ matrix.arch }}-linux-musl
+        needs: [build]
+        strategy:
+            fail-fast: false
+            matrix:
+                arch: [x86_64, aarch64]
+                include:
+                    - arch: aarch64
+                      args: '--platform linux/arm64'
+                      runner: ubuntu-24.04-arm
+                    - arch: x86_64
+                      args: ''
+                      runner: ubuntu-latest
+        runs-on: ${{ matrix.runner }}
+        steps:
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
+              with:
+                  node-version-file: .node-version
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - name: Download binding
+              uses: actions/download-artifact@v8
+              with:
+                  name: bindings-${{ matrix.arch }}-unknown-linux-musl
+                  path: packages/webfont-generator/
+            - name: Build plugin
+              run: pnpm --filter vite-svg-2-webfont exec vp pack
+            - name: Resolve pnpm version
+              id: pnpm-version
+              run: echo "version=$(node -p "JSON.parse(require('fs').readFileSync('package.json','utf8')).packageManager.split('@')[1].split('+')[0]")" >> "$GITHUB_OUTPUT"
+            - name: Run tests
+              uses: tj-actions/docker-run@v2
+              with:
+                  image: node:24-alpine
+                  name: test-${{ matrix.arch }}-linux-musl
+                  options: ${{ matrix.args }} -v ${{ github.workspace }}:/build -w /build -e CI=true
+                  args: |
+                      sh -c "set -e && npm install -g pnpm@${{ steps.pnpm-version.outputs.version }} && pnpm install --frozen-lockfile --ignore-scripts && pnpm exec vp test --run"
+
+    test-vite-compat:
+        name: test (node ${{ matrix.node_version }}, vite ${{ matrix.vite_major }})
+        needs: [build]
         strategy:
             matrix:
                 include:
@@ -62,6 +155,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
+            - uses: dtolnay/rust-toolchain@stable
             - uses: voidzero-dev/setup-vp@v1
               with:
                   node-version: ${{ matrix.node_version }}
@@ -70,6 +164,15 @@ jobs:
             - name: Select vite major
               run: node ./scripts/ci/set-vite-major.js ${{ matrix.vite_major }}
             - run: vp install --no-frozen-lockfile
+            - name: Download binding
+              uses: actions/download-artifact@v8
+              with:
+                  name: bindings-x86_64-unknown-linux-gnu
+                  path: packages/webfont-generator/
+            - name: Verify binding
+              run: ls packages/webfont-generator/*.node
+            - name: Build plugin
+              run: vp run vite-svg-2-webfont#pack
             - name: Verify vite version
               run: |
                   VITE_VERSION=$(node -p "JSON.parse(require('node:fs').readFileSync('node_modules/vite/package.json', 'utf8')).version")
@@ -83,10 +186,10 @@ jobs:
                   esac
             - name: Run coverage
               if: ${{ matrix.primary }}
-              run: vp run coverage
-            - name: Run test
+              run: vp test --coverage
+            - name: Run tests
               if: ${{ !matrix.primary }}
-              run: vp run test
+              run: vp test
             - uses: actions/upload-artifact@v7
               if: ${{ matrix.primary }}
               with:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@
 
 ## Packages
 
-| Package                                               | Description          |
-| ----------------------------------------------------- | -------------------- |
-| [`vite-svg-2-webfont`](./packages/vite-svg-2-webfont) | The core Vite plugin |
+| Package                                                         | Description                           |
+| --------------------------------------------------------------- | ------------------------------------- |
+| [`vite-svg-2-webfont`](./packages/vite-svg-2-webfont)           | The core Vite plugin                  |
+| [`@atlowchemi/webfont-generator`](./packages/webfont-generator) | Native Rust webfont generation engine |
 
 ## Documentation
 

--- a/packages/vite-svg-2-webfont/src/optionParser.test.ts
+++ b/packages/vite-svg-2-webfont/src/optionParser.test.ts
@@ -96,21 +96,21 @@ describe('optionParser', () => {
         const fontName = 'fontname';
         const extension = 'css';
         it.concurrent("doesn't concatenate fileDest if not set", () => {
-            expect(optionParser.resolveFileDest(globalDest, undefined, fontName, extension)).toBe(resolve(`${globalDest}/${fontName}.${extension}`));
+            expect(optionParser.resolveFileDest(globalDest, undefined, fontName, extension)).toBe(resolve(globalDest, `${fontName}.${extension}`));
         });
 
         it.concurrent("doesn't concatenate fontName if fileDest has a file extension", () => {
-            expect(optionParser.resolveFileDest(globalDest, `file.${extension}`, fontName, extension)).toBe(resolve(`${globalDest}/file.${extension}`));
+            expect(optionParser.resolveFileDest(globalDest, `file.${extension}`, fontName, extension)).toBe(resolve(globalDest, `file.${extension}`));
         });
 
         it.concurrent("concatenates fontName if fileDest doesn't have a file extension", () => {
-            expect(optionParser.resolveFileDest(globalDest, 'file', fontName, extension)).toBe(resolve(`${globalDest}/file/${fontName}.${extension}`));
+            expect(optionParser.resolveFileDest(globalDest, 'file', fontName, extension)).toBe(resolve(globalDest, `file/${fontName}.${extension}`));
         });
 
         it.concurrent("doesn't concatenate globalDest if fileDest is absolute", () => {
             const absFile = resolve('/file');
             expect(optionParser.resolveFileDest(globalDest, '/file', fontName, extension)).toBe(resolve(absFile, `${fontName}.${extension}`));
-            expect(optionParser.resolveFileDest(globalDest, `/file.${extension}`, fontName, extension)).toBe(resolve(`${absFile}.${extension}`));
+            expect(optionParser.resolveFileDest(globalDest, `/file.${extension}`, fontName, extension)).toBe(`${absFile}.${extension}`);
         });
     });
 
@@ -292,7 +292,7 @@ describe('optionParser', () => {
             const parent = '/parent/';
             const resDefault = optionParser.parseOptions({ context: `${parent}exIcons` });
             expect(resDefault.dest).toBe(`${resolve(parent, 'artifacts')}${sep}`);
-            const resExplicit = optionParser.parseOptions({ context: `${parent}exIcons`, dest: parent });
+            const resExplicit = optionParser.parseOptions({ context: `${parent}exIcons`, dest: resolve(parent) });
             expect(resExplicit.dest).toBe(`${resolve(parent)}${sep}`);
         });
 
@@ -433,7 +433,7 @@ describe('optionParser', () => {
             expect('cssTemplate' in resDefault).toEqual(false);
             const cssTemplate = '/cssTemplate';
             const resExplicit = optionParser.parseOptions({ context, cssTemplate });
-            expect(resExplicit.cssTemplate).toBe(cssTemplate);
+            expect(resExplicit.cssTemplate).toBe(resolve(cssTemplate));
         });
 
         it.concurrent('sets cssContext only if defined in options', () => {

--- a/packages/webfont-generator/README.md
+++ b/packages/webfont-generator/README.md
@@ -1,0 +1,60 @@
+# @atlowchemi/webfont-generator
+
+A native Rust [NAPI](https://napi.rs) addon that generates webfonts (SVG, TTF, EOT, WOFF, WOFF2) and their companion CSS/HTML from a set of SVG icon files.
+
+This is a ground-up rewrite of [`@vusion/webfonts-generator`](https://github.com/vusion/webfonts-generator) in Rust — the original package and its authors deserve credit for the API design and template system that this project builds on. The JS implementation is unmaintained, so this package reimplements the same pipeline natively for better performance and long-term maintainability.
+
+The API is largely compatible with `@vusion/webfonts-generator`, with a few differences:
+
+- The `cssContext` and `htmlContext` callbacks receive only the context object. The original also passed `options` and the `handlebars` instance as additional arguments — those are no longer available.
+- Generated font binaries (TTF, WOFF, etc.) may differ at the byte level because a different encoder is used, but the fonts are equally valid.
+- CSS, HTML, and template output is identical.
+
+Performance scales better with glyph count — for larger icon sets the native pipeline is significantly faster.
+
+## Installation
+
+```bash
+npm install @atlowchemi/webfont-generator
+```
+
+Pre-built binaries are published for the following targets:
+
+| Platform       | Architecture      |
+| -------------- | ----------------- |
+| macOS          | x64, arm64        |
+| Linux (glibc)  | x64, arm64, armv7 |
+| Linux (musl)   | x64, arm64        |
+| Windows (MSVC) | x64, arm64        |
+
+## Usage
+
+```js
+import { generateWebfonts } from '@atlowchemi/webfont-generator';
+
+const result = await generateWebfonts({
+    files: ['./icons/home.svg', './icons/search.svg'],
+    dest: './dist/fonts',
+    fontName: 'my-icons',
+    types: ['woff2', 'woff'],
+});
+
+const css = result.generateCss();
+const html = result.generateHtml();
+```
+
+## Templates
+
+Default CSS, SCSS, and HTML templates are available via the `/templates` export:
+
+```js
+import { templates } from '@atlowchemi/webfont-generator/templates';
+
+console.log(templates.css); // path to default CSS template
+console.log(templates.scss); // path to default SCSS template
+console.log(templates.html); // path to default HTML template
+```
+
+## License
+
+[MIT](../../LICENSE)


### PR DESCRIPTION
## Summary

- Add `build-native.yaml` reusable workflow: 9-target cross-compilation using cargo-zigbuild (Linux/macOS) and cargo-xwin (Windows MSVC)
- Add `build` job to main CI triggering native builds after lint passes
- Add `test-host` job: native binary smoke tests on 5 platforms x 3 Node versions (macOS x64/arm64, Linux arm64, Windows x64/arm64)
- Add `test-docker` job: Alpine musl testing for x86_64 and aarch64
- Rename `test` -> `test-vite-compat` with native binary download and plugin pack steps
- Add `@atlowchemi/webfont-generator` README and link from root README

PR 2 of 5 splitting #80.