### PR TITLE
ci: add release-please config and publish workflow for native package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
         outputs:
             plugin-released: ${{ steps.release.outputs['packages/vite-svg-2-webfont--release_created'] }}
             plugin-tag: ${{ steps.release.outputs['packages/vite-svg-2-webfont--tag_name'] }}
+            native-released: ${{ steps.release.outputs['packages/webfont-generator--release_created'] }}
+            native-tag: ${{ steps.release.outputs['packages/webfont-generator--tag_name'] }}
             any-released: ${{ steps.release.outputs.releases_created }}
         steps:
             - uses: googleapis/release-please-action@v4
@@ -53,9 +55,52 @@ jobs:
                     git push
                   fi
 
+    build-native:
+        name: Build native binaries
+        needs: [release-please]
+        if: needs.release-please.outputs.any-released == 'true'
+        uses: ./.github/workflows/build-native.yaml
+
+    publish-native:
+        name: Publish @atlowchemi/webfont-generator
+        needs: [release-please, build-native]
+        if: needs.release-please.outputs.native-released == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: voidzero-dev/setup-vp@v1
+              with:
+                  node-version-file: .node-version
+                  run-install: true
+                  cache: true
+
+            - name: Download all binding artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  path: packages/webfont-generator/artifacts
+                  pattern: bindings-*
+
+            - name: Create npm dirs
+              run: vp exec napi create-npm-dirs --cwd packages/webfont-generator
+            - name: Move artifacts
+              run: vp exec napi artifacts --cwd packages/webfont-generator
+            - name: List packages
+              run: ls -R ./packages/webfont-generator/npm
+              shell: bash
+
+            - name: Publish
+              run: pnpm publish --filter @atlowchemi/webfont-generator --access public --provenance
+
+            - name: Upload to native release
+              if: needs.release-please.outputs.native-released == 'true'
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ needs.release-please.outputs.native-tag }}
+                  files: packages/webfont-generator/**/*.node
+
     publish-plugin:
         name: Publish vite-svg-2-webfont
-        needs: [release-please]
+        needs: [release-please, build-native]
         if: needs.release-please.outputs.plugin-released == 'true'
         runs-on: ubuntu-latest
         steps:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ node_modules/
 dist
 target/
 packages/webfont-generator/*.node
+packages/webfont-generator/artifacts/
+packages/webfont-generator/npm/
 packages/webfont-generator/target/
 packages/vite-svg-2-webfont/src/fixtures/webfont-test/artifacts/*
 packages/docs/.vitepress/cache

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-    "packages/vite-svg-2-webfont": "6.1.2"
+    "packages/vite-svg-2-webfont": "6.1.2",
+    "packages/webfont-generator": "0.1.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,4 +116,4 @@ In practice, assume formatting, linting, and unit tests are part of the validati
 - Keep lockfile changes in `pnpm-lock.yaml` when dependencies change.
 - Do not commit `package-lock.json` files to the workspace.
 - Use `vp` instead of calling `pnpm`, `vite`, `vitest`, `oxlint`, or `oxfmt` directly for normal repository workflows.
-- The docs site is driven by Vite+ run tasks, so prefer `vp run @atlowchemi/vite-svg-webfont-docs#dev`, `vp run @atlowchemi/vite-svg-webfont-docs#build`, and `vp run @atlowchemi/vite-svg-webfont-docs#preview` over direct `vitepress` commands.
+- The docs site is driven by Vite+ run tasks in `packages/docs/`, so prefer `vp run @atlowchemi/vite-svg-webfont-docs#dev` over direct `vitepress` commands.

--- a/packages/webfont-generator/package.json
+++ b/packages/webfont-generator/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@atlowchemi/webfont-generator",
     "version": "0.1.0",
+    "license": "MIT",
     "type": "module",
     "main": "./index.js",
     "types": "./index.d.ts",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,10 @@
         "packages/vite-svg-2-webfont": {
             "release-type": "node",
             "component": "vite-svg-2-webfont"
+        },
+        "packages/webfont-generator": {
+            "release-type": "node",
+            "component": "webfont-generator"
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `packages/webfont-generator` to release-please config and manifest (v0.1.0)
- Add `build-native` and `publish-native` jobs to the release workflow
- `publish-plugin` now depends on `build-native` completing first
- Upload `.node` binaries to GitHub release on native publish
- Simplify docs note in CONTRIBUTING.md

PR 3 of 5 splitting #80. After merging, the auto-created release-please PR should be merged to trigger the first npm publish of `@atlowchemi/webfont-generator@0.1.0`.