### PR TITLE
feat: publish webfont-generator crate with library API, CLI, and docs

### DIFF
--- a/.github/workflows/build-native.yaml
+++ b/.github/workflows/build-native.yaml
@@ -122,7 +122,7 @@ jobs:
               run: >
                   npx napi build --release --platform --esm --js binding.js --dts binding.d.ts
                   ${{ matrix.target != 'x86_64-unknown-linux-gnu' && format('--target {0} -x', matrix.target) || '' }}
-                  -- --locked
+                  -- --locked --features napi
               env:
                   XWIN_CACHE_DIR: ${{ github.workspace }}/.xwin
                   CFLAGS_x86_64_apple_darwin: -mmacosx-version-min=10.13

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,6 +98,20 @@ jobs:
                   tag_name: ${{ needs.release-please.outputs.native-tag }}
                   files: packages/webfont-generator/**/*.node
 
+    publish-crate:
+        name: Publish to crates.io
+        needs: [release-please]
+        if: needs.release-please.outputs.native-released == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: dtolnay/rust-toolchain@stable
+            - name: Publish to crates.io
+              working-directory: packages/webfont-generator
+              run: cargo publish
+              env:
+                  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
     publish-plugin:
         name: Publish vite-svg-2-webfont
         needs: [release-please, build-native]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.oxc": "explicit"
     },
-    "rust-analyzer.linkedProjects": ["packages/webfont-generator/Cargo.toml"]
+    "rust-analyzer.linkedProjects": ["packages/webfont-generator/Cargo.toml"],
+    "rust-analyzer.cargo.features": ["cli", "napi"]
 }

--- a/packages/webfont-generator/Cargo.lock
+++ b/packages/webfont-generator/Cargo.lock
@@ -9,6 +9,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +132,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "convert_case"
@@ -469,6 +565,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +591,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -676,6 +784,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oxvg_parse"
@@ -1160,6 +1274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1295,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "webfont-generator"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "flate2",
  "handlebars",
  "kurbo",
@@ -1198,6 +1319,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "woff"

--- a/packages/webfont-generator/Cargo.toml
+++ b/packages/webfont-generator/Cargo.toml
@@ -1,19 +1,35 @@
 [package]
 name = "webfont-generator"
 version = "0.1.0"
-edition = "2021"
-publish = false
+edition = "2024"
+license = "MIT"
+description = "Generate webfonts (SVG, TTF, EOT, WOFF, WOFF2) from SVG icons"
+repository = "https://github.com/atlowChemi/vite-svg-2-webfont"
+documentation = "https://docs.rs/webfont-generator"
+readme = "README.md"
+keywords = ["webfont", "svg", "icon-font", "woff", "opentype"]
+categories = ["command-line-utilities", "graphics", "web-programming"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "webfont-generator"
+required-features = ["cli"]
+
+[features]
+default = []
+napi = ["dep:napi", "dep:napi-derive"]
+cli = ["dep:clap"]
+
 [dependencies]
+clap = { version = "4", features = ["derive"], optional = true }
 flate2 = "1.1.5"
 handlebars = "6.3.2"
 kurbo = "0.13.0"
 md5 = "0.8.0"
-napi = { version = "3.8.4", default-features = false, features = ["napi4", "async", "serde-json-ordered"] }
-napi-derive = "3.5.3"
+napi = { version = "3.8.4", default-features = false, features = ["napi4", "async", "serde-json-ordered"], optional = true }
+napi-derive = { version = "3.5.3", optional = true }
 rayon = "1.11.0"
 roxmltree = "0.21.1"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -23,6 +39,9 @@ tokio = { version = "1", features = ["fs", "macros", "rt", "rt-multi-thread"] }
 woff = { version = "0.6.3" }
 usvg = "0.47.0"
 write-fonts = { version = "0.46.0", features = ["read"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 napi-build = "2.3.1"

--- a/packages/webfont-generator/README.md
+++ b/packages/webfont-generator/README.md
@@ -12,7 +12,7 @@ The API is largely compatible with `@vusion/webfonts-generator`, with a few diff
 
 Performance scales better with glyph count — for larger icon sets the native pipeline is significantly faster.
 
-## Installation
+## Node.js (npm)
 
 ```bash
 npm install @atlowchemi/webfont-generator
@@ -27,8 +27,6 @@ Pre-built binaries are published for the following targets:
 | Linux (musl)   | x64, arm64        |
 | Windows (MSVC) | x64, arm64        |
 
-## Usage
-
 ```js
 import { generateWebfonts } from '@atlowchemi/webfont-generator';
 
@@ -41,6 +39,87 @@ const result = await generateWebfonts({
 
 const css = result.generateCss();
 const html = result.generateHtml();
+```
+
+## Rust library (crates.io)
+
+```bash
+cargo add webfont-generator
+```
+
+```rust
+use webfont_generator::{GenerateWebfontsOptions, FontType};
+
+let result = webfont_generator::generate_sync(
+    GenerateWebfontsOptions {
+        dest: "dist/fonts".to_owned(),
+        files: vec!["icons/home.svg".to_owned(), "icons/search.svg".to_owned()],
+        font_name: Some("my-icons".to_owned()),
+        types: Some(vec![FontType::Woff2, FontType::Woff]),
+        ..Default::default()
+    },
+    None,
+).unwrap();
+
+let css = result.generate_css_pure(None).unwrap();
+```
+
+An async API (`webfont_generator::generate`) is also available for use with tokio.
+
+## CLI
+
+The CLI is available as an opt-in feature (to avoid pulling in `clap` for library users):
+
+```bash
+cargo install webfont-generator --features cli
+```
+
+### Usage
+
+```
+webfont-generator [OPTIONS] --dest <DEST> <FILES>...
+```
+
+### Examples
+
+```bash
+# Generate default formats (eot, woff, woff2) from a directory of SVGs
+webfont-generator --dest ./dist/fonts ./icons/
+
+# Generate specific formats with a custom font name
+webfont-generator --dest ./dist/fonts --types woff2,woff --font-name my-icons ./icons/
+
+# Generate fonts with an HTML preview page
+webfont-generator --dest ./dist/fonts --html ./icons/*.svg
+```
+
+### Options
+
+```
+Arguments:
+  <FILES>...  SVG files or directories containing SVG files
+
+Options:
+  -d, --dest <DEST>                        Output directory
+  -n, --font-name <FONT_NAME>              Font name [default: iconfont]
+  -t, --types <TYPES>                      Font types to generate [possible values: svg, ttf, eot, woff, woff2]
+      --css                                Generate CSS (default)
+      --no-css                             Skip CSS generation
+      --html                               Generate HTML preview
+      --no-html                            Skip HTML generation (default)
+      --css-template <CSS_TEMPLATE>        Custom CSS template path
+      --html-template <HTML_TEMPLATE>      Custom HTML template path
+      --css-fonts-url <CSS_FONTS_URL>      CSS fonts URL prefix
+      --write                               Write output files to disk (default)
+      --no-write                           Do not write output files (dry run)
+      --ligature                           Enable ligatures (default)
+      --no-ligature                        Disable ligatures
+      --font-height <FONT_HEIGHT>          Font height
+      --ascent <ASCENT>                    Ascent value
+      --descent <DESCENT>                  Descent value
+      --start-codepoint <START_CODEPOINT>  Start codepoint (hex, e.g. 0xF101)
+  -h, --help                               Print help
+  -V, --version                            Print version
 ```
 
 ## Templates

--- a/packages/webfont-generator/build.rs
+++ b/packages/webfont-generator/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    #[cfg(feature = "napi")]
     napi_build::setup();
 }

--- a/packages/webfont-generator/src/eot/mod.rs
+++ b/packages/webfont-generator/src/eot/mod.rs
@@ -241,8 +241,8 @@ fn write_u32_le(data: &mut [u8], offset: usize, value: u32) -> Result<(), Error>
 
 #[cfg(test)]
 mod tests {
-    use super::{ttf_to_eot, EOT_VERSION};
-    use crate::{ttf::generate_ttf_font_bytes, GenerateWebfontsOptions};
+    use super::{EOT_VERSION, ttf_to_eot};
+    use crate::{GenerateWebfontsOptions, ttf::generate_ttf_font_bytes};
 
     #[test]
     fn generates_an_eot_buffer_with_expected_header() {

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -1,3 +1,64 @@
+//! # webfont-generator
+//!
+//! Generate webfonts (SVG, TTF, EOT, WOFF, WOFF2) from SVG icon files.
+//!
+//! ## Library usage
+//!
+//! ```rust,no_run
+//! use webfont_generator::{GenerateWebfontsOptions, FontType};
+//!
+//! // Async API (requires a tokio runtime)
+//! # async fn example() -> std::io::Result<()> {
+//! let options = GenerateWebfontsOptions {
+//!     dest: "output".to_owned(),
+//!     files: vec!["icons/add.svg".to_owned(), "icons/remove.svg".to_owned()],
+//!     font_name: Some("my-icons".to_owned()),
+//!     types: Some(vec![FontType::Woff2, FontType::Woff]),
+//!     ..Default::default()
+//! };
+//!
+//! let result = webfont_generator::generate(options, None).await?;
+//! if let Some(woff2) = result.woff2_bytes() {
+//!     println!("Generated WOFF2: {} bytes", woff2.len());
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ```rust,no_run
+//! use webfont_generator::{GenerateWebfontsOptions, FontType};
+//!
+//! // Synchronous API
+//! let options = GenerateWebfontsOptions {
+//!     dest: "output".to_owned(),
+//!     files: vec!["icons/add.svg".to_owned()],
+//!     write_files: Some(false),
+//!     ..Default::default()
+//! };
+//!
+//! let result = webfont_generator::generate_sync(options, None).unwrap();
+//! ```
+//!
+//! ## CLI
+//!
+//! Install the CLI binary with:
+//!
+//! ```sh
+//! cargo install webfont-generator --features cli
+//! ```
+//!
+//! Then run:
+//!
+//! ```sh
+//! webfont-generator --dest ./dist/fonts ./icons/
+//! ```
+//!
+//! ## Feature flags
+//!
+//! - **`cli`**: Builds the `webfont-generator` CLI binary (adds `clap` dependency).
+//!   Not enabled by default — use `cargo install webfont-generator --features cli`.
+//! - **`napi`**: Enables Node.js NAPI bindings for use as a native addon.
+
 mod eot;
 mod svg;
 mod templates;
@@ -8,31 +69,40 @@ mod types;
 mod util;
 mod woff;
 
+#[cfg(feature = "napi")]
 use napi::threadsafe_function::ThreadsafeFunction;
-use napi::{Error, Status};
+#[cfg(feature = "napi")]
+use napi::{Error as NapiError, Status};
+#[cfg(feature = "napi")]
 use napi_derive::napi;
 use rayon::join;
 use std::collections::HashSet;
+use std::io::ErrorKind;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+#[cfg(feature = "napi")]
+use std::sync::Mutex;
 use tokio::task::JoinSet;
 
 use svg::{build_svg_font, prepare_svg_font, svg_options_from_options};
+#[cfg(feature = "napi")]
 use templates::{
-    apply_context_function, build_css_context, build_html_context, build_html_registry,
-    render_css_with_hbs_context, render_html_with_hbs_context, SharedTemplateData,
+    SharedTemplateData, apply_context_function, build_css_context, build_html_context,
+    build_html_registry,
 };
-use util::{glyph_name_from_path, resolve_codepoints, to_napi_err};
+use templates::{render_css_with_hbs_context, render_html_with_hbs_context};
+#[cfg(feature = "napi")]
+use util::to_napi_err;
 
 use types::{
-    resolved_font_types, LoadedSvgFile, ResolvedGenerateWebfontsOptions, DEFAULT_FONT_ORDER,
+    DEFAULT_FONT_ORDER, LoadedSvgFile, ResolvedGenerateWebfontsOptions, resolved_font_types,
 };
 pub use types::{
     FontType, FormatOptions, GenerateWebfontsOptions, GenerateWebfontsResult, SvgFormatOptions,
     TtfFormatOptions, WoffFormatOptions,
 };
 
-#[cfg(test)]
+#[cfg(all(test, feature = "napi"))]
 #[unsafe(no_mangle)]
 extern "C" fn napi_call_threadsafe_function(
     _: napi::sys::napi_threadsafe_function,
@@ -42,6 +112,7 @@ extern "C" fn napi_call_threadsafe_function(
     0
 }
 
+#[cfg(feature = "napi")]
 #[napi]
 #[allow(clippy::type_complexity)] // NAPI proc macro requires the verbose ThreadsafeFunction type
 pub async fn generate_webfonts(
@@ -67,7 +138,7 @@ pub async fn generate_webfonts(
     >,
 ) -> napi::Result<GenerateWebfontsResult> {
     validate_generate_webfonts_options(&options)?;
-    let source_files = load_svg_files(&options.files, rename.as_ref()).await?;
+    let source_files = load_svg_files_napi(&options.files, rename.as_ref()).await?;
     let mut resolved_options = resolve_generate_webfonts_options(options)?;
     finalize_generate_webfonts_options(&mut resolved_options, &source_files)?;
 
@@ -75,7 +146,7 @@ pub async fn generate_webfonts(
         tokio::task::spawn_blocking(move || generate_webfonts_sync(resolved_options, source_files))
             .await
             .map_err(|error| {
-                Error::new(
+                NapiError::new(
                     Status::GenericFailure,
                     format!("Native webfont generation task failed: {error}"),
                 )
@@ -109,7 +180,7 @@ pub async fn generate_webfonts(
             result.html_context = Some(html_ctx.clone());
         }
 
-        // Seed the OnceLock — avoids re-creating SharedTemplateData in get_cached()
+        // Seed the OnceLock -- avoids re-creating SharedTemplateData in get_cached()
         let html_registry = build_html_registry(&result.options).map_err(to_napi_err)?;
         let css_hbs_context = handlebars::Context::wraps(&css_ctx).map_err(to_napi_err)?;
         let html_hbs_context = handlebars::Context::wraps(&html_ctx).map_err(to_napi_err)?;
@@ -131,41 +202,74 @@ pub async fn generate_webfonts(
     Ok(result)
 }
 
-fn validate_generate_webfonts_options(options: &GenerateWebfontsOptions) -> napi::Result<()> {
+/// A glyph rename function that maps file stems to custom glyph names.
+pub type RenameFn = Box<dyn Fn(&str) -> String + Send + Sync>;
+
+/// Generate webfonts from SVG files.
+///
+/// This is the pure Rust async entry point. Requires a tokio runtime.
+pub async fn generate(
+    options: GenerateWebfontsOptions,
+    rename: Option<RenameFn>,
+) -> std::io::Result<GenerateWebfontsResult> {
+    validate_generate_webfonts_options(&options)?;
+    let source_files = load_svg_files(&options.files, rename.as_deref()).await?;
+    let mut resolved_options = resolve_generate_webfonts_options(options)?;
+    finalize_generate_webfonts_options(&mut resolved_options, &source_files)?;
+
+    let result =
+        tokio::task::spawn_blocking(move || generate_webfonts_sync(resolved_options, source_files))
+            .await
+            .map_err(std::io::Error::other)??;
+
+    if result.options.write_files {
+        write_generate_webfonts_result(&result).await?;
+    }
+
+    Ok(result)
+}
+
+/// Synchronous version of [`generate`]. Spawns a tokio runtime internally.
+pub fn generate_sync(
+    options: GenerateWebfontsOptions,
+    rename: Option<RenameFn>,
+) -> std::io::Result<GenerateWebfontsResult> {
+    tokio::runtime::Runtime::new()?.block_on(generate(options, rename))
+}
+
+fn validate_generate_webfonts_options(options: &GenerateWebfontsOptions) -> std::io::Result<()> {
     if options.dest.is_empty() {
-        return Err(Error::new(
-            Status::InvalidArg,
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
             "\"options.dest\" is empty.".to_owned(),
         ));
     }
 
     if options.files.is_empty() {
-        return Err(Error::new(
-            Status::InvalidArg,
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
             "\"options.files\" is empty.".to_owned(),
         ));
     }
 
-    if options.css.unwrap_or(true) {
-        if let Some(ref path) = options.css_template {
-            if !Path::new(path).exists() {
-                return Err(Error::new(
-                    Status::InvalidArg,
-                    format!("\"options.cssTemplate\" file not found: {path}"),
-                ));
-            }
-        }
+    if options.css.unwrap_or(true)
+        && let Some(ref path) = options.css_template
+        && !Path::new(path).exists()
+    {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("\"options.cssTemplate\" file not found: {path}"),
+        ));
     }
 
-    if options.html.unwrap_or(false) {
-        if let Some(ref path) = options.html_template {
-            if !Path::new(path).exists() {
-                return Err(Error::new(
-                    Status::InvalidArg,
-                    format!("\"options.htmlTemplate\" file not found: {path}"),
-                ));
-            }
-        }
+    if options.html.unwrap_or(false)
+        && let Some(ref path) = options.html_template
+        && !Path::new(path).exists()
+    {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("\"options.htmlTemplate\" file not found: {path}"),
+        ));
     }
 
     Ok(())
@@ -173,7 +277,7 @@ fn validate_generate_webfonts_options(options: &GenerateWebfontsOptions) -> napi
 
 pub(crate) fn resolve_generate_webfonts_options(
     options: GenerateWebfontsOptions,
-) -> napi::Result<ResolvedGenerateWebfontsOptions> {
+) -> std::io::Result<ResolvedGenerateWebfontsOptions> {
     let types = resolved_font_types(&options);
     validate_font_type_order(&options, &types)?;
     let order = resolve_font_type_order(&options, &types);
@@ -210,10 +314,10 @@ pub(crate) fn resolve_generate_webfonts_options(
         css_dest,
         css_template: match options.css_template {
             Some(ref t) if t.is_empty() => {
-                return Err(Error::new(
-                    Status::InvalidArg,
+                return Err(std::io::Error::new(
+                    ErrorKind::InvalidInput,
                     "\"options.cssTemplate\" must not be empty.".to_owned(),
-                ))
+                ));
             }
             other => other,
         },
@@ -228,10 +332,10 @@ pub(crate) fn resolve_generate_webfonts_options(
         html_dest,
         html_template: match options.html_template {
             Some(ref t) if t.is_empty() => {
-                return Err(Error::new(
-                    Status::InvalidArg,
+                return Err(std::io::Error::new(
+                    ErrorKind::InvalidInput,
                     "\"options.htmlTemplate\" must not be empty.".to_owned(),
-                ))
+                ));
             }
             other => other,
         },
@@ -255,10 +359,9 @@ pub(crate) fn resolve_generate_webfonts_options(
 pub(crate) fn finalize_generate_webfonts_options(
     options: &mut ResolvedGenerateWebfontsOptions,
     source_files: &[LoadedSvgFile],
-) -> napi::Result<()> {
+) -> std::io::Result<()> {
     options.codepoints =
-        resolve_codepoints(source_files, &options.codepoints, options.start_codepoint)
-            .map_err(|error| Error::new(Status::InvalidArg, error.to_string()))?;
+        resolve_codepoints(source_files, &options.codepoints, options.start_codepoint)?;
 
     Ok(())
 }
@@ -284,7 +387,7 @@ fn default_output_dest(dest: &str, font_name: &str, extension: &str) -> String {
 fn generate_webfonts_sync(
     options: ResolvedGenerateWebfontsOptions,
     source_files: Vec<LoadedSvgFile>,
-) -> napi::Result<GenerateWebfontsResult> {
+) -> std::io::Result<GenerateWebfontsResult> {
     let wants_svg = options.types.contains(&FontType::Svg);
     let wants_ttf = options.types.contains(&FontType::Ttf);
     let wants_woff = options.types.contains(&FontType::Woff);
@@ -292,22 +395,21 @@ fn generate_webfonts_sync(
     let wants_eot = options.types.contains(&FontType::Eot);
 
     let svg_options = svg_options_from_options(&options);
-    let prepared = prepare_svg_font(&svg_options, &source_files).map_err(to_napi_err)?;
+    let prepared = prepare_svg_font(&svg_options, &source_files)?;
 
     let (svg_font, raw_ttf) = join(
-        || -> napi::Result<Option<String>> {
+        || -> std::io::Result<Option<String>> {
             if wants_svg {
                 Ok(Some(build_svg_font(&svg_options, &prepared)))
             } else {
                 Ok(None)
             }
         },
-        || -> napi::Result<Option<Vec<u8>>> {
+        || -> std::io::Result<Option<Vec<u8>>> {
             if wants_ttf || wants_woff || wants_woff2 || wants_eot {
                 let ttf_options = ttf::ttf_options_from_options(&options);
                 ttf::generate_ttf_font_bytes_from_glyphs(ttf_options, &prepared.processed_glyphs)
                     .map(Some)
-                    .map_err(to_napi_err)
             } else {
                 Ok(None)
             }
@@ -327,27 +429,25 @@ fn generate_webfonts_sync(
             .and_then(|value| value.metadata.as_deref());
 
         let (woff_font, (woff2_font, eot_font)) = join(
-            || -> napi::Result<Option<Vec<u8>>> {
+            || -> std::io::Result<Option<Vec<u8>>> {
                 if wants_woff {
-                    woff::ttf_to_woff1(&raw_ttf, woff_metadata)
-                        .map(Some)
-                        .map_err(to_napi_err)
+                    woff::ttf_to_woff1(&raw_ttf, woff_metadata).map(Some)
                 } else {
                     Ok(None)
                 }
             },
             || {
                 join(
-                    || -> napi::Result<Option<Vec<u8>>> {
+                    || -> std::io::Result<Option<Vec<u8>>> {
                         if wants_woff2 {
-                            woff::ttf_to_woff2(&raw_ttf).map(Some).map_err(to_napi_err)
+                            woff::ttf_to_woff2(&raw_ttf).map(Some)
                         } else {
                             Ok(None)
                         }
                     },
-                    || -> napi::Result<Option<Vec<u8>>> {
+                    || -> std::io::Result<Option<Vec<u8>>> {
                         if wants_eot {
-                            eot::ttf_to_eot(&raw_ttf).map(Some).map_err(to_napi_err)
+                            eot::ttf_to_eot(&raw_ttf).map(Some)
                         } else {
                             Ok(None)
                         }
@@ -380,7 +480,7 @@ fn generate_webfonts_sync(
     })
 }
 
-async fn write_generate_webfonts_result(result: &GenerateWebfontsResult) -> napi::Result<()> {
+async fn write_generate_webfonts_result(result: &GenerateWebfontsResult) -> std::io::Result<()> {
     let mut tasks = JoinSet::new();
     let font_name = result.options.font_name.clone();
     let dest = result.options.dest.clone();
@@ -417,12 +517,11 @@ async fn write_generate_webfonts_result(result: &GenerateWebfontsResult) -> napi
 
     // Only render CSS/HTML templates when those files need to be written.
     if result.options.css || result.options.html {
-        let cached = result.get_cached()?;
+        let cached = result.get_cached_io()?;
 
         if result.options.css {
             let ctx = cached.css_hbs_context.lock().unwrap();
-            let css = render_css_with_hbs_context(&cached.shared, &ctx, &cached.css_context)
-                .map_err(to_napi_err)?;
+            let css = render_css_with_hbs_context(&cached.shared, &ctx, &cached.css_context)?;
             drop(ctx);
             let css_dest = result.options.css_dest.clone();
             let css = Arc::new(css);
@@ -435,22 +534,16 @@ async fn write_generate_webfonts_result(result: &GenerateWebfontsResult) -> napi
                 cached.html_registry.as_ref(),
                 &ctx,
                 &cached.html_context,
-            )
-            .map_err(to_napi_err)?;
+            )?;
             let html_dest = result.options.html_dest.clone();
             tasks.spawn(async move { write_output_file(html_dest, html.into_bytes()).await });
         }
     }
 
     while let Some(result) = tasks.join_next().await {
-        result
-            .map_err(|error| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("Native write task failed: {error}"),
-                )
-            })?
-            .map_err(to_napi_err)?;
+        result.map_err(|error| {
+            std::io::Error::other(format!("Native write task failed: {error}"))
+        })??;
     }
 
     Ok(())
@@ -467,32 +560,27 @@ async fn write_output_file(path: String, contents: impl AsRef<[u8]>) -> std::io:
 fn validate_font_type_order(
     options: &GenerateWebfontsOptions,
     requested_types: &[FontType],
-) -> napi::Result<()> {
-    if let Some(order) = &options.order {
-        if let Some(invalid_type) = order
+) -> std::io::Result<()> {
+    if let Some(order) = &options.order
+        && let Some(invalid_type) = order
             .iter()
             .copied()
             .find(|font_type| !requested_types.contains(font_type))
-        {
-            return Err(Error::new(
-                Status::InvalidArg,
-                format!(
-                    "Invalid font type order: '{}' is not present in 'types'.",
-                    invalid_type.as_extension()
-                ),
-            ));
-        }
+    {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "Invalid font type order: '{}' is not present in 'types'.",
+                invalid_type.as_extension()
+            ),
+        ));
     }
 
     Ok(())
 }
 
-async fn load_svg_files(
-    paths: &[String],
-    rename: Option<
-        &napi::threadsafe_function::ThreadsafeFunction<String, String, String, Status, false>,
-    >,
-) -> napi::Result<Vec<LoadedSvgFile>> {
+/// Load SVG file contents in parallel, preserving the original order.
+async fn load_svg_contents(paths: &[String]) -> std::io::Result<Vec<(String, String)>> {
     let mut tasks = JoinSet::new();
 
     for (index, path) in paths.iter().cloned().enumerate() {
@@ -503,52 +591,77 @@ async fn load_svg_files(
         });
     }
 
-    let mut source_files = Vec::with_capacity(paths.len());
-
+    let mut results = Vec::with_capacity(paths.len());
     while let Some(result) = tasks.join_next().await {
-        let (index, (path, contents)) = result
+        let (index, pair) = result
+            .map_err(|error| std::io::Error::other(format!("SVG loading task failed: {error}")))?
             .map_err(|error| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("Native SVG loading task failed: {error}"),
-                )
-            })?
-            .map_err(|error| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("Failed to read source SVG file: {error}"),
-                )
+                std::io::Error::other(format!("Failed to read source SVG file: {error}"))
             })?;
-        let glyph_name = glyph_name_from_path(&path, rename).await?;
-        source_files.push((
-            index,
-            LoadedSvgFile {
+        results.push((index, pair));
+    }
+
+    results.sort_by_key(|(index, _)| *index);
+    Ok(results.into_iter().map(|(_, pair)| pair).collect())
+}
+
+/// Load SVG files and resolve glyph names using an optional sync rename function.
+async fn load_svg_files(
+    paths: &[String],
+    rename: Option<&(dyn Fn(&str) -> String + Send + Sync)>,
+) -> std::io::Result<Vec<LoadedSvgFile>> {
+    let raw = load_svg_contents(paths).await?;
+    let source_files: Vec<LoadedSvgFile> = raw
+        .into_iter()
+        .map(|(path, contents)| {
+            let glyph_name = util::glyph_name_from_path(&path, rename)?;
+            Ok(LoadedSvgFile {
                 contents,
                 glyph_name,
                 path,
-            },
-        ));
-    }
-
-    source_files.sort_by_key(|(index, _)| *index);
-
-    let source_files = source_files
-        .into_iter()
-        .map(|(_, source_file)| source_file)
-        .collect::<Vec<_>>();
+            })
+        })
+        .collect::<std::io::Result<_>>()?;
 
     validate_glyph_names(&source_files)?;
-
     Ok(source_files)
 }
 
-fn validate_glyph_names(source_files: &[LoadedSvgFile]) -> napi::Result<()> {
+/// NAPI version: resolve glyph names via async ThreadsafeFunction callback.
+#[cfg(feature = "napi")]
+async fn load_svg_files_napi(
+    paths: &[String],
+    rename: Option<
+        &napi::threadsafe_function::ThreadsafeFunction<String, String, String, Status, false>,
+    >,
+) -> napi::Result<Vec<LoadedSvgFile>> {
+    let raw = load_svg_contents(paths).await.map_err(to_napi_err)?;
+    let mut source_files = Vec::with_capacity(raw.len());
+
+    for (path, contents) in raw {
+        let glyph_name = if let Some(rename) = rename {
+            rename.call_async(path.clone()).await?
+        } else {
+            util::default_glyph_name_from_path(&path).map_err(to_napi_err)?
+        };
+        source_files.push(LoadedSvgFile {
+            contents,
+            glyph_name,
+            path,
+        });
+    }
+
+    validate_glyph_names(&source_files).map_err(to_napi_err)?;
+    Ok(source_files)
+}
+
+fn validate_glyph_names(source_files: &[LoadedSvgFile]) -> std::io::Result<()> {
     let mut seen_names = HashSet::with_capacity(source_files.len());
 
     for source_file in source_files {
         if !seen_names.insert(source_file.glyph_name.clone()) {
-            return Err(Error::new(
-                Status::InvalidArg,
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidInput,
                 format!(
                     "The glyph name \"{}\" must be unique.",
                     source_file.glyph_name
@@ -560,15 +673,16 @@ fn validate_glyph_names(source_files: &[LoadedSvgFile]) -> napi::Result<()> {
     Ok(())
 }
 
+// Re-export resolve_codepoints for use in finalize_generate_webfonts_options
+use util::resolve_codepoints;
+
 #[cfg(test)]
 mod tests {
-    use napi::Status;
-
     use super::{
         resolve_generate_webfonts_options, resolved_font_types, validate_font_type_order,
         validate_generate_webfonts_options, woff,
     };
-    use crate::{ttf::generate_ttf_font_bytes, FontType, GenerateWebfontsOptions};
+    use crate::{FontType, GenerateWebfontsOptions, ttf::generate_ttf_font_bytes};
 
     #[test]
     fn generates_woff2_font_with_expected_header() {
@@ -605,10 +719,11 @@ mod tests {
 
         let error = validate_font_type_order(&options, &resolved_font_types(&options)).unwrap_err();
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert_eq!(
-            error.reason.as_str(),
-            "Invalid font type order: 'woff' is not present in 'types'."
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid font type order: 'woff' is not present in 'types'.")
         );
     }
 
@@ -625,8 +740,8 @@ mod tests {
 
         let error = validate_generate_webfonts_options(&options).unwrap_err();
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert_eq!(error.reason.as_str(), "\"options.dest\" is empty.");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("\"options.dest\" is empty."));
     }
 
     #[test]
@@ -642,8 +757,8 @@ mod tests {
 
         let error = validate_generate_webfonts_options(&options).unwrap_err();
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert_eq!(error.reason.as_str(), "\"options.files\" is empty.");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("\"options.files\" is empty."));
     }
 
     #[test]
@@ -664,10 +779,11 @@ mod tests {
             .err()
             .expect("expected empty css template to fail");
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert_eq!(
-            error.reason.as_str(),
-            "\"options.cssTemplate\" must not be empty."
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("\"options.cssTemplate\" must not be empty.")
         );
     }
 
@@ -689,10 +805,11 @@ mod tests {
             .err()
             .expect("expected empty html template to fail");
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert_eq!(
-            error.reason.as_str(),
-            "\"options.htmlTemplate\" must not be empty."
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("\"options.htmlTemplate\" must not be empty.")
         );
     }
 
@@ -729,8 +846,8 @@ mod tests {
         })
         .unwrap_err();
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert!(error.reason.contains("cssTemplate"));
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("cssTemplate"));
     }
 
     #[test]
@@ -758,8 +875,8 @@ mod tests {
         })
         .unwrap_err();
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert!(error.reason.contains("htmlTemplate"));
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("htmlTemplate"));
     }
 
     #[test]

--- a/packages/webfont-generator/src/main.rs
+++ b/packages/webfont-generator/src/main.rs
@@ -1,0 +1,190 @@
+use std::path::Path;
+use std::process::ExitCode;
+
+use clap::{ArgAction, Parser, builder::styling};
+use webfont_generator::{FontType, GenerateWebfontsOptions};
+
+const STYLES: styling::Styles = styling::Styles::styled()
+    .header(styling::AnsiColor::Green.on_default().bold())
+    .usage(styling::AnsiColor::Green.on_default().bold())
+    .literal(styling::AnsiColor::Cyan.on_default().bold())
+    .placeholder(styling::AnsiColor::White.on_default());
+
+#[derive(Parser)]
+#[command(
+    name = "webfont-generator",
+    version,
+    styles = STYLES,
+    about = "Generate webfonts from SVG icons"
+)]
+struct Cli {
+    /// SVG files or directories containing SVG files
+    #[arg(required = true)]
+    files: Vec<String>,
+
+    /// Output directory
+    #[arg(short, long)]
+    dest: String,
+
+    /// Font name
+    #[arg(short = 'n', long, default_value = "iconfont")]
+    font_name: String,
+
+    /// Font types to generate
+    #[arg(short, long, value_delimiter = ',')]
+    types: Option<Vec<FontType>>,
+
+    /// Generate CSS (default)
+    #[arg(long, overrides_with = "no_css", action = ArgAction::SetTrue)]
+    css: bool,
+
+    /// Skip CSS generation
+    #[arg(long = "no-css", overrides_with = "css", action = ArgAction::SetTrue)]
+    no_css: bool,
+
+    /// Generate HTML preview
+    #[arg(long, overrides_with = "no_html", action = ArgAction::SetTrue)]
+    html: bool,
+
+    /// Skip HTML generation (default)
+    #[arg(long = "no-html", overrides_with = "html", action = ArgAction::SetTrue)]
+    no_html: bool,
+
+    /// Custom CSS template path
+    #[arg(long)]
+    css_template: Option<String>,
+
+    /// Custom HTML template path
+    #[arg(long)]
+    html_template: Option<String>,
+
+    /// CSS fonts URL prefix
+    #[arg(long)]
+    css_fonts_url: Option<String>,
+
+    /// Write output files to disk (default)
+    #[arg(long, overrides_with = "no_write", action = ArgAction::SetTrue)]
+    write: bool,
+
+    /// Do not write output files (dry run)
+    #[arg(long = "no-write", overrides_with = "write", action = ArgAction::SetTrue)]
+    no_write: bool,
+
+    /// Enable ligatures (default)
+    #[arg(long, overrides_with = "no_ligature", action = ArgAction::SetTrue)]
+    ligature: bool,
+
+    /// Disable ligatures
+    #[arg(long = "no-ligature", overrides_with = "ligature", action = ArgAction::SetTrue)]
+    no_ligature: bool,
+
+    /// Font height
+    #[arg(long)]
+    font_height: Option<f64>,
+
+    /// Ascent value
+    #[arg(long)]
+    ascent: Option<f64>,
+
+    /// Descent value
+    #[arg(long)]
+    descent: Option<f64>,
+
+    /// Start codepoint (hex, e.g. 0xF101)
+    #[arg(long)]
+    start_codepoint: Option<String>,
+}
+
+fn collect_svg_files(paths: &[String]) -> std::io::Result<Vec<String>> {
+    let mut result = Vec::new();
+    for path in paths {
+        let p = Path::new(path);
+        if p.is_dir() {
+            let mut dir_files: Vec<String> = std::fs::read_dir(p)?
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("svg"))
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect();
+            dir_files.sort();
+            result.extend(dir_files);
+        } else {
+            result.push(path.clone());
+        }
+    }
+    Ok(result)
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let files = match collect_svg_files(&cli.files) {
+        Ok(files) => files,
+        Err(error) => {
+            eprintln!("Error: failed to read input path: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if files.is_empty() {
+        eprintln!("Error: no SVG files found in the specified paths.");
+        return ExitCode::FAILURE;
+    }
+
+    let start_codepoint = cli.start_codepoint.and_then(|s| {
+        let s = s.trim();
+        if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+            u32::from_str_radix(hex, 16).ok()
+        } else {
+            s.parse::<u32>().ok()
+        }
+    });
+
+    // For --flag / --no-flag pairs: when neither is passed, both are false,
+    // so !no_flag = true (matching the library defaults). When one is passed,
+    // overrides_with ensures only the last one is active.
+    let options = GenerateWebfontsOptions {
+        ascent: cli.ascent,
+        css: Some(!cli.no_css),
+        css_template: cli.css_template,
+        css_fonts_url: cli.css_fonts_url,
+        descent: cli.descent,
+        dest: cli.dest,
+        files,
+        font_height: cli.font_height,
+        font_name: Some(cli.font_name),
+        html: Some(cli.html && !cli.no_html),
+        html_template: cli.html_template,
+        ligature: Some(!cli.no_ligature),
+        start_codepoint,
+        types: cli.types,
+        write_files: Some(!cli.no_write),
+        ..Default::default()
+    };
+
+    match webfont_generator::generate_sync(options, None) {
+        Ok(result) => {
+            let mut generated = Vec::new();
+            if result.svg_string().is_some() {
+                generated.push("SVG");
+            }
+            if result.ttf_bytes().is_some() {
+                generated.push("TTF");
+            }
+            if result.eot_bytes().is_some() {
+                generated.push("EOT");
+            }
+            if result.woff_bytes().is_some() {
+                generated.push("WOFF");
+            }
+            if result.woff2_bytes().is_some() {
+                generated.push("WOFF2");
+            }
+            println!("Generated: {}", generated.join(", "));
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("Error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/packages/webfont-generator/src/svg/mod.rs
+++ b/packages/webfont-generator/src/svg/mod.rs
@@ -88,7 +88,7 @@ pub(crate) fn prepare_svg_font(
     let mut glyphs = work_items
         .par_iter()
         .map(|item| parse_svg_glyph(item, preserve_aspect_ratio))
-        .collect::<napi::Result<Vec<_>>>()
+        .collect::<Result<Vec<_>, Error>>()
         .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
     glyphs.sort_by_key(|glyph| glyph.index);
 
@@ -143,7 +143,7 @@ pub(crate) fn prepare_svg_font(
                 optimize_output,
             )
         })
-        .collect::<napi::Result<Vec<_>>>()
+        .collect::<Result<Vec<_>, Error>>()
         .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
     processed_glyphs.sort_by_key(|glyph| glyph.index);
 

--- a/packages/webfont-generator/src/svg/parse.rs
+++ b/packages/webfont-generator/src/svg/parse.rs
@@ -1,6 +1,6 @@
-use napi::{bindgen_prelude::Error, Status};
-use usvg::tiny_skia_path::Path as TinyPath;
+use std::io::{Error, ErrorKind};
 use usvg::Transform;
+use usvg::tiny_skia_path::Path as TinyPath;
 
 use crate::svg::types::{GlyphWorkItem, ParsedGlyph};
 
@@ -17,13 +17,13 @@ struct RootSvgMetrics {
 pub(crate) fn parse_svg_glyph(
     item: &GlyphWorkItem,
     preserve_aspect_ratio: bool,
-) -> napi::Result<ParsedGlyph> {
+) -> Result<ParsedGlyph, Error> {
     let svg = item.source_file.contents.as_bytes();
     let root_metrics = parse_root_svg_metrics(svg)?;
     let options = usvg::Options::default();
     let tree = usvg::Tree::from_data(svg, &options).map_err(|error| {
         Error::new(
-            Status::InvalidArg,
+            ErrorKind::InvalidInput,
             format!(
                 "Failed to parse SVG fixture '{}': {error}",
                 item.source_file.path
@@ -53,7 +53,7 @@ fn collect_paths(
     group: &usvg::Group,
     root_correction: Option<Transform>,
     paths: &mut Vec<TinyPath>,
-) -> napi::Result<()> {
+) -> Result<(), Error> {
     for node in group.children() {
         match node {
             usvg::Node::Group(child_group) => collect_paths(child_group, root_correction, paths)?,
@@ -93,17 +93,11 @@ fn collect_paths(
                 };
 
                 let transformed = path_data.transform(path.abs_transform()).ok_or_else(|| {
-                    Error::new(
-                        Status::GenericFailure,
-                        "Failed to apply an absolute transform to a glyph path.",
-                    )
+                    Error::other("Failed to apply an absolute transform to a glyph path.")
                 })?;
                 let transformed = if let Some(root_correction) = root_correction {
                     transformed.transform(root_correction).ok_or_else(|| {
-                        Error::new(
-                            Status::GenericFailure,
-                            "Failed to apply a root viewBox correction to a glyph path.",
-                        )
+                        Error::other("Failed to apply a root viewBox correction to a glyph path.")
                     })?
                 } else {
                     transformed
@@ -117,10 +111,10 @@ fn collect_paths(
     Ok(())
 }
 
-fn parse_root_svg_metrics(svg: &[u8]) -> napi::Result<Option<RootSvgMetrics>> {
+fn parse_root_svg_metrics(svg: &[u8]) -> Result<Option<RootSvgMetrics>, Error> {
     let svg_text = std::str::from_utf8(svg).map_err(|error| {
         Error::new(
-            Status::InvalidArg,
+            ErrorKind::InvalidInput,
             format!("Failed to decode SVG fixture as UTF-8: {error}"),
         )
     })?;
@@ -133,7 +127,7 @@ fn parse_root_svg_metrics(svg: &[u8]) -> napi::Result<Option<RootSvgMetrics>> {
     )
     .map_err(|error| {
         Error::new(
-            Status::InvalidArg,
+            ErrorKind::InvalidInput,
             format!("Failed to inspect SVG root element: {error}"),
         )
     })?;
@@ -147,7 +141,7 @@ fn parse_root_svg_metrics(svg: &[u8]) -> napi::Result<Option<RootSvgMetrics>> {
     };
     let values = parse_view_box(view_box).ok_or_else(|| {
         Error::new(
-            Status::InvalidArg,
+            ErrorKind::InvalidInput,
             "Failed to parse the SVG viewBox for native generation.",
         )
     })?;
@@ -178,7 +172,7 @@ fn parse_root_svg_metrics(svg: &[u8]) -> napi::Result<Option<RootSvgMetrics>> {
 fn build_root_viewbox_correction(
     metrics: &RootSvgMetrics,
     preserve_aspect_ratio: bool,
-) -> napi::Result<Option<Transform>> {
+) -> Result<Option<Transform>, Error> {
     let current = root_viewbox_transform(metrics, metrics.current_preserve_aspect_ratio);
     let desired = root_viewbox_transform(metrics, preserve_aspect_ratio);
 
@@ -186,12 +180,9 @@ fn build_root_viewbox_correction(
         return Ok(None);
     }
 
-    let inverse_current = current.invert().ok_or_else(|| {
-        Error::new(
-            Status::GenericFailure,
-            "Failed to invert the current root viewBox transform.",
-        )
-    })?;
+    let inverse_current = current
+        .invert()
+        .ok_or_else(|| Error::other("Failed to invert the current root viewBox transform."))?;
 
     Ok(Some(concat_transforms(desired, inverse_current)))
 }

--- a/packages/webfont-generator/src/svg/process.rs
+++ b/packages/webfont-generator/src/svg/process.rs
@@ -1,4 +1,4 @@
-use napi::{bindgen_prelude::Error, Status};
+use std::io::Error;
 use usvg::tiny_skia_path::Rect;
 
 use crate::svg::serialize::{append_path, optimize_path_data};
@@ -18,14 +18,10 @@ pub(crate) fn process_glyph(
     font_width: f64,
     descent: f64,
     optimize_output: bool,
-) -> napi::Result<ProcessedGlyph> {
+) -> Result<ProcessedGlyph, Error> {
     let ratio = if normalize {
         let base = glyph.width.max(glyph.height);
-        if base > 0.0 {
-            font_height / base
-        } else {
-            1.0
-        }
+        if base > 0.0 { font_height / base } else { 1.0 }
     } else if max_glyph_height > 0.0 {
         font_height / max_glyph_height
     } else {
@@ -45,12 +41,9 @@ pub(crate) fn process_glyph(
 
     let mut transformed_paths = Vec::with_capacity(glyph.paths.len());
     for path in glyph.paths {
-        let transformed = path.transform(glyph_path_transform).ok_or_else(|| {
-            Error::new(
-                Status::GenericFailure,
-                format!("Failed to transform glyph '{}'.", glyph.name),
-            )
-        })?;
+        let transformed = path
+            .transform(glyph_path_transform)
+            .ok_or_else(|| Error::other(format!("Failed to transform glyph '{}'.", glyph.name)))?;
         transformed_paths.push(transformed);
     }
     if fixed_width {
@@ -74,13 +67,10 @@ pub(crate) fn process_glyph(
                 .into_iter()
                 .map(|path| {
                     path.transform(translate).ok_or_else(|| {
-                        Error::new(
-                            Status::GenericFailure,
-                            format!("Failed to center glyph '{}'.", glyph.name),
-                        )
+                        Error::other(format!("Failed to center glyph '{}'.", glyph.name))
                     })
                 })
-                .collect::<napi::Result<Vec<_>>>()?;
+                .collect::<Result<Vec<_>, Error>>()?;
         }
     }
     let mut path_data = String::new();

--- a/packages/webfont-generator/src/svg/serialize.rs
+++ b/packages/webfont-generator/src/svg/serialize.rs
@@ -57,13 +57,17 @@ pub(crate) fn build_svg_font(options: &SvgOptions, prepared: &PreparedSvgFont) -
                 _ = write!(
                     svg_font,
                     "    <glyph glyph-name=\"{}\"\n      unicode=\"{unicode}\"\n      horiz-adv-x=\"{}\" d=\"{}\" />\n",
-                    escape_xml(&glyph.name), glyph.width, escape_xml(&glyph.path_data),
+                    escape_xml(&glyph.name),
+                    glyph.width,
+                    escape_xml(&glyph.path_data),
                 );
             } else {
                 _ = write!(
                     svg_font,
                     "    <glyph glyph-name=\"{}-{index}\"\n      unicode=\"{unicode}\"\n      horiz-adv-x=\"{}\" d=\"{}\" />\n",
-                    escape_xml(&glyph.name), glyph.width, escape_xml(&glyph.path_data),
+                    escape_xml(&glyph.name),
+                    glyph.width,
+                    escape_xml(&glyph.path_data),
                 );
             }
         }
@@ -136,7 +140,7 @@ fn round_to_string(value: f64, round: f64) -> String {
 }
 
 pub(crate) fn optimize_path_data(path_data: &str) -> String {
-    use oxvg_path::{convert::run as optimize_path, parser::Parse as _, Path};
+    use oxvg_path::{Path, convert::run as optimize_path, parser::Parse as _};
 
     let mut path = match Path::parse_string(path_data) {
         Ok(p) => p,

--- a/packages/webfont-generator/src/svg/tests.rs
+++ b/packages/webfont-generator/src/svg/tests.rs
@@ -3,11 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::{build_svg_font, prepare_svg_font, svg_options_from_options};
-use napi::sys::{napi_env, napi_ref, napi_status};
 
 use crate::{
-    finalize_generate_webfonts_options, resolve_generate_webfonts_options, FormatOptions,
-    GenerateWebfontsOptions, LoadedSvgFile, SvgFormatOptions,
+    FormatOptions, GenerateWebfontsOptions, LoadedSvgFile, SvgFormatOptions,
+    finalize_generate_webfonts_options, resolve_generate_webfonts_options,
 };
 
 #[derive(Clone, Copy)]
@@ -25,11 +24,16 @@ struct SvgParityCase {
     preserve_aspect_ratio: bool,
 }
 
+#[cfg(feature = "napi")]
+use napi::sys::{napi_env, napi_ref, napi_status};
+
+#[cfg(feature = "napi")]
 #[unsafe(no_mangle)]
 extern "C" fn napi_delete_reference(_: napi_env, _: napi_ref) -> napi_status {
     0
 }
 
+#[cfg(feature = "napi")]
 #[unsafe(no_mangle)]
 extern "C" fn napi_reference_unref(_: napi_env, _: napi_ref, result: *mut u32) -> napi_status {
     if !result.is_null() {
@@ -482,10 +486,12 @@ fn empty_svg_produces_glyph_with_empty_path_data() {
     let svg = generate_svg_font(GenerateWebfontsOptions {
         css: Some(false),
         dest: "artifacts".to_owned(),
-        files: vec![icons_root()
-            .join("emptyicons/empty.svg")
-            .to_string_lossy()
-            .into_owned()],
+        files: vec![
+            icons_root()
+                .join("emptyicons/empty.svg")
+                .to_string_lossy()
+                .into_owned(),
+        ],
         html: Some(false),
         font_name: Some("iconfont".to_owned()),
         ligature: Some(false),

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -5,7 +5,6 @@ use std::io::Error;
 
 use handlebars::Handlebars;
 use md5::Context;
-use napi::threadsafe_function::ThreadsafeFunction;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -130,7 +129,8 @@ fn make_ctx(
     ctx
 }
 
-pub(crate) type ContextFunction = ThreadsafeFunction<
+#[cfg(feature = "napi")]
+pub(crate) type ContextFunction = napi::threadsafe_function::ThreadsafeFunction<
     Map<String, Value>,
     Map<String, Value>,
     Map<String, Value>,
@@ -138,6 +138,7 @@ pub(crate) type ContextFunction = ThreadsafeFunction<
     false,
 >;
 
+#[cfg(feature = "napi")]
 pub(crate) async fn apply_context_function(
     ctx: Map<String, Value>,
     context_fn: Option<&ContextFunction>,
@@ -230,9 +231,15 @@ fn render_default_css_inner(ctx: &Map<String, Value>, font_name: &str, src: &str
     let codepoint_count = codepoints.map_or(0, |c| c.len());
     let mut result = String::with_capacity(256 + codepoint_count * 60);
 
-    _ = write!(result, "@font-face {{\n\tfont-family: \"{font_name}\";\n\tfont-display: block;\n\tsrc: {src};\n}}\n\n");
+    _ = write!(
+        result,
+        "@font-face {{\n\tfont-family: \"{font_name}\";\n\tfont-display: block;\n\tsrc: {src};\n}}\n\n"
+    );
     _ = write!(result, "{base_selector} {{\n\tline-height: 1;\n}}\n\n");
-    _ = write!(result, "{base_selector}:before {{\n\tfont-family: {font_name} !important;\n\tfont-style: normal;\n\tfont-weight: normal !important;\n\tvertical-align: top;\n}}\n\n");
+    _ = write!(
+        result,
+        "{base_selector}:before {{\n\tfont-family: {font_name} !important;\n\tfont-style: normal;\n\tfont-weight: normal !important;\n\tvertical-align: top;\n}}\n\n"
+    );
 
     if let Some(codepoints) = codepoints {
         for (name, value) in codepoints {
@@ -571,8 +578,8 @@ impl<'a> From<&'a crate::types::WoffFormatOptions> for HashableWoffFormatOptions
 #[cfg(test)]
 mod tests {
     use super::{
-        build_css_context, calc_hash, make_ctx, make_src, make_urls, render_css_with_context,
-        template_contains_exact_mustache_name, SharedTemplateData,
+        SharedTemplateData, build_css_context, calc_hash, make_ctx, make_src, make_urls,
+        render_css_with_context, template_contains_exact_mustache_name,
     };
     use crate::{
         FontType, FormatOptions, GenerateWebfontsOptions, LoadedSvgFile,
@@ -1085,7 +1092,10 @@ mod tests {
 
     #[test]
     fn render_css_with_hbs_context_matches_direct_render_for_custom_template() {
-        let template_path = write_temp_template("native-css-hbs-ctx", "@font-face { src: {{{src}}}; } {{#each codepoints}}.{{@key}}:before { content: \"\\\\{{this}}\"; }{{/each}}");
+        let template_path = write_temp_template(
+            "native-css-hbs-ctx",
+            "@font-face { src: {{{src}}}; } {{#each codepoints}}.{{@key}}:before { content: \"\\\\{{this}}\"; }{{/each}}",
+        );
         let options = resolve_options(GenerateWebfontsOptions {
             css: Some(true),
             css_template: Some(template_path),

--- a/packages/webfont-generator/src/templates/html.rs
+++ b/packages/webfont-generator/src/templates/html.rs
@@ -4,7 +4,7 @@ use std::io::Error;
 use std::path::Path;
 
 use crate::templates::css::{
-    build_css_context_with_fonts_url, render_css_with_context, SharedTemplateData,
+    SharedTemplateData, build_css_context_with_fonts_url, render_css_with_context,
 };
 use crate::types::{LoadedSvgFile, ResolvedGenerateWebfontsOptions};
 use crate::util::to_io_err;
@@ -101,7 +101,10 @@ fn render_default_html_inner(ctx: &Map<String, Value>, styles: &str) -> String {
     let name_count = names.map_or(0, |n| n.len());
     let mut result = String::with_capacity(512 + name_count * 120);
 
-    _ = write!(result, "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n\t<meta charset=\"UTF-8\">\n\t<title>{font_name}</title>\n\t<style>\n");
+    _ = write!(
+        result,
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n\t<meta charset=\"UTF-8\">\n\t<title>{font_name}</title>\n\t<style>\n"
+    );
     result.push_str("\t\tbody {\n\t\t\tfont-family: sans-serif;\n\t\t\tmargin: 0;\n\t\t\tpadding: 10px 20px;\n\t\t}\n\n");
     result.push_str("\t\t.preview {\n\t\t\tline-height: 2em;\n\t\t}\n\n");
     result.push_str("\t\t.preview__icon {\n\t\t\tdisplay: inline-block;\n\t\t\twidth: 32px;\n\t\t\ttext-align: center;\n\t\t}\n\n");
@@ -116,7 +119,10 @@ fn render_default_html_inner(ctx: &Map<String, Value>, styles: &str) -> String {
     if let Some(names) = names {
         for name_value in names {
             let name = name_value.as_str().unwrap_or("");
-            _ = write!(result, "\t<div class=\"preview\">\n\t\t<span class=\"preview__icon\">\n\t\t\t<span class=\"{base_class} {class_prefix}{name}\"></span>\n\t\t</span>\n\t\t<span>{name}</span>\n\t</div>\n");
+            _ = write!(
+                result,
+                "\t<div class=\"preview\">\n\t\t<span class=\"preview__icon\">\n\t\t\t<span class=\"{base_class} {class_prefix}{name}\"></span>\n\t\t</span>\n\t\t<span>{name}</span>\n\t</div>\n"
+            );
         }
     }
 

--- a/packages/webfont-generator/src/templates/mod.rs
+++ b/packages/webfont-generator/src/templates/mod.rs
@@ -9,9 +9,11 @@ pub(super) fn ctx_str<'a>(ctx: &'a Map<String, Value>, key: &str, default: &'a s
     ctx.get(key).and_then(|v| v.as_str()).unwrap_or(default)
 }
 
+#[cfg(feature = "napi")]
+pub(crate) use css::apply_context_function;
 pub(crate) use css::{
-    apply_context_function, build_css_context, make_src, render_css_with_hbs_context,
-    render_css_with_src_mutate, SharedTemplateData,
+    SharedTemplateData, build_css_context, make_src, render_css_with_hbs_context,
+    render_css_with_src_mutate,
 };
 pub(crate) use html::{
     build_html_context, build_html_registry, render_default_html_with_styles,

--- a/packages/webfont-generator/src/test_helpers.rs
+++ b/packages/webfont-generator/src/test_helpers.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::types::{LoadedSvgFile, ResolvedGenerateWebfontsOptions};
-use crate::{resolve_generate_webfonts_options, GenerateWebfontsOptions};
+use crate::{GenerateWebfontsOptions, resolve_generate_webfonts_options};
 
 pub fn resolve_options(options: GenerateWebfontsOptions) -> ResolvedGenerateWebfontsOptions {
     resolve_generate_webfonts_options(options)

--- a/packages/webfont-generator/src/ttf/mod.rs
+++ b/packages/webfont-generator/src/ttf/mod.rs
@@ -4,10 +4,11 @@ use std::io::{Error, ErrorKind};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use kurbo::{BezPath, CubicBez, PathEl};
+use write_fonts::FontBuilder;
 use write_fonts::tables::cmap::Cmap;
 use write_fonts::tables::glyf::{GlyfLocaBuilder, Glyph, SimpleGlyph};
 use write_fonts::tables::gsub::{
-    builders::LigatureSubBuilder, Gsub, SubstitutionLookup, SubstitutionLookupList,
+    Gsub, SubstitutionLookup, SubstitutionLookupList, builders::LigatureSubBuilder,
 };
 use write_fonts::tables::head::Head;
 use write_fonts::tables::hhea::Hhea;
@@ -22,16 +23,15 @@ use write_fonts::tables::os2::Os2;
 use write_fonts::tables::post::Post;
 use write_fonts::tables::variations::ivs_builder::VariationStoreBuilder;
 use write_fonts::types::{FWord, Fixed, GlyphId, GlyphId16, LongDateTime, NameId, Tag, UfWord};
-use write_fonts::FontBuilder;
 
+#[cfg(test)]
+use crate::GenerateWebfontsOptions;
 use crate::svg::types::ProcessedGlyph;
 #[cfg(test)]
 use crate::svg::{prepare_svg_font, svg_options_from_options};
 #[cfg(test)]
 use crate::types::LoadedSvgFile;
 use crate::types::ResolvedGenerateWebfontsOptions;
-#[cfg(test)]
-use crate::GenerateWebfontsOptions;
 #[cfg(test)]
 use crate::{finalize_generate_webfonts_options, resolve_generate_webfonts_options};
 

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -2,18 +2,21 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::{Mutex, OnceLock};
 
+#[cfg(feature = "napi")]
 use napi::bindgen_prelude::Uint8Array;
+#[cfg(feature = "napi")]
 use napi_derive::napi;
 use serde_json::{Map, Value};
 
 use crate::templates::{
-    build_css_context, build_html_context, build_html_registry, make_src,
+    SharedTemplateData, build_css_context, build_html_context, build_html_registry, make_src,
     render_css_with_hbs_context, render_css_with_src_mutate, render_default_html_with_styles,
-    render_html_with_hbs_context, SharedTemplateData,
+    render_html_with_hbs_context,
 };
-use crate::util::to_napi_err;
+use crate::util::to_io_err;
 
-#[napi(string_enum = "lowercase")]
+#[cfg_attr(feature = "napi", napi(string_enum = "lowercase"))]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FontType {
     Svg,
@@ -49,7 +52,7 @@ impl FontType {
     }
 }
 
-#[napi(object)]
+#[cfg_attr(feature = "napi", napi(object))]
 #[derive(Clone, Default)]
 pub struct SvgFormatOptions {
     pub center_vertically: Option<bool>,
@@ -59,7 +62,7 @@ pub struct SvgFormatOptions {
     pub preserve_aspect_ratio: Option<bool>,
 }
 
-#[napi(object)]
+#[cfg_attr(feature = "napi", napi(object))]
 #[derive(Clone)]
 pub struct TtfFormatOptions {
     pub copyright: Option<String>,
@@ -69,13 +72,13 @@ pub struct TtfFormatOptions {
     pub version: Option<String>,
 }
 
-#[napi(object)]
+#[cfg_attr(feature = "napi", napi(object))]
 #[derive(Clone)]
 pub struct WoffFormatOptions {
     pub metadata: Option<String>,
 }
 
-#[napi(object)]
+#[cfg_attr(feature = "napi", napi(object))]
 #[derive(Clone, Default)]
 pub struct FormatOptions {
     pub svg: Option<SvgFormatOptions>,
@@ -83,7 +86,7 @@ pub struct FormatOptions {
     pub woff: Option<WoffFormatOptions>,
 }
 
-#[napi(object)]
+#[cfg_attr(feature = "napi", napi(object))]
 #[derive(Clone, Default)]
 pub struct GenerateWebfontsOptions {
     pub ascent: Option<f64>,
@@ -200,7 +203,7 @@ pub(crate) struct CachedTemplateData {
     pub(crate) render_cache: Mutex<RenderCache>,
 }
 
-#[napi]
+#[cfg_attr(feature = "napi", napi)]
 pub struct GenerateWebfontsResult {
     pub(crate) css_context: Option<Map<String, Value>>,
     pub(crate) eot_font: Option<Arc<Vec<u8>>>,
@@ -214,6 +217,193 @@ pub struct GenerateWebfontsResult {
     pub(crate) cached: OnceLock<Result<CachedTemplateData, String>>,
 }
 
+// Pure Rust getters (always available)
+impl GenerateWebfontsResult {
+    /// Returns the EOT font bytes, if generated.
+    pub fn eot_bytes(&self) -> Option<&[u8]> {
+        self.eot_font.as_ref().map(|v| v.as_ref().as_slice())
+    }
+
+    /// Returns the SVG font string, if generated.
+    pub fn svg_string(&self) -> Option<&str> {
+        self.svg_font.as_ref().map(|v| v.as_ref().as_str())
+    }
+
+    /// Returns the TTF font bytes, if generated.
+    pub fn ttf_bytes(&self) -> Option<&[u8]> {
+        self.ttf_font.as_ref().map(|v| v.as_ref().as_slice())
+    }
+
+    /// Returns the WOFF font bytes, if generated.
+    pub fn woff_bytes(&self) -> Option<&[u8]> {
+        self.woff_font.as_ref().map(|v| v.as_ref().as_slice())
+    }
+
+    /// Returns the WOFF2 font bytes, if generated.
+    pub fn woff2_bytes(&self) -> Option<&[u8]> {
+        self.woff2_font.as_ref().map(|v| v.as_ref().as_slice())
+    }
+
+    pub(crate) fn get_cached_io(&self) -> std::io::Result<&CachedTemplateData> {
+        self.cached
+            .get_or_init(|| {
+                let shared = SharedTemplateData::new(&self.options, &self.source_files)
+                    .map_err(|e| e.to_string())?;
+                let css_context = match &self.css_context {
+                    Some(ctx) => ctx.clone(),
+                    None => build_css_context(&self.options, &shared),
+                };
+                let html_context = match &self.html_context {
+                    Some(ctx) => ctx.clone(),
+                    None => build_html_context(&self.options, &shared, &self.source_files, None)
+                        .map_err(|e| e.to_string())?,
+                };
+                let html_registry =
+                    build_html_registry(&self.options).map_err(|e| e.to_string())?;
+                let css_hbs_context =
+                    handlebars::Context::wraps(&css_context).map_err(|e| e.to_string())?;
+                let html_hbs_context =
+                    handlebars::Context::wraps(&html_context).map_err(|e| e.to_string())?;
+                Ok(CachedTemplateData {
+                    shared,
+                    css_context,
+                    css_hbs_context: Mutex::new(css_hbs_context),
+                    html_context,
+                    html_hbs_context: Mutex::new(html_hbs_context),
+                    html_registry,
+                    render_cache: Mutex::new(RenderCache::default()),
+                })
+            })
+            .as_ref()
+            .map_err(to_io_err)
+    }
+
+    /// Generate a CSS string for this webfont result.
+    ///
+    /// Pass `urls` to override the default font URLs in the CSS output.
+    pub fn generate_css_pure(
+        &self,
+        urls: Option<HashMap<FontType, String>>,
+    ) -> std::io::Result<String> {
+        let cached = self.get_cached_io()?;
+        let mut rc = cached.render_cache.lock().unwrap();
+
+        match &urls {
+            None => {
+                if let Some(result) = &rc.css_no_urls {
+                    return Ok(result.clone());
+                }
+                let ctx = cached.css_hbs_context.lock().unwrap();
+                let result =
+                    render_css_with_hbs_context(&cached.shared, &ctx, &cached.css_context)?;
+                rc.css_no_urls = Some(result.clone());
+                Ok(result)
+            }
+            Some(urls) => {
+                // If the template doesn't reference {{src}}, URLs don't affect output
+                if !cached.shared.css_template_uses_src {
+                    drop(rc);
+                    return self.generate_css_pure(None);
+                }
+                if rc.css_last_urls.as_ref() == Some(urls)
+                    && let Some(result) = &rc.css_last_result
+                {
+                    return Ok(result.clone());
+                }
+                let src = make_src(&self.options, urls);
+                let mut ctx = cached.css_hbs_context.lock().unwrap();
+                let result = render_css_with_src_mutate(
+                    &cached.shared,
+                    &mut ctx,
+                    &cached.css_context,
+                    &src,
+                )?;
+                rc.css_last_urls = Some(urls.clone());
+                rc.css_last_result = Some(result.clone());
+                Ok(result)
+            }
+        }
+    }
+
+    /// Generate an HTML string for this webfont result.
+    ///
+    /// Pass `urls` to override the default font URLs in the HTML output.
+    pub fn generate_html_pure(
+        &self,
+        urls: Option<HashMap<FontType, String>>,
+    ) -> std::io::Result<String> {
+        let cached = self.get_cached_io()?;
+        let mut rc = cached.render_cache.lock().unwrap();
+
+        match &urls {
+            None => {
+                if let Some(result) = &rc.html_no_urls {
+                    return Ok(result.clone());
+                }
+                let ctx = cached.html_hbs_context.lock().unwrap();
+                let result = render_html_with_hbs_context(
+                    cached.html_registry.as_ref(),
+                    &ctx,
+                    &cached.html_context,
+                )?;
+                rc.html_no_urls = Some(result.clone());
+                Ok(result)
+            }
+            Some(urls) => {
+                // If the CSS template doesn't reference {{src}}, URLs don't affect output
+                if !cached.shared.css_template_uses_src {
+                    drop(rc);
+                    return self.generate_html_pure(None);
+                }
+                if rc.html_last_urls.as_ref() == Some(urls)
+                    && let Some(result) = &rc.html_last_result
+                {
+                    return Ok(result.clone());
+                }
+                // Render CSS with the custom URLs (in-place src mutate, no clone)
+                let src = make_src(&self.options, urls);
+                let styles = {
+                    let mut css_ctx = cached.css_hbs_context.lock().unwrap();
+                    render_css_with_src_mutate(
+                        &cached.shared,
+                        &mut css_ctx,
+                        &cached.css_context,
+                        &src,
+                    )?
+                };
+                // Hot path: default HTML template -- inject styles directly, skip clone
+                if self.options.html_template.is_none() {
+                    let result = render_default_html_with_styles(&cached.html_context, &styles);
+                    rc.html_last_urls = Some(urls.clone());
+                    rc.html_last_result = Some(result.clone());
+                    return Ok(result);
+                }
+                // Custom HTML template: in-place styles mutate, no clone
+                let mut html_ctx = cached.html_hbs_context.lock().unwrap();
+                let registry = cached
+                    .html_registry
+                    .as_ref()
+                    .expect("HTML registry should exist for custom template");
+                let result = crate::util::render_with_field_swap(
+                    &mut html_ctx,
+                    "styles",
+                    serde_json::Value::String(styles),
+                    |ctx| {
+                        registry
+                            .render_with_context("html", ctx)
+                            .map_err(crate::util::to_io_err)
+                    },
+                )?;
+                rc.html_last_urls = Some(urls.clone());
+                rc.html_last_result = Some(result.clone());
+                Ok(result)
+            }
+        }
+    }
+}
+
+// NAPI getters and methods
+#[cfg(feature = "napi")]
 #[napi]
 impl GenerateWebfontsResult {
     #[napi(getter)]
@@ -249,156 +439,22 @@ impl GenerateWebfontsResult {
             .map(|v| Uint8Array::from(v.as_ref().clone()))
     }
 
-    pub(crate) fn get_cached(&self) -> napi::Result<&CachedTemplateData> {
-        self.cached
-            .get_or_init(|| {
-                let shared = SharedTemplateData::new(&self.options, &self.source_files)
-                    .map_err(|e| e.to_string())?;
-                let css_context = match &self.css_context {
-                    Some(ctx) => ctx.clone(),
-                    None => build_css_context(&self.options, &shared),
-                };
-                let html_context = match &self.html_context {
-                    Some(ctx) => ctx.clone(),
-                    None => build_html_context(&self.options, &shared, &self.source_files, None)
-                        .map_err(|e| e.to_string())?,
-                };
-                let html_registry =
-                    build_html_registry(&self.options).map_err(|e| e.to_string())?;
-                let css_hbs_context =
-                    handlebars::Context::wraps(&css_context).map_err(|e| e.to_string())?;
-                let html_hbs_context =
-                    handlebars::Context::wraps(&html_context).map_err(|e| e.to_string())?;
-                Ok(CachedTemplateData {
-                    shared,
-                    css_context,
-                    css_hbs_context: Mutex::new(css_hbs_context),
-                    html_context,
-                    html_hbs_context: Mutex::new(html_hbs_context),
-                    html_registry,
-                    render_cache: Mutex::new(RenderCache::default()),
-                })
-            })
-            .as_ref()
-            .map_err(to_napi_err)
-    }
-
     #[napi(ts_args_type = "urls?: Partial<Record<FontType, string>>")]
     pub fn generate_css(&self, urls: Option<HashMap<String, String>>) -> napi::Result<String> {
         let urls = urls.map(parse_native_urls).transpose()?;
-        let cached = self.get_cached()?;
-        let mut rc = cached.render_cache.lock().unwrap();
-
-        match &urls {
-            None => {
-                if let Some(result) = &rc.css_no_urls {
-                    return Ok(result.clone());
-                }
-                let ctx = cached.css_hbs_context.lock().unwrap();
-                let result = render_css_with_hbs_context(&cached.shared, &ctx, &cached.css_context)
-                    .map_err(to_napi_err)?;
-                rc.css_no_urls = Some(result.clone());
-                Ok(result)
-            }
-            Some(urls) => {
-                // If the template doesn't reference {{src}}, URLs don't affect output
-                if !cached.shared.css_template_uses_src {
-                    drop(rc);
-                    return self.generate_css(None);
-                }
-                if rc.css_last_urls.as_ref() == Some(urls) {
-                    if let Some(result) = &rc.css_last_result {
-                        return Ok(result.clone());
-                    }
-                }
-                let src = make_src(&self.options, urls);
-                let mut ctx = cached.css_hbs_context.lock().unwrap();
-                let result =
-                    render_css_with_src_mutate(&cached.shared, &mut ctx, &cached.css_context, &src)
-                        .map_err(to_napi_err)?;
-                rc.css_last_urls = Some(urls.clone());
-                rc.css_last_result = Some(result.clone());
-                Ok(result)
-            }
-        }
+        self.generate_css_pure(urls)
+            .map_err(crate::util::to_napi_err)
     }
 
     #[napi(ts_args_type = "urls?: Partial<Record<FontType, string>>")]
     pub fn generate_html(&self, urls: Option<HashMap<String, String>>) -> napi::Result<String> {
         let urls = urls.map(parse_native_urls).transpose()?;
-        let cached = self.get_cached()?;
-        let mut rc = cached.render_cache.lock().unwrap();
-
-        match &urls {
-            None => {
-                if let Some(result) = &rc.html_no_urls {
-                    return Ok(result.clone());
-                }
-                let ctx = cached.html_hbs_context.lock().unwrap();
-                let result = render_html_with_hbs_context(
-                    cached.html_registry.as_ref(),
-                    &ctx,
-                    &cached.html_context,
-                )
-                .map_err(to_napi_err)?;
-                rc.html_no_urls = Some(result.clone());
-                Ok(result)
-            }
-            Some(urls) => {
-                // If the CSS template doesn't reference {{src}}, URLs don't affect output
-                if !cached.shared.css_template_uses_src {
-                    drop(rc);
-                    return self.generate_html(None);
-                }
-                if rc.html_last_urls.as_ref() == Some(urls) {
-                    if let Some(result) = &rc.html_last_result {
-                        return Ok(result.clone());
-                    }
-                }
-                // Render CSS with the custom URLs (in-place src mutate, no clone)
-                let src = make_src(&self.options, urls);
-                let styles = {
-                    let mut css_ctx = cached.css_hbs_context.lock().unwrap();
-                    render_css_with_src_mutate(
-                        &cached.shared,
-                        &mut css_ctx,
-                        &cached.css_context,
-                        &src,
-                    )
-                    .map_err(to_napi_err)?
-                };
-                // Hot path: default HTML template — inject styles directly, skip clone
-                if self.options.html_template.is_none() {
-                    let result = render_default_html_with_styles(&cached.html_context, &styles);
-                    rc.html_last_urls = Some(urls.clone());
-                    rc.html_last_result = Some(result.clone());
-                    return Ok(result);
-                }
-                // Custom HTML template: in-place styles mutate, no clone
-                let mut html_ctx = cached.html_hbs_context.lock().unwrap();
-                let registry = cached
-                    .html_registry
-                    .as_ref()
-                    .expect("HTML registry should exist for custom template");
-                let result = crate::util::render_with_field_swap(
-                    &mut html_ctx,
-                    "styles",
-                    serde_json::Value::String(styles),
-                    |ctx| {
-                        registry
-                            .render_with_context("html", ctx)
-                            .map_err(crate::util::to_io_err)
-                    },
-                )
-                .map_err(to_napi_err)?;
-                rc.html_last_urls = Some(urls.clone());
-                rc.html_last_result = Some(result.clone());
-                Ok(result)
-            }
-        }
+        self.generate_html_pure(urls)
+            .map_err(crate::util::to_napi_err)
     }
 }
 
+#[cfg(feature = "napi")]
 fn parse_native_urls(urls: HashMap<String, String>) -> napi::Result<HashMap<FontType, String>> {
     urls.into_iter()
         .filter_map(|(font_type, url)| {
@@ -489,7 +545,7 @@ mod tests {
         };
 
         if let Some(dir) = cleanup_dir {
-            // Don't clean up yet — template file needed for lazy compilation
+            // Don't clean up yet -- template file needed for lazy compilation
             std::mem::forget(dir);
         }
 
@@ -500,8 +556,8 @@ mod tests {
     fn generate_css_returns_cached_result_on_repeated_calls_without_urls() {
         let result = build_result(None);
 
-        let first = result.generate_css(None).unwrap();
-        let second = result.generate_css(None).unwrap();
+        let first = result.generate_css_pure(None).unwrap();
+        let second = result.generate_css_pure(None).unwrap();
 
         assert_eq!(first, second);
         assert!(!first.is_empty());
@@ -510,10 +566,10 @@ mod tests {
     #[test]
     fn generate_css_returns_cached_result_on_repeated_calls_with_same_urls() {
         let result = build_result(None);
-        let urls = HashMap::from([("svg".to_owned(), "/a.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/a.svg".to_owned())]);
 
-        let first = result.generate_css(Some(urls.clone())).unwrap();
-        let second = result.generate_css(Some(urls)).unwrap();
+        let first = result.generate_css_pure(Some(urls.clone())).unwrap();
+        let second = result.generate_css_pure(Some(urls)).unwrap();
 
         assert_eq!(first, second);
         assert!(first.contains("/a.svg"));
@@ -522,11 +578,11 @@ mod tests {
     #[test]
     fn generate_css_returns_different_result_for_different_urls() {
         let result = build_result(None);
-        let urls_a = HashMap::from([("svg".to_owned(), "/a.svg".to_owned())]);
-        let urls_b = HashMap::from([("svg".to_owned(), "/b.svg".to_owned())]);
+        let urls_a = HashMap::from([(FontType::Svg, "/a.svg".to_owned())]);
+        let urls_b = HashMap::from([(FontType::Svg, "/b.svg".to_owned())]);
 
-        let result_a = result.generate_css(Some(urls_a)).unwrap();
-        let result_b = result.generate_css(Some(urls_b)).unwrap();
+        let result_a = result.generate_css_pure(Some(urls_a)).unwrap();
+        let result_b = result.generate_css_pure(Some(urls_b)).unwrap();
 
         assert_ne!(result_a, result_b);
         assert!(result_a.contains("/a.svg"));
@@ -536,12 +592,12 @@ mod tests {
     #[test]
     fn generate_css_cache_updates_when_urls_change() {
         let result = build_result(None);
-        let urls_a = HashMap::from([("svg".to_owned(), "/a.svg".to_owned())]);
-        let urls_b = HashMap::from([("svg".to_owned(), "/b.svg".to_owned())]);
+        let urls_a = HashMap::from([(FontType::Svg, "/a.svg".to_owned())]);
+        let urls_b = HashMap::from([(FontType::Svg, "/b.svg".to_owned())]);
 
-        let first_a = result.generate_css(Some(urls_a.clone())).unwrap();
-        let first_b = result.generate_css(Some(urls_b)).unwrap();
-        let second_a = result.generate_css(Some(urls_a)).unwrap();
+        let first_a = result.generate_css_pure(Some(urls_a.clone())).unwrap();
+        let first_b = result.generate_css_pure(Some(urls_b)).unwrap();
+        let second_a = result.generate_css_pure(Some(urls_a)).unwrap();
 
         assert_eq!(
             first_a, second_a,
@@ -553,10 +609,10 @@ mod tests {
     #[test]
     fn generate_css_cache_works_with_custom_template() {
         let result = build_result(Some("@font-face { src: {{{src}}}; }"));
-        let urls = HashMap::from([("svg".to_owned(), "/cached.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/cached.svg".to_owned())]);
 
-        let first = result.generate_css(Some(urls.clone())).unwrap();
-        let second = result.generate_css(Some(urls)).unwrap();
+        let first = result.generate_css_pure(Some(urls.clone())).unwrap();
+        let second = result.generate_css_pure(Some(urls)).unwrap();
 
         assert_eq!(first, second);
         assert!(first.contains("/cached.svg"));
@@ -565,11 +621,11 @@ mod tests {
     #[test]
     fn generate_css_no_urls_and_with_urls_are_independent_caches() {
         let result = build_result(None);
-        let urls = HashMap::from([("svg".to_owned(), "/custom.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/custom.svg".to_owned())]);
 
-        let no_urls = result.generate_css(None).unwrap();
-        let with_urls = result.generate_css(Some(urls)).unwrap();
-        let no_urls_again = result.generate_css(None).unwrap();
+        let no_urls = result.generate_css_pure(None).unwrap();
+        let with_urls = result.generate_css_pure(Some(urls)).unwrap();
+        let no_urls_again = result.generate_css_pure(None).unwrap();
 
         assert_eq!(
             no_urls, no_urls_again,
@@ -581,10 +637,10 @@ mod tests {
     #[test]
     fn generate_css_with_urls_returns_no_urls_result_when_template_does_not_use_src() {
         let result = build_result(Some(".icon { font-family: {{fontName}}; }"));
-        let urls = HashMap::from([("svg".to_owned(), "/should-not-appear.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/should-not-appear.svg".to_owned())]);
 
-        let no_urls = result.generate_css(None).unwrap();
-        let with_urls = result.generate_css(Some(urls)).unwrap();
+        let no_urls = result.generate_css_pure(None).unwrap();
+        let with_urls = result.generate_css_pure(Some(urls)).unwrap();
 
         assert_eq!(
             no_urls, with_urls,
@@ -600,10 +656,10 @@ mod tests {
     #[test]
     fn generate_html_with_urls_returns_no_urls_result_when_css_template_does_not_use_src() {
         let result = build_result(Some(".icon { font-family: {{fontName}}; }"));
-        let urls = HashMap::from([("svg".to_owned(), "/should-not-appear.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/should-not-appear.svg".to_owned())]);
 
-        let no_urls = result.generate_html(None).unwrap();
-        let with_urls = result.generate_html(Some(urls)).unwrap();
+        let no_urls = result.generate_html_pure(None).unwrap();
+        let with_urls = result.generate_html_pure(Some(urls)).unwrap();
 
         assert_eq!(
             no_urls, with_urls,
@@ -615,7 +671,7 @@ mod tests {
     fn generate_css_without_urls_produces_valid_css_using_css_fonts_url() {
         let result = build_result(None);
 
-        let css = result.generate_css(None).unwrap();
+        let css = result.generate_css_pure(None).unwrap();
 
         assert!(
             css.contains("@font-face"),
@@ -639,9 +695,9 @@ mod tests {
     #[test]
     fn generate_css_with_urls_replaces_default_urls_in_src() {
         let result = build_result(None);
-        let urls = HashMap::from([("svg".to_owned(), "/cdn/icons.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/cdn/icons.svg".to_owned())]);
 
-        let css = result.generate_css(Some(urls)).unwrap();
+        let css = result.generate_css_pure(Some(urls)).unwrap();
 
         assert!(
             css.contains("/cdn/icons.svg"),
@@ -661,7 +717,7 @@ mod tests {
     fn generate_html_without_urls_produces_valid_html() {
         let result = build_result(None);
 
-        let html = result.generate_html(None).unwrap();
+        let html = result.generate_html_pure(None).unwrap();
 
         assert!(
             html.contains("<!DOCTYPE html>"),
@@ -674,9 +730,9 @@ mod tests {
     #[test]
     fn generate_html_with_urls_embeds_css_using_custom_urls() {
         let result = build_result(None);
-        let urls = HashMap::from([("svg".to_owned(), "/cdn/icons.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/cdn/icons.svg".to_owned())]);
 
-        let html = result.generate_html(Some(urls)).unwrap();
+        let html = result.generate_html_pure(Some(urls)).unwrap();
 
         assert!(
             html.contains("/cdn/icons.svg"),
@@ -691,10 +747,10 @@ mod tests {
     #[test]
     fn generate_html_cache_returns_same_result_for_same_urls() {
         let result = build_result(None);
-        let urls = HashMap::from([("svg".to_owned(), "/cached.svg".to_owned())]);
+        let urls = HashMap::from([(FontType::Svg, "/cached.svg".to_owned())]);
 
-        let first = result.generate_html(Some(urls.clone())).unwrap();
-        let second = result.generate_html(Some(urls)).unwrap();
+        let first = result.generate_html_pure(Some(urls.clone())).unwrap();
+        let second = result.generate_html_pure(Some(urls)).unwrap();
 
         assert_eq!(first, second);
         assert!(first.contains("/cached.svg"));
@@ -703,11 +759,11 @@ mod tests {
     #[test]
     fn generate_html_cache_returns_different_result_for_different_urls() {
         let result = build_result(None);
-        let urls_a = HashMap::from([("svg".to_owned(), "/a.svg".to_owned())]);
-        let urls_b = HashMap::from([("svg".to_owned(), "/b.svg".to_owned())]);
+        let urls_a = HashMap::from([(FontType::Svg, "/a.svg".to_owned())]);
+        let urls_b = HashMap::from([(FontType::Svg, "/b.svg".to_owned())]);
 
-        let result_a = result.generate_html(Some(urls_a)).unwrap();
-        let result_b = result.generate_html(Some(urls_b)).unwrap();
+        let result_a = result.generate_html_pure(Some(urls_a)).unwrap();
+        let result_b = result.generate_html_pure(Some(urls_b)).unwrap();
 
         assert_ne!(result_a, result_b);
         assert!(result_a.contains("/a.svg"));
@@ -765,10 +821,10 @@ mod tests {
     #[test]
     fn generate_css_partial_urls_uses_empty_string_for_missing_types() {
         let result = build_multi_type_result();
-        // Override only woff2, leave svg un-provided — matches upstream behavior
-        let urls = HashMap::from([("woff2".to_owned(), "/cdn/font.woff2".to_owned())]);
+        // Override only woff2, leave svg un-provided -- matches upstream behavior
+        let urls = HashMap::from([(FontType::Woff2, "/cdn/font.woff2".to_owned())]);
 
-        let css = result.generate_css(Some(urls)).unwrap();
+        let css = result.generate_css_pure(Some(urls)).unwrap();
 
         assert!(
             css.contains("/cdn/font.woff2"),
@@ -787,9 +843,9 @@ mod tests {
     #[test]
     fn generate_html_partial_urls_uses_empty_string_for_missing_types() {
         let result = build_multi_type_result();
-        let urls = HashMap::from([("woff2".to_owned(), "/cdn/font.woff2".to_owned())]);
+        let urls = HashMap::from([(FontType::Woff2, "/cdn/font.woff2".to_owned())]);
 
-        let html = result.generate_html(Some(urls)).unwrap();
+        let html = result.generate_html_pure(Some(urls)).unwrap();
 
         assert!(
             html.contains("/cdn/font.woff2"),

--- a/packages/webfont-generator/src/util.rs
+++ b/packages/webfont-generator/src/util.rs
@@ -4,12 +4,13 @@ use std::path::{Component, Path, PathBuf};
 
 use serde_json::Value;
 
-use napi::threadsafe_function::ThreadsafeFunction;
+#[cfg(feature = "napi")]
 use napi::{Error as NapiError, Status};
 
 use crate::types::LoadedSvgFile;
 
 /// Convert any displayable error into a NAPI GenericFailure error.
+#[cfg(feature = "napi")]
 #[inline]
 pub(crate) fn to_napi_err(error: impl std::fmt::Display) -> NapiError {
     NapiError::new(Status::GenericFailure, error.to_string())
@@ -93,7 +94,7 @@ pub(crate) fn path_to_slashes(path: PathBuf) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
-fn default_glyph_name_from_path(path: &str) -> Result<String, Error> {
+pub(crate) fn default_glyph_name_from_path(path: &str) -> Result<String, Error> {
     Path::new(path)
         .file_stem()
         .and_then(|stem| stem.to_str())
@@ -106,15 +107,14 @@ fn default_glyph_name_from_path(path: &str) -> Result<String, Error> {
         })
 }
 
-pub(crate) async fn glyph_name_from_path(
+/// Resolve a glyph name from a file path, optionally applying a rename function.
+pub(crate) fn glyph_name_from_path(
     path: &str,
-    rename: Option<&ThreadsafeFunction<String, String, String, Status, false>>,
-) -> napi::Result<String> {
-    if let Some(rename) = rename {
-        rename.call_async(path.to_owned()).await
-    } else {
-        default_glyph_name_from_path(path)
-            .map_err(|error| NapiError::new(Status::InvalidArg, error.to_string()))
+    rename: Option<&(dyn Fn(&str) -> String + Send + Sync)>,
+) -> Result<String, Error> {
+    match rename {
+        Some(rename) => Ok(rename(path)),
+        None => default_glyph_name_from_path(path),
     }
 }
 
@@ -151,9 +151,8 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::Path;
 
-    use super::{glyph_name_from_path, resolve_codepoints};
+    use super::{default_glyph_name_from_path, glyph_name_from_path, resolve_codepoints};
     use crate::types::LoadedSvgFile;
-    use napi::Status;
 
     fn loaded_svg_file(path: &str) -> LoadedSvgFile {
         LoadedSvgFile {
@@ -169,25 +168,21 @@ mod tests {
 
     #[test]
     fn derives_glyph_name_from_path() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let glyph_name = runtime
-            .block_on(glyph_name_from_path("/tmp/icons/arrow-left.svg", None))
-            .unwrap();
+        let glyph_name = glyph_name_from_path("/tmp/icons/arrow-left.svg", None).unwrap();
 
         assert_eq!(glyph_name, "arrow-left");
     }
 
     #[test]
     fn errors_when_glyph_name_cannot_be_derived() {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let error = runtime
-            .block_on(glyph_name_from_path("/tmp/icons/..", None))
-            .unwrap_err();
+        let error = default_glyph_name_from_path("/tmp/icons/..").unwrap_err();
 
-        assert_eq!(error.status, Status::InvalidArg);
-        assert!(error
-            .to_string()
-            .contains("Unable to derive glyph name from '/tmp/icons/..'."));
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("Unable to derive glyph name from '/tmp/icons/..'.")
+        );
     }
 
     #[test]

--- a/packages/webfont-generator/src/woff/mod.rs
+++ b/packages/webfont-generator/src/woff/mod.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, ErrorKind, Write};
 
-use flate2::write::ZlibEncoder;
 use flate2::Compression;
+use flate2::write::ZlibEncoder;
 
 const WOFF_HEADER_SIZE: usize = 44;
 const META_OFFSET_POS: usize = 24;

--- a/packages/webfont-generator/tests/integration.rs
+++ b/packages/webfont-generator/tests/integration.rs
@@ -1,0 +1,598 @@
+// Integration tests exercise the pure Rust API and CLI. They cannot link against
+// the NAPI feature because the test binary is not a Node.js addon.
+#![cfg(not(feature = "napi"))]
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use webfont_generator::{FontType, GenerateWebfontsOptions};
+
+fn fixture_files() -> Vec<String> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/svg/fixtures/icons/cleanicons");
+    let mut files: Vec<String> = std::fs::read_dir(&dir)
+        .expect("fixture dir should exist")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("svg"))
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    files.sort();
+    files
+}
+
+fn temp_dest(prefix: &str) -> String {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir()
+        .join(format!("{prefix}-{unique}"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+// --- generate_sync tests ---
+
+#[test]
+fn generate_sync_produces_all_default_font_types() {
+    let dest = temp_dest("gen-sync-defaults");
+    let result = webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest: dest.clone(),
+            files: fixture_files(),
+            write_files: Some(false),
+            ..Default::default()
+        },
+        None,
+    )
+    .expect("generate_sync should succeed");
+
+    // Default types: eot, woff, woff2
+    assert!(result.eot_bytes().is_some(), "should generate EOT");
+    assert!(result.woff_bytes().is_some(), "should generate WOFF");
+    assert!(result.woff2_bytes().is_some(), "should generate WOFF2");
+    // SVG and TTF are not in the default types
+    assert!(
+        result.svg_string().is_none(),
+        "should not generate SVG by default"
+    );
+    assert!(
+        result.ttf_bytes().is_none(),
+        "should not generate TTF by default"
+    );
+}
+
+#[test]
+fn generate_sync_produces_requested_types_only() {
+    let dest = temp_dest("gen-sync-types");
+    let result = webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest,
+            files: fixture_files(),
+            types: Some(vec![FontType::Svg, FontType::Ttf]),
+            write_files: Some(false),
+            ..Default::default()
+        },
+        None,
+    )
+    .expect("generate_sync should succeed");
+
+    assert!(result.svg_string().is_some(), "should generate SVG");
+    assert!(result.ttf_bytes().is_some(), "should generate TTF");
+    assert!(result.eot_bytes().is_none(), "should not generate EOT");
+    assert!(result.woff_bytes().is_none(), "should not generate WOFF");
+    assert!(result.woff2_bytes().is_none(), "should not generate WOFF2");
+}
+
+#[test]
+fn generate_sync_writes_files_to_disk() {
+    let dest = temp_dest("gen-sync-write");
+    let font_name = "test-icons";
+    let result = webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest: dest.clone(),
+            files: fixture_files(),
+            font_name: Some(font_name.to_owned()),
+            types: Some(vec![FontType::Woff2]),
+            css: Some(true),
+            write_files: Some(true),
+            ..Default::default()
+        },
+        None,
+    )
+    .expect("generate_sync should succeed");
+
+    assert!(result.woff2_bytes().is_some());
+    assert!(
+        Path::new(&dest).join(format!("{font_name}.woff2")).exists(),
+        "WOFF2 file should be written"
+    );
+    assert!(
+        Path::new(&dest).join(format!("{font_name}.css")).exists(),
+        "CSS file should be written"
+    );
+
+    // Clean up
+    let _ = std::fs::remove_dir_all(&dest);
+}
+
+#[test]
+fn generate_sync_generates_valid_css() {
+    let dest = temp_dest("gen-sync-css");
+    let result = webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest,
+            files: fixture_files(),
+            font_name: Some("my-icons".to_owned()),
+            types: Some(vec![FontType::Woff2]),
+            css: Some(true),
+            write_files: Some(false),
+            ..Default::default()
+        },
+        None,
+    )
+    .expect("generate_sync should succeed");
+
+    let css = result
+        .generate_css_pure(None)
+        .expect("CSS generation should succeed");
+
+    assert!(css.contains("@font-face"), "CSS should contain @font-face");
+    assert!(
+        css.contains("font-family: \"my-icons\""),
+        "CSS should use the configured font name"
+    );
+    assert!(
+        css.contains("format(\"woff2\")"),
+        "CSS should reference woff2 format"
+    );
+}
+
+#[test]
+fn generate_sync_generates_html_when_requested() {
+    let dest = temp_dest("gen-sync-html");
+    let result = webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest,
+            files: fixture_files(),
+            types: Some(vec![FontType::Woff2]),
+            html: Some(true),
+            write_files: Some(false),
+            ..Default::default()
+        },
+        None,
+    )
+    .expect("generate_sync should succeed");
+
+    let html = result
+        .generate_html_pure(None)
+        .expect("HTML generation should succeed");
+
+    assert!(
+        html.contains("<!DOCTYPE html>") || html.contains("<html"),
+        "should produce HTML"
+    );
+    assert!(
+        html.contains("@font-face"),
+        "HTML should embed CSS with @font-face"
+    );
+}
+
+#[test]
+fn generate_sync_applies_rename_callback() {
+    let dest = temp_dest("gen-sync-rename");
+    let result = webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest,
+            files: fixture_files(),
+            types: Some(vec![FontType::Svg]),
+            css: Some(true),
+            write_files: Some(false),
+            ..Default::default()
+        },
+        Some(Box::new(|name: &str| format!("prefix-{name}"))),
+    )
+    .expect("generate_sync should succeed");
+
+    let css = result
+        .generate_css_pure(None)
+        .expect("CSS generation should succeed");
+
+    assert!(
+        css.contains("prefix-"),
+        "renamed glyphs should appear in CSS"
+    );
+}
+
+#[test]
+fn generate_sync_rejects_empty_dest() {
+    match webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest: String::new(),
+            files: fixture_files(),
+            ..Default::default()
+        },
+        None,
+    ) {
+        Err(err) => {
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+            assert!(err.to_string().contains("dest"));
+        }
+        Ok(_) => panic!("should fail with empty dest"),
+    }
+}
+
+#[test]
+fn generate_sync_rejects_empty_files() {
+    match webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest: "output".to_owned(),
+            files: vec![],
+            ..Default::default()
+        },
+        None,
+    ) {
+        Err(err) => {
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+            assert!(err.to_string().contains("files"));
+        }
+        Ok(_) => panic!("should fail with empty files"),
+    }
+}
+
+#[test]
+fn generate_sync_with_explicit_codepoints() {
+    let dest = temp_dest("gen-sync-codepoints");
+    let files = fixture_files();
+    let first_glyph = Path::new(&files[0])
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let result = webfont_generator::generate_sync(
+        GenerateWebfontsOptions {
+            dest,
+            files,
+            types: Some(vec![FontType::Svg]),
+            codepoints: Some(HashMap::from([(first_glyph.clone(), 0xE900)])),
+            css: Some(true),
+            write_files: Some(false),
+            ..Default::default()
+        },
+        None,
+    )
+    .expect("generate_sync should succeed");
+
+    let css = result
+        .generate_css_pure(None)
+        .expect("CSS generation should succeed");
+
+    assert!(
+        css.contains("e900"),
+        "CSS should contain the explicit codepoint"
+    );
+}
+
+// --- async generate tests ---
+
+#[tokio::test]
+async fn generate_async_produces_fonts() {
+    let dest = temp_dest("gen-async");
+    let result = webfont_generator::generate(
+        GenerateWebfontsOptions {
+            dest,
+            files: fixture_files(),
+            types: Some(vec![FontType::Woff2, FontType::Svg]),
+            write_files: Some(false),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("async generate should succeed");
+
+    assert!(result.woff2_bytes().is_some());
+    assert!(result.svg_string().is_some());
+}
+
+// --- CLI tests ---
+
+#[cfg(feature = "cli")]
+mod cli {
+    use std::process::Command;
+
+    fn cli_bin() -> Command {
+        Command::new(env!("CARGO_BIN_EXE_webfont-generator"))
+    }
+
+    fn fixture_dir() -> String {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/svg/fixtures/icons/cleanicons")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn help_flag_succeeds() {
+        let output = cli_bin().arg("--help").output().expect("should execute");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("Generate webfonts from SVG icons"));
+    }
+
+    #[test]
+    fn version_flag_succeeds() {
+        let output = cli_bin().arg("--version").output().expect("should execute");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("webfont-generator"));
+    }
+
+    #[test]
+    fn generates_fonts_from_directory() {
+        let dest = super::temp_dest("cli-dir");
+        let output = cli_bin()
+            .args(["--dest", &dest, "--types", "woff2", &fixture_dir()])
+            .output()
+            .expect("should execute");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "CLI should succeed. stdout: {stdout}, stderr: {stderr}"
+        );
+        assert!(stdout.contains("WOFF2"), "should report generated WOFF2");
+        assert!(
+            std::path::Path::new(&dest).join("iconfont.woff2").exists(),
+            "WOFF2 file should be written"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+
+    #[test]
+    fn fails_with_no_files() {
+        let output = cli_bin()
+            .args(["--dest", "/tmp/empty", "/nonexistent/path"])
+            .output()
+            .expect("should execute");
+
+        assert!(!output.status.success());
+    }
+
+    #[test]
+    fn generates_css_and_html() {
+        let dest = super::temp_dest("cli-css-html");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "woff2",
+                "--html",
+                "--font-name",
+                "test-font",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(output.status.success(), "CLI should succeed");
+        assert!(
+            std::path::Path::new(&dest).join("test-font.css").exists(),
+            "CSS file should be written"
+        );
+        assert!(
+            std::path::Path::new(&dest).join("test-font.html").exists(),
+            "HTML file should be written"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+
+    #[test]
+    fn no_css_suppresses_css_output() {
+        let dest = super::temp_dest("cli-no-css");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "woff2",
+                "--no-css",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(output.status.success(), "CLI should succeed");
+        assert!(
+            std::path::Path::new(&dest).join("iconfont.woff2").exists(),
+            "font file should be written"
+        );
+        assert!(
+            !std::path::Path::new(&dest).join("iconfont.css").exists(),
+            "CSS file should NOT be written with --no-css"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+
+    #[test]
+    fn no_html_suppresses_html_even_with_html_flag() {
+        let dest = super::temp_dest("cli-no-html");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "woff2",
+                "--html",
+                "--no-html",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(output.status.success(), "CLI should succeed");
+        assert!(
+            !std::path::Path::new(&dest).join("iconfont.html").exists(),
+            "HTML file should NOT be written when --no-html overrides --html"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+
+    #[test]
+    fn no_write_suppresses_all_file_output() {
+        let dest = super::temp_dest("cli-no-write");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "woff2",
+                "--no-write",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(output.status.success(), "CLI should succeed");
+        assert!(
+            !std::path::Path::new(&dest).exists(),
+            "dest directory should not be created with --no-write"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_font_type() {
+        let output = cli_bin()
+            .args(["--dest", "/tmp/test", "--types", "wof22", &fixture_dir()])
+            .output()
+            .expect("should execute");
+
+        assert!(!output.status.success(), "should fail with invalid type");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("invalid value"),
+            "should report invalid value"
+        );
+    }
+
+    #[test]
+    fn invalid_start_codepoint_uses_default() {
+        let dest = super::temp_dest("cli-bad-codepoint");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "woff2",
+                "--no-css",
+                "--start-codepoint",
+                "not-a-number",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(
+            output.status.success(),
+            "should succeed with invalid codepoint (falls back to default)"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+
+    #[test]
+    fn ligature_no_ligature_last_flag_wins() {
+        let dest = super::temp_dest("cli-ligature-precedence");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "svg",
+                "--no-css",
+                "--ligature",
+                "--no-ligature",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(output.status.success(), "CLI should succeed");
+
+        // With ligatures enabled, each glyph gets two <glyph> entries (codepoint +
+        // ligature string). Without ligatures, only the codepoint entry exists.
+        // The fixture dir has 10 SVGs, so we expect exactly 10 glyphs (no ligatures).
+        let svg =
+            std::fs::read_to_string(std::path::Path::new(&dest).join("iconfont.svg")).unwrap();
+        let glyph_count = svg.matches("<glyph ").count();
+        assert_eq!(
+            glyph_count, 10,
+            "should have exactly 10 <glyph> entries (no ligature duplicates) when --no-ligature wins"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+
+    #[test]
+    fn no_css_then_css_restores_css_output() {
+        let dest = super::temp_dest("cli-no-css-css");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "woff2",
+                "--no-css",
+                "--css",
+                "--font-name",
+                "precedence-test",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(output.status.success(), "CLI should succeed");
+        assert!(
+            std::path::Path::new(&dest)
+                .join("precedence-test.css")
+                .exists(),
+            "CSS should be generated when --css overrides earlier --no-css"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+
+    #[test]
+    fn no_write_then_write_restores_file_output() {
+        let dest = super::temp_dest("cli-no-write-write");
+        let output = cli_bin()
+            .args([
+                "--dest",
+                &dest,
+                "--types",
+                "woff2",
+                "--no-css",
+                "--no-write",
+                "--write",
+                &fixture_dir(),
+            ])
+            .output()
+            .expect("should execute");
+
+        assert!(output.status.success(), "CLI should succeed");
+        assert!(
+            std::path::Path::new(&dest).join("iconfont.woff2").exists(),
+            "font should be written when --write overrides earlier --no-write"
+        );
+
+        let _ = std::fs::remove_dir_all(&dest);
+    }
+}

--- a/packages/webfont-generator/vite.config.ts
+++ b/packages/webfont-generator/vite.config.ts
@@ -4,18 +4,18 @@ export default defineProject({
     run: {
         tasks: {
             check: {
-                command: 'cargo clippy -- -D warnings && cargo fmt -- --check',
+                command: 'cargo clippy -- -D warnings && cargo clippy --features cli -- -D warnings && cargo clippy --features napi -- -D warnings && cargo fmt -- --check',
             },
             test: {
-                command: 'cargo t',
+                command: 'cargo t && cargo t --features cli && cargo t --features napi',
                 dependsOn: ['check'],
                 env: ['UPDATE_SVG_FIXTURES'],
             },
             build: {
-                command: 'napi build --platform --esm --js binding.js --dts binding.d.ts',
+                command: 'napi build --platform --esm --js binding.js --dts binding.d.ts -- --features napi',
             },
             'build:release': {
-                command: 'napi build --platform --esm --js binding.js --dts binding.d.ts --release',
+                command: 'napi build --platform --esm --js binding.js --dts binding.d.ts --release -- --features napi',
                 dependsOn: ['test'],
             },
         },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,14 @@
         },
         "packages/webfont-generator": {
             "release-type": "node",
-            "component": "webfont-generator"
+            "component": "webfont-generator",
+            "extra-files": [
+                {
+                    "type": "toml",
+                    "path": "Cargo.toml",
+                    "jsonpath": "$.package.version"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
## Summary

- Decouple Rust core from NAPI with feature flags: `napi` (Node.js binding), `cli` (standalone binary with clap)
- Add pure Rust public API: `generate()` async + `generate_sync()`, with pure Rust getters on the result type
- Add CLI binary: `cargo install webfont-generator --features cli`
- Refactor all internal error handling from `napi::Result` to `std::io::Result` — NAPI conversion at boundary only
- Add crate metadata for crates.io (license, keywords, categories, docs), edition 2024
- Add `publish-crate` job to release workflow for crates.io publishing
- CI now clippy-checks and tests all three feature configs (default, cli, napi)
- 15 new integration tests covering the library API and CLI end-to-end

PR 4 of 5 splitting #80.