### PR TITLE
fix(ci): sync Cargo.lock on release PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,15 +43,20 @@ jobs:
                   run-install: true
                   cache: true
 
-            - name: Format changelog
+            - name: Setup Rust toolchain
+              if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Format changelog and sync Cargo.lock
               if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
               run: |
                   vp check --fix || true
+                  cargo update -p webfont-generator --manifest-path packages/webfont-generator/Cargo.toml
                   if ! git diff --quiet; then
                     git config user.name "github-actions[bot]"
                     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                     git add -A
-                    git commit --no-verify -m "chore: format changelog"
+                    git commit --no-verify -m "chore: format changelog and sync Cargo.lock"
                     git push
                   fi
 
@@ -89,7 +94,7 @@ jobs:
               shell: bash
 
             - name: Publish
-              run: pnpm publish --filter @atlowchemi/webfont-generator --access public --provenance
+              run: vp pm publish --filter @atlowchemi/webfont-generator --access public --provenance
 
             - name: Upload to native release
               if: needs.release-please.outputs.native-released == 'true'

--- a/packages/webfont-generator/Cargo.lock
+++ b/packages/webfont-generator/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "webfont-generator"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "flate2",


### PR DESCRIPTION
Add cargo update step to the release-please PR formatting job so Cargo.lock stays in sync when Cargo.toml version is bumped.