### PR TITLE
fix(ci): use heredoc for binding.js version sync, add README badges

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,15 +52,15 @@ jobs:
               run: |
                   vp check --fix || true
                   cargo update -p webfont-generator --manifest-path packages/webfont-generator/Cargo.toml
-                  node -e "
-                    const fs = require('fs');
-                    const { version } = JSON.parse(fs.readFileSync('packages/webfont-generator/package.json', 'utf8'));
-                    const file = 'packages/webfont-generator/binding.js';
-                    const updated = fs.readFileSync(file, 'utf8')
-                      .replaceAll(/bindingPackageVersion !== '[^']+'/g, \`bindingPackageVersion !== '\${version}'\`)
-                      .replaceAll(/expected [^ ]+ but got \${bindingPackageVersion}/g, \`expected \${version} but got \\\${bindingPackageVersion}\`);
-                    fs.writeFileSync(file, updated);
-                  "
+                  node <<'NODE'
+                  const fs = require('fs');
+                  const { version } = JSON.parse(fs.readFileSync('packages/webfont-generator/package.json', 'utf8'));
+                  const file = 'packages/webfont-generator/binding.js';
+                  const updated = fs.readFileSync(file, 'utf8')
+                    .replaceAll(/bindingPackageVersion !== '[^']+'/g, `bindingPackageVersion !== '${version}'`)
+                    .replaceAll(/expected [^ ]+ but got \${bindingPackageVersion}/g, `expected ${version} but got \${bindingPackageVersion}`);
+                  fs.writeFileSync(file, updated);
+                  NODE
                   if ! git diff --quiet; then
                     git config user.name "github-actions[bot]"
                     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/packages/webfont-generator/README.md
+++ b/packages/webfont-generator/README.md
@@ -1,5 +1,12 @@
 # @atlowchemi/webfont-generator
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@atlowchemi/webfont-generator"><img src="https://img.shields.io/npm/v/@atlowchemi/webfont-generator.svg?style=flat-square" alt="npm" /></a>
+  <a href="https://crates.io/crates/webfont-generator"><img src="https://img.shields.io/crates/v/webfont-generator.svg?style=flat-square" alt="crates.io" /></a>
+  <a href="https://docs.rs/webfont-generator"><img src="https://img.shields.io/docsrs/webfont-generator?style=flat-square" alt="docs.rs" /></a>
+  <a href="https://github.com/atlowChemi/vite-svg-2-webfont/blob/master/LICENSE"><img src="https://img.shields.io/github/license/atlowChemi/vite-svg-2-webfont.svg?style=flat-square" alt="license" /></a>
+</p>
+
 A native Rust [NAPI](https://napi.rs) addon that generates webfonts (SVG, TTF, EOT, WOFF, WOFF2) and their companion CSS/HTML from a set of SVG icon files.
 
 This is a ground-up rewrite of [`@vusion/webfonts-generator`](https://github.com/vusion/webfonts-generator) in Rust — the original package and its authors deserve credit for the API design and template system that this project builds on. The JS implementation is unmaintained, so this package reimplements the same pipeline natively for better performance and long-term maintainability.


### PR DESCRIPTION
## Summary

- Fix binding.js version sync script in release workflow: switch from `node -e "..."` to a quoted heredoc (`node <<'NODE'`) to avoid shell escaping issues with `$` in regex patterns that caused the error message version to not be updated
- Add npm, crates.io, docs.rs, and license badges to the webfont-generator README

PR 7 of 7 splitting #80.