### PR TITLE
fix(ci): disable GitHub release creation in napi pre-publish

### DIFF
--- a/packages/webfont-generator/package.json
+++ b/packages/webfont-generator/package.json
@@ -26,7 +26,7 @@
         "provenance": true
     },
     "scripts": {
-        "prepublishOnly": "napi pre-publish -t npm"
+        "prepublishOnly": "napi pre-publish -t npm --no-gh-release"
     },
     "files": [
         "binding.js",


### PR DESCRIPTION
## Summary

Add `--no-gh-release` to `napi pre-publish` in the `prepublishOnly` script. The current script attempts to create GitHub releases for each platform package during npm publish, which fails with 401/404 errors because the publish job doesn't have the right token/tag format. GitHub release asset uploads are already handled separately by `softprops/action-gh-release`.