### PR TITLE
feat(webfont-generator): type cssContext and htmlContext callback context

### DIFF
--- a/packages/webfont-generator/binding.d.ts
+++ b/packages/webfont-generator/binding.d.ts
@@ -10,6 +10,28 @@ export declare class GenerateWebfontsResult {
   generateHtml(urls?: Partial<Record<FontType, string>>): string
 }
 
+/**
+ * Guaranteed fields supplied to a `cssContext` callback. Additional keys from
+ * user-supplied `templateOptions` are merged into the same object at runtime,
+ * so the JS-side type widens this with an open-ended index signature.
+ */
+export interface CssContext {
+  /** Name of the generated font, mirroring the `fontName` option. */
+  fontName: string
+  /**
+   * Pre-rendered value for the CSS `@font-face` `src:` descriptor — a
+   * comma-separated list of `url(...) format(...)` entries derived from the
+   * configured `types`, `order`, and `cssFontsUrl`.
+   */
+  src: string
+  /**
+   * Map from glyph name to its assigned codepoint as a hex-encoded string
+   * (e.g. `"add" -> "f101"`), suitable for use inside CSS `content`
+   * declarations like `content: "\f101"`.
+   */
+  codepoints: Record<string, string>
+}
+
 export declare const enum FontType {
   Svg = 'svg',
   Ttf = 'ttf',
@@ -57,6 +79,33 @@ export interface GenerateWebfontsOptions {
   templateOptions?: Record<string, any>
   types?: Array<FontType>
   writeFiles?: boolean
+}
+
+/**
+ * Guaranteed fields supplied to an `htmlContext` callback. Additional keys
+ * from user-supplied `templateOptions` are merged into the same object at
+ * runtime, so the JS-side type widens this with an open-ended index signature.
+ */
+export interface HtmlContext {
+  /** Name of the generated font, mirroring the `fontName` option. */
+  fontName: string
+  /**
+   * Glyph names in declaration order, after any `rename` callback has been
+   * applied. Useful for iterating over icons in a preview template.
+   */
+  names: Array<string>
+  /**
+   * Pre-rendered CSS (the same string the engine writes to the `.css`
+   * output) so HTML templates can embed it inline for self-contained
+   * previews without an external stylesheet reference.
+   */
+  styles: string
+  /**
+   * Map from glyph name to its assigned codepoint as a numeric value
+   * (e.g. `"add" -> 0xF101`). Use the CSS context's hex form if you need a
+   * string for embedding into CSS `content` declarations.
+   */
+  codepoints: Record<string, number>
 }
 
 export interface SvgFormatOptions {

--- a/packages/webfont-generator/index.d.ts
+++ b/packages/webfont-generator/index.d.ts
@@ -1,11 +1,25 @@
-import type { GenerateWebfontsOptions, GenerateWebfontsResult as RawGenerateWebfontsResult } from './binding';
+import type { CssContext as RawCssContext, GenerateWebfontsOptions, GenerateWebfontsResult as RawGenerateWebfontsResult, HtmlContext as RawHtmlContext } from './binding';
 import * as templates from './templates.js';
 
 export type FontType = 'svg' | 'ttf' | 'eot' | 'woff' | 'woff2';
 
+/**
+ * Context object passed to the `cssContext` callback. The named fields are
+ * always supplied by the native engine; the index signature accommodates
+ * arbitrary keys merged in from user-supplied `templateOptions`.
+ */
+export type CssContext = RawCssContext & { [key: string]: unknown };
+
+/**
+ * Context object passed to the `htmlContext` callback. The named fields are
+ * always supplied by the native engine; the index signature accommodates
+ * arbitrary keys merged in from user-supplied `templateOptions`.
+ */
+export type HtmlContext = RawHtmlContext & { [key: string]: unknown };
+
 export interface GenerateWebfontsInputOptions<T extends FontType = FontType> extends Omit<GenerateWebfontsOptions, 'types' | 'order'> {
-    cssContext?: (context: Record<string, any>) => void;
-    htmlContext?: (context: Record<string, any>) => void;
+    cssContext?: (context: CssContext) => void;
+    htmlContext?: (context: HtmlContext) => void;
     order?: NoInfer<T>[];
     rename?: (name: string) => string;
     types?: T[];

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -94,12 +94,12 @@ use templates::{render_css_with_hbs_context, render_html_with_hbs_context};
 #[cfg(feature = "napi")]
 use util::to_napi_err;
 
+pub use types::{
+    CssContext, FontType, FormatOptions, GenerateWebfontsOptions, GenerateWebfontsResult,
+    HtmlContext, SvgFormatOptions, TtfFormatOptions, WoffFormatOptions,
+};
 use types::{
     DEFAULT_FONT_ORDER, LoadedSvgFile, ResolvedGenerateWebfontsOptions, resolved_font_types,
-};
-pub use types::{
-    FontType, FormatOptions, GenerateWebfontsOptions, GenerateWebfontsResult, SvgFormatOptions,
-    TtfFormatOptions, WoffFormatOptions,
 };
 
 #[cfg(all(test, feature = "napi"))]

--- a/packages/webfont-generator/src/svg/fixtures/README.md
+++ b/packages/webfont-generator/src/svg/fixtures/README.md
@@ -29,7 +29,7 @@ How to regenerate `expected/`:
     ```
 3. Rebuild the native NAPI addon and run the full JS test suite:
     ```sh
-    vp run native:build
+    vp run @atlowchemi/webfont-generator#build
     vp run test
     ```
 

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -86,6 +86,45 @@ pub struct FormatOptions {
     pub woff: Option<WoffFormatOptions>,
 }
 
+/// Guaranteed fields supplied to a `cssContext` callback. Additional keys from
+/// user-supplied `templateOptions` are merged into the same object at runtime,
+/// so the JS-side type widens this with an open-ended index signature.
+#[cfg_attr(feature = "napi", napi(object))]
+#[derive(Clone)]
+pub struct CssContext {
+    /// Name of the generated font, mirroring the `fontName` option.
+    pub font_name: String,
+    /// Pre-rendered value for the CSS `@font-face` `src:` descriptor — a
+    /// comma-separated list of `url(...) format(...)` entries derived from the
+    /// configured `types`, `order`, and `cssFontsUrl`.
+    pub src: String,
+    /// Map from glyph name to its assigned codepoint as a hex-encoded string
+    /// (e.g. `"add" -> "f101"`), suitable for use inside CSS `content`
+    /// declarations like `content: "\f101"`.
+    pub codepoints: HashMap<String, String>,
+}
+
+/// Guaranteed fields supplied to an `htmlContext` callback. Additional keys
+/// from user-supplied `templateOptions` are merged into the same object at
+/// runtime, so the JS-side type widens this with an open-ended index signature.
+#[cfg_attr(feature = "napi", napi(object))]
+#[derive(Clone)]
+pub struct HtmlContext {
+    /// Name of the generated font, mirroring the `fontName` option.
+    pub font_name: String,
+    /// Glyph names in declaration order, after any `rename` callback has been
+    /// applied. Useful for iterating over icons in a preview template.
+    pub names: Vec<String>,
+    /// Pre-rendered CSS (the same string the engine writes to the `.css`
+    /// output) so HTML templates can embed it inline for self-contained
+    /// previews without an external stylesheet reference.
+    pub styles: String,
+    /// Map from glyph name to its assigned codepoint as a numeric value
+    /// (e.g. `"add" -> 0xF101`). Use the CSS context's hex form if you need a
+    /// string for embedding into CSS `content` declarations.
+    pub codepoints: HashMap<String, u32>,
+}
+
 #[cfg_attr(feature = "napi", napi(object))]
 #[derive(Clone, Default)]
 pub struct GenerateWebfontsOptions {


### PR DESCRIPTION
## Summary
- Replaces the `Record<string, any>` parameter on `cssContext` / `htmlContext` callbacks with named `CssContext` / `HtmlContext` types so consumers get hover docs and autocomplete for the fields the native engine guarantees (`fontName`, `src`, `codepoints` for CSS; `fontName`, `names`, `styles`, `codepoints` for HTML).
- The types are `#[napi(object)]` structs in the Rust crate, so `binding.d.ts` regenerates from Rust on every native build — future field additions or renames flow into the TS API automatically.
- The TS overlay in `index.d.ts` widens them with an open-ended index signature so arbitrary keys merged in from user-supplied `templateOptions` still type-check.
- Runtime calldata across the NAPI boundary remains `serde_json::Map<String, Value>` — no behavior change, no JS-wrapper change.
- Also fixes the regenerate-fixtures README to use the renamed `@atlowchemi/webfont-generator#build` task instead of the old `native:build` task that no longer exists.

## Notes
- `binding.d.ts` is committed because it is consumed by `index.d.ts`; the diff is fully auto-generated by `napi build` from the new `#[napi(object)]` structs and their `///` field docs.
- The plugin-side type swap (`vite-svg-2-webfont/src/optionParser.ts`) and the v6 → v7 migration guide are intentionally out of scope here — they belong with PR #80, which is what introduces the `@atlowchemi/webfont-generator` migration in the first place.