### PR TITLE
ci(release-please): include commit authors in changelog and release body

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
             native-tag: ${{ steps.release.outputs['packages/webfont-generator--tag_name'] }}
             any-released: ${{ steps.release.outputs.releases_created }}
         steps:
-            - uses: googleapis/release-please-action@v4
+            - uses: googleapis/release-please-action@v5
               id: release
               with:
                   config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "include-commit-authors": true,
     "packages": {
         "packages/vite-svg-2-webfont": {
             "release-type": "node",


### PR DESCRIPTION
## Summary
- Adds `include-commit-authors: true` to the release-please config so each commit row in the generated changelog and the matching GitHub release body is suffixed with the GitHub author handle (`(@username)`), falling back to the git author name when no GitHub username is known.
- The default conventional-commit grouping (Features / Bug Fixes / BREAKING CHANGES / etc.) is preserved — only the per-row format changes.
- Bumps `googleapis/release-please-action` from `@v4` to `@v5` because `include-commit-authors` requires release-please >= 17.5.0, which only ships in action v5+. The only other change in v5 is the runtime upgrade to Node 24, which is supported on `ubuntu-latest`.

## Notes
- The option does not affect commit parsing for version bumps — `feat!:` / `BREAKING CHANGE:` footers continue to drive major bumps as before. Only the changelog rendering is affected.
- The IDE's JSON schema validator may flag `include-commit-authors` as unknown; the option is read by release-please at runtime (`manifest.ts:1400`) but isn't yet listed in the published JSON schema.