### PR TITLE
fix(webfont-generator): ship CJS entrypoints for require() consumers

### DIFF
--- a/packages/webfont-generator/index.cjs
+++ b/packages/webfont-generator/index.cjs
@@ -1,0 +1,52 @@
+const templates = require('./templates.cjs');
+
+const UPSTREAM_TTF_COMPAT_TS = 1_484_141_760_000;
+
+function coerceCodepoints(codepoints) {
+    if (!codepoints) return undefined;
+    return Object.fromEntries(Object.entries(codepoints).map(([name, value]) => [name, String.fromCharCode(value).codePointAt(0) ?? 0]));
+}
+
+async function generateWebfonts(options) {
+    if (!options.dest) throw new Error('"options.dest" is empty.');
+    if (!options.files?.length) throw new Error('"options.files" is empty.');
+
+    const { rename, cssContext, htmlContext, ...nativeFields } = options;
+
+    const nativeOptions = {
+        ...nativeFields,
+        codepoints: coerceCodepoints(options.codepoints),
+        cssTemplate: options.cssTemplate,
+        htmlTemplate: options.htmlTemplate,
+        formatOptions: {
+            ...options.formatOptions,
+            ttf: {
+                ...(typeof options.formatOptions?.ttf === 'object' && options.formatOptions.ttf),
+                ts: UPSTREAM_TTF_COMPAT_TS,
+            },
+        },
+    };
+
+    const { generateWebfonts: generateNativeBinding } = await import('./binding.js');
+
+    return generateNativeBinding(
+        nativeOptions,
+        rename,
+        cssContext
+            ? context => {
+                  cssContext(context);
+                  return context;
+              }
+            : undefined,
+        htmlContext
+            ? context => {
+                  htmlContext(context);
+                  return context;
+              }
+            : undefined,
+    );
+}
+
+generateWebfonts.templates = templates;
+
+module.exports = { generateWebfonts, templates };

--- a/packages/webfont-generator/package.json
+++ b/packages/webfont-generator/package.json
@@ -9,12 +9,12 @@
         ".": {
             "types": "./index.d.ts",
             "import": "./index.js",
-            "require": "./index.js"
+            "require": "./index.cjs"
         },
         "./templates": {
             "types": "./templates.d.ts",
             "import": "./templates.js",
-            "require": "./templates.js"
+            "require": "./templates.cjs"
         }
     },
     "repository": {
@@ -32,8 +32,10 @@
         "binding.js",
         "binding.d.ts",
         "index.js",
+        "index.cjs",
         "index.d.ts",
         "templates.js",
+        "templates.cjs",
         "templates.d.ts",
         "templates"
     ],

--- a/packages/webfont-generator/templates.cjs
+++ b/packages/webfont-generator/templates.cjs
@@ -1,0 +1,7 @@
+const path = require('node:path');
+
+const css = path.join(__dirname, 'templates', 'css.hbs');
+const html = path.join(__dirname, 'templates', 'html.hbs');
+const scss = path.join(__dirname, 'templates', 'scss.hbs');
+
+module.exports = { css, html, scss };


### PR DESCRIPTION
## Summary

The engine's `require` export conditions for `.` and `./templates` both pointed at ESM-only `.js` files, so `require('@atlowchemi/webfont-generator')` and `require('@atlowchemi/webfont-generator/templates')` failed with `ERR_REQUIRE_ESM` on Node 20 < 20.19 (where `require(esm)` is gated).

This regressed CJS consumers of `vite-svg-2-webfont`: its CJS bundle synchronously `require`s the templates module at module load (`packages/vite-svg-2-webfont/src/index.ts:5`), so the plugin crashed before its own code ran on the affected Node versions.

Flagged by `chatgpt-codex-connector` on PR #80 ([review comment](https://github.com/atlowChemi/vite-svg-2-webfont/pull/80#discussion_r3143554481)).

## Changes

- Add `packages/webfont-generator/index.cjs` and `packages/webfont-generator/templates.cjs` siblings.
- Point the `require` conditions on both `.` and `./templates` at the new `.cjs` files.
- Include the new files in the `files` array so they ship to npm.
- The CJS index loads the NAPI binding via dynamic `import()` inside the async generator, mirroring what the ESM index does at the top level — `binding.js` is ESM-only and would otherwise hit the same ERR_REQUIRE_ESM trap.

## Verification

- `vp check` — pass (86 files formatted, 36 files type-clean).
- `vp run test` — 252 tests passing across 5 files.
- Smoke-tested `node -e "require('./templates.cjs')"` and `require('./index.cjs')` — both resolve and expose the expected keys.