### PR TITLE
fix(vite-svg-2-webfont): widen @atlowchemi/webfont-generator dependency range

### DIFF
--- a/packages/vite-svg-2-webfont/package.json
+++ b/packages/vite-svg-2-webfont/package.json
@@ -41,7 +41,7 @@
         "vite": "^6.0.0  || ^7.0.0 || ^8.0.0"
     },
     "dependencies": {
-        "@atlowchemi/webfont-generator": "workspace:*",
+        "@atlowchemi/webfont-generator": "workspace:^",
         "glob": "^13.0.6"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
   packages/vite-svg-2-webfont:
     dependencies:
       '@atlowchemi/webfont-generator':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../webfont-generator
       glob:
         specifier: ^13.0.6


### PR DESCRIPTION
## Summary

Switches the workspace protocol on the bundled engine dep from `workspace:*` to `workspace:^`.

`workspace:*` publishes the resolved version verbatim (e.g. `@atlowchemi/webfont-generator: 0.3.0`), pinning consumers to the exact engine release shipped alongside the plugin and blocking them from receiving patch/minor engine updates without a plugin re-release. `workspace:^` publishes as `^0.3.0`, allowing semver-compatible engine updates on install.

No runtime change in this repo — the local workspace link is unaffected; only the published `dependencies` field of `vite-svg-2-webfont` is changed.