### PR TITLE
fix(webfont-generator): preserve leading slash when cssFontsUrl is "/"

### DIFF
--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -374,3 +374,36 @@ describe('build allowWriteFilesInBuild', () => {
         await expect(access(filePath, constants.F_OK)).resolves.not.toThrow();
     });
 });
+
+describe('build cssFontsUrl root', () => {
+    // Regression test for https://github.com/atlowChemi/vite-svg-2-webfont/issues/121:
+    // cssFontsUrl: '/' must produce absolute-from-root URLs like '/iconfont.woff2',
+    // not a bare filename. Captures the rendered src via cssContext to inspect the
+    // plugin output directly, before Vite's asset pipeline rewrites the URLs.
+    const webfontFolder = fileURLToPath(new URL('webfont-test/svg', root));
+    let capturedSrc: string | undefined;
+
+    beforeAll(async () => {
+        await build({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            build: { assetsInlineLimit: 0, write: false },
+            plugins: [
+                viteSvgToWebfont({
+                    context: webfontFolder,
+                    types: ['woff2', 'ttf'],
+                    cssFontsUrl: '/',
+                    cssContext: context => {
+                        capturedSrc = context.src;
+                    },
+                }),
+            ],
+        });
+    });
+
+    it.each(['woff2', 'ttf'] as const)('emits leading-slash url for type %s', type => {
+        expect(capturedSrc).toMatch(new RegExp(`url\\("/iconfont\\.${type}\\?[^"]+"\\)`));
+        expect(capturedSrc).not.toMatch(new RegExp(`url\\("iconfont\\.${type}\\?`));
+    });
+});

--- a/packages/vite-svg-2-webfont/src/optionParser.test.ts
+++ b/packages/vite-svg-2-webfont/src/optionParser.test.ts
@@ -453,16 +453,23 @@ describe('optionParser', () => {
         it.concurrent('sets cssFontsUrl only if defined in options', () => {
             const resDefault = optionParser.parseOptions({ context });
             expect('cssFontsUrl' in resDefault).toEqual(false);
-            const cssFontsUrl = '/cssFontsUrl';
-            const resExplicit = optionParser.parseOptions({ context, cssFontsUrl });
-            expect(resExplicit.cssFontsUrl).toBe(resolve(cssFontsUrl));
         });
 
-        it.concurrent('concatenates dest to cssFontsUrl', () => {
+        it.concurrent('concatenates dest to relative cssFontsUrl', () => {
             const dest = '/root';
             const cssFontsUrl = 'cssFontsUrl';
             const resExplicit = optionParser.parseOptions({ context, dest, cssFontsUrl });
             expect(resExplicit.cssFontsUrl).toBe(resolve(dest, cssFontsUrl));
+        });
+
+        it.concurrent.each([
+            { cssFontsUrl: '/', label: 'root' },
+            { cssFontsUrl: '/assets/fonts', label: 'absolute path' },
+            { cssFontsUrl: '//cdn.example.com/fonts', label: 'protocol-relative URL' },
+            { cssFontsUrl: 'https://cdn.example.com/fonts', label: 'absolute URL' },
+        ])('passes absolute cssFontsUrl ($label) through unchanged', ({ cssFontsUrl }) => {
+            const resExplicit = optionParser.parseOptions({ context, dest: '/root', cssFontsUrl });
+            expect(resExplicit.cssFontsUrl).toBe(cssFontsUrl);
         });
 
         it.concurrent('sets htmlTemplate only if defined in options', () => {

--- a/packages/vite-svg-2-webfont/src/optionParser.ts
+++ b/packages/vite-svg-2-webfont/src/optionParser.ts
@@ -190,6 +190,21 @@ export function parsePreloadFormatsOption<T extends FontType = FontType>({ prelo
     return parseGeneratedFontTypeOption(preloadFormats);
 }
 
+const CSS_FONTS_URL_ABSOLUTE_RE = /^(?:\/|[a-z][a-z0-9+.-]*:\/\/)/i;
+
+function resolveCssFontsUrl(dest: string, cssFontsUrl: string): string {
+    // Absolute URL paths ('/...', '//cdn/...') and full URLs ('https://...') are
+    // URL values, not filesystem paths — passing them through `path.resolve` on
+    // Windows mangles them (e.g. `resolve(dest, '/')` returns `'C:/'`). Match
+    // upstream @vusion/webfonts-generator, which never resolves cssFontsUrl
+    // against dest, while keeping the existing dest-concat behavior for
+    // relative values consumers may already rely on.
+    if (CSS_FONTS_URL_ABSOLUTE_RE.test(cssFontsUrl)) {
+        return cssFontsUrl;
+    }
+    return resolve(dest, cssFontsUrl);
+}
+
 export function parseFiles({ files, context }: Pick<IconPluginOptions, 'files' | 'context'>): string[] {
     files ||= ['*.svg'];
     const resolvedFiles = globSync(files, { cwd: context })?.map(file => join(context, file)) || [];
@@ -273,7 +288,7 @@ export function parseOptions<T extends FontType = FontType>(options: IconPluginO
         htmlDest: resolveFileDest(options.dest, options.htmlDest, options.fontName, 'html'),
         ...(options.cssTemplate && { cssTemplate: resolve(options.dest, options.cssTemplate) }),
         ...(options.cssContext && { cssContext: options.cssContext }),
-        ...(options.cssFontsUrl && { cssFontsUrl: resolve(options.dest, options.cssFontsUrl) }),
+        ...(options.cssFontsUrl && { cssFontsUrl: resolveCssFontsUrl(options.dest, options.cssFontsUrl) }),
         ...(options.htmlTemplate && { htmlTemplate: resolve(options.dest, options.htmlTemplate) }),
         ...(typeof options.fixedWidth !== 'undefined' && { fixedWidth: options.fixedWidth }),
         ...(typeof options.centerHorizontally !== 'undefined' && { centerHorizontally: options.centerHorizontally }),

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -729,7 +729,7 @@ mod tests {
     }
 
     #[test]
-    fn make_urls_treats_an_empty_trimmed_css_fonts_url_as_no_base_url() {
+    fn make_urls_preserves_leading_slash_when_css_fonts_url_is_only_slashes() {
         let options = GenerateWebfontsOptions {
             css: Some(false),
             css_fonts_url: Some("///".to_owned()),
@@ -757,7 +757,7 @@ mod tests {
 
         assert_eq!(
             urls.get(&FontType::Svg),
-            Some(&format!("iconfont.svg?{hash}"))
+            Some(&format!("/iconfont.svg?{hash}"))
         );
     }
 

--- a/packages/webfont-generator/src/util.rs
+++ b/packages/webfont-generator/src/util.rs
@@ -53,11 +53,19 @@ where
 }
 
 /// Join a base URL with a file name, normalizing slashes.
+///
+/// When `base_url` consists only of slashes (e.g. `"/"`), the leading slash
+/// is preserved so absolute-from-root references like `cssFontsUrl: "/"`
+/// produce URLs such as `"/iconfont.woff2"` rather than collapsing to a
+/// relative path.
 pub(crate) fn join_url(base_url: &str, file_name: &str) -> String {
+    if base_url.is_empty() {
+        return file_name.trim_start_matches('/').to_owned();
+    }
     let trimmed_base = base_url.trim_end_matches('/');
     let trimmed_file = file_name.trim_start_matches('/');
     if trimmed_base.is_empty() {
-        trimmed_file.to_owned()
+        format!("/{trimmed_file}")
     } else {
         format!("{trimmed_base}/{trimmed_file}")
     }
@@ -151,7 +159,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::Path;
 
-    use super::{default_glyph_name_from_path, glyph_name_from_path, resolve_codepoints};
+    use super::{default_glyph_name_from_path, glyph_name_from_path, join_url, resolve_codepoints};
     use crate::types::LoadedSvgFile;
 
     fn loaded_svg_file(path: &str) -> LoadedSvgFile {
@@ -217,6 +225,44 @@ mod tests {
         assert_eq!(resolved_codepoints.get("arrow-left"), Some(&0xF105));
         assert_eq!(resolved_codepoints.get("check"), Some(&0xF101));
         assert_eq!(resolved_codepoints.get("arrow-right"), Some(&0xF102));
+    }
+
+    #[test]
+    fn join_url_returns_file_name_when_base_is_empty() {
+        assert_eq!(join_url("", "iconfont.woff2"), "iconfont.woff2");
+        assert_eq!(join_url("", "/iconfont.woff2"), "iconfont.woff2");
+    }
+
+    #[test]
+    fn join_url_preserves_leading_slash_when_base_is_root() {
+        assert_eq!(join_url("/", "iconfont.woff2"), "/iconfont.woff2");
+        assert_eq!(join_url("/", "/iconfont.woff2"), "/iconfont.woff2");
+        assert_eq!(join_url("//", "iconfont.woff2"), "/iconfont.woff2");
+    }
+
+    #[test]
+    fn join_url_joins_relative_and_absolute_paths() {
+        assert_eq!(join_url("/foo", "iconfont.woff2"), "/foo/iconfont.woff2");
+        assert_eq!(join_url("/foo/", "iconfont.woff2"), "/foo/iconfont.woff2");
+        assert_eq!(join_url("foo", "iconfont.woff2"), "foo/iconfont.woff2");
+        assert_eq!(join_url("foo/", "iconfont.woff2"), "foo/iconfont.woff2");
+        assert_eq!(join_url("/foo", "/iconfont.woff2"), "/foo/iconfont.woff2");
+    }
+
+    #[test]
+    fn join_url_preserves_absolute_url_origins() {
+        assert_eq!(
+            join_url("https://cdn.example.com", "iconfont.woff2"),
+            "https://cdn.example.com/iconfont.woff2"
+        );
+        assert_eq!(
+            join_url("https://cdn.example.com/", "iconfont.woff2"),
+            "https://cdn.example.com/iconfont.woff2"
+        );
+        assert_eq!(
+            join_url("https://cdn.example.com/assets", "iconfont.woff2"),
+            "https://cdn.example.com/assets/iconfont.woff2"
+        );
     }
 
     #[test]

--- a/tests/webfonts-generator.compat.test.ts
+++ b/tests/webfonts-generator.compat.test.ts
@@ -1383,6 +1383,34 @@ describe('compat:webfonts-generator:side-by-side', () => {
         });
     });
 
+    describe.each([
+        { cssFontsUrl: '/', label: 'root' },
+        { cssFontsUrl: '///', label: 'multi-slash root' },
+        { cssFontsUrl: '/assets/fonts', label: 'absolute path' },
+        { cssFontsUrl: '/assets/fonts/', label: 'absolute path with trailing slash' },
+        { cssFontsUrl: 'fonts/nested', label: 'relative path' },
+        { cssFontsUrl: 'fonts/nested/', label: 'relative path with trailing slash' },
+        { cssFontsUrl: 'https://cdn.example.com/fonts', label: 'absolute URL' },
+        { cssFontsUrl: 'https://cdn.example.com/fonts/', label: 'absolute URL with trailing slash' },
+    ] as const)('cssFontsUrl parity: $label', ({ cssFontsUrl }) => {
+        // Regression coverage for https://github.com/atlowChemi/vite-svg-2-webfont/issues/121:
+        // the generated CSS urls for any cssFontsUrl value must match upstream
+        // @vusion/webfonts-generator (which delegates to the url-join npm package).
+        it('matches generated CSS side-by-side', async () => {
+            const dest = await createTempDir('__webfonts-compat-side-by-side-css-fonts-url-');
+            const options = baseOptions(dest, {
+                css: false,
+                cssFontsUrl,
+                html: false,
+                order: ['eot', 'woff2', 'woff', 'ttf', 'svg'],
+                types: ['eot', 'woff2', 'woff', 'ttf', 'svg'],
+            });
+            const { newCore, upstream } = await runSideBySide(options);
+
+            expect(sanitizeTemplateOutput(newCore.generateCss())).toBe(sanitizeTemplateOutput(upstream.generateCss()));
+        });
+    });
+
     it('matches default scss template output', async () => {
         const destUpstream = await createTempDir(`__webfonts-compat-side-by-side-default-scss-template-upstream-`);
         const destNewCore = await createTempDir(`__webfonts-compat-side-by-side-default-scss-template-new-core-`);


### PR DESCRIPTION
## Summary

Fixes #121.

`cssFontsUrl: "/"` produced relative URLs in the generated CSS (`url("iconfont.woff2")` instead of `url("/iconfont.woff2")`). v6.x produced absolute URLs (matching upstream `@vusion/webfonts-generator`), so this was a regression in v7.0.0's Rust rewrite.

CI on Windows runners then surfaced a second, related bug: `path.resolve(dest, "/")` returns `"C:/"` on Windows because `"/"` is interpreted as the current drive root, leaving `url("C:/iconfont.woff2")` in the generated CSS.

## Commits

1. **`fix(webfont-generator): preserve leading slash when cssFontsUrl trims to root`** — the Rust `join_url` fix in `util.rs`, the renamed/corrected `make_urls_*` test in `css.rs`, and unit tests for `join_url` covering empty base, root-only base, relative and absolute paths, and full URL origins. This is the fix for #121 itself.
2. **`fix(vite-svg-2-webfont): pass absolute cssFontsUrl values through on Windows`** — `optionParser` skips `path.resolve` when `cssFontsUrl` is already an absolute URL value (POSIX-style `"/..."` path or full `"scheme://..."` URL). Relative values keep the dest-concat behavior.
3. **`test: cover cssFontsUrl shapes end-to-end`** — a plugin integration test that asserts `cssFontsUrl: "/"` produces a leading-slash url through `cssContext.src` (the same callback the issue reporter used), plus side-by-side parity tests against upstream `@vusion/webfonts-generator` in `tests/webfonts-generator.compat.test.ts` covering: root, multi-slash root, absolute path (+/- trailing slash), relative path (+/- trailing slash), and absolute URL (+/- trailing slash).