### PR TITLE
chore(ci): harden CI — SHA-pin actions, add required-checks fan-in, stage publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+      groups:
+          actions:
+              patterns:
+                  - '*'

--- a/.github/workflows/build-native.yaml
+++ b/.github/workflows/build-native.yaml
@@ -30,10 +30,10 @@ jobs:
                     - x86_64-pc-windows-msvc
                     - aarch64-pc-windows-msvc
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Cache cargo registry
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: |
                       ~/.cargo/registry
@@ -41,7 +41,7 @@ jobs:
                   key: cargo-${{ runner.os }}-${{ hashFiles('packages/webfont-generator/Cargo.lock') }}
                   restore-keys: cargo-${{ runner.os }}-
             - name: Cache build artifacts
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: |
                       ./packages/webfont-generator/target
@@ -52,7 +52,7 @@ jobs:
             - name: Restore xwin SDK/CRT cache
               id: xwin-cache-restore
               if: contains(matrix.target, 'windows-msvc')
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ github.workspace }}/.xwin
                   key: xwin-${{ runner.os }}-windows-msvc-v1
@@ -60,11 +60,11 @@ jobs:
                       xwin-${{ runner.os }}-windows-msvc-
                       xwin-${{ runner.os }}-
 
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable@2026-05
               with:
                   targets: ${{ matrix.target }}
 
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
               with:
                   node-version-file: .node-version
                   run-install: true
@@ -72,13 +72,13 @@ jobs:
 
             - name: Install ziglang
               if: matrix.target != 'x86_64-unknown-linux-gnu' && !contains(matrix.target, 'windows-msvc')
-              uses: mlugg/setup-zig@v2
+              uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
               with:
                   version: 0.14.1
 
             - name: Install cargo-zigbuild
               if: matrix.target != 'x86_64-unknown-linux-gnu' && !contains(matrix.target, 'windows-msvc')
-              uses: taiki-e/install-action@v2
+              uses: taiki-e/install-action@920ab1831fbf4fb3ef75c8ead83556c918bb7290 # v2.79.8
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -98,7 +98,7 @@ jobs:
 
             - name: Install cargo-xwin
               if: contains(matrix.target, 'windows-msvc')
-              uses: taiki-e/install-action@v2
+              uses: taiki-e/install-action@920ab1831fbf4fb3ef75c8ead83556c918bb7290 # v2.79.8
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:
@@ -112,7 +112,7 @@ jobs:
 
             - name: Save xwin SDK/CRT cache
               if: contains(matrix.target, 'windows-msvc') && success() && steps.xwin-cache-restore.outputs.cache-hit != 'true'
-              uses: actions/cache/save@v5
+              uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ github.workspace }}/.xwin
                   key: xwin-${{ runner.os }}-windows-msvc-v1
@@ -130,7 +130,7 @@ jobs:
                   CFLAGS_aarch64_apple_darwin: -mmacosx-version-min=11.0
                   CXXFLAGS_aarch64_apple_darwin: -mmacosx-version-min=11.0
 
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: bindings-${{ matrix.target }}
                   path: packages/webfont-generator/*.node

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,10 +19,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - name: setup pages
-              uses: actions/configure-pages@v5
-            - uses: voidzero-dev/setup-vp@v1
+              uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+            - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
               with:
                   node-version-file: .node-version
                   run-install: true
@@ -30,7 +30,7 @@ jobs:
             - name: build docs
               run: vp run @atlowchemi/vite-svg-webfont-docs#build
             - name: upload pages artifact
-              uses: actions/upload-pages-artifact@v4
+              uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
               with:
                   path: packages/docs/.vitepress/dist
 
@@ -44,4 +44,4 @@ jobs:
         steps:
             - name: deploy to github pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,11 +14,11 @@ jobs:
         name: lint and check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable@2026-05
               with:
                   components: clippy, rustfmt
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: |
                       ~/.cargo/registry
@@ -26,7 +26,7 @@ jobs:
                       packages/webfont-generator/target
                   key: cargo-${{ runner.os }}-${{ hashFiles('packages/webfont-generator/Cargo.lock') }}
                   restore-keys: cargo-${{ runner.os }}-
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
               with:
                   node-version-file: .node-version
                   run-install: true
@@ -64,16 +64,16 @@ jobs:
                 node: ['22', '24', '26']
         runs-on: ${{ matrix.settings.host }}
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v5
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node }}
                   cache: pnpm
                   architecture: ${{ matrix.settings.architecture }}
             - run: pnpm install --frozen-lockfile
             - name: Download binding
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: bindings-${{ matrix.settings.target }}
                   path: packages/webfont-generator/
@@ -101,15 +101,15 @@ jobs:
                       runner: ubuntu-latest
         runs-on: ${{ matrix.runner }}
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v5
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version-file: .node-version
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
             - name: Download binding
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: bindings-${{ matrix.arch }}-unknown-linux-musl
                   path: packages/webfont-generator/
@@ -119,7 +119,7 @@ jobs:
               id: pnpm-version
               run: echo "version=$(node -p "JSON.parse(require('fs').readFileSync('package.json','utf8')).packageManager.split('@')[1].split('+')[0]")" >> "$GITHUB_OUTPUT"
             - name: Run tests
-              uses: tj-actions/docker-run@v2
+              uses: tj-actions/docker-run@1d25a677da8f1243a138dc5db21e307e92986ffe # v2.2.1
               with:
                   image: node:26-alpine
                   name: test-${{ matrix.arch }}-linux-musl
@@ -159,9 +159,9 @@ jobs:
             fail-fast: false
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: dtolnay/rust-toolchain@stable
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable@2026-05
+            - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
               with:
                   node-version: ${{ matrix.node_version }}
                   run-install: false
@@ -170,7 +170,7 @@ jobs:
               run: node ./scripts/ci/set-vite-major.ts ${{ matrix.vite_major }}
             - run: vp install --no-frozen-lockfile
             - name: Download binding
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: bindings-x86_64-unknown-linux-gnu
                   path: packages/webfont-generator/
@@ -195,7 +195,7 @@ jobs:
             - name: Run tests
               if: ${{ !matrix.primary }}
               run: vp test
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               if: ${{ matrix.primary }}
               with:
                   name: coverage-node-${{ matrix.node_version }}-vite-${{ matrix.vite_major }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -200,3 +200,23 @@ jobs:
               with:
                   name: coverage-node-${{ matrix.node_version }}-vite-${{ matrix.vite_major }}
                   path: coverage
+
+    # Single fan-in job for branch protection: matrix job names are dynamic
+    # (one per OS × node × vite combination) and would need re-listing in the
+    # repo settings every time the matrix changes. Requiring this one job
+    # instead covers every dependent without that maintenance burden.
+    required-checks:
+        name: Required checks
+        if: always()
+        needs: [ci, build, test-host, test-docker, test-vite-compat]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify all dependent jobs succeeded
+              run: |
+                  if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" \
+                     || "${{ contains(needs.*.result, 'cancelled') }}" == "true" \
+                     || "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+                      echo "::error::One or more required jobs failed, were cancelled, or were skipped."
+                      exit 1
+                  fi
+                  echo "All required jobs succeeded."

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -16,7 +16,7 @@ jobs:
         name: Validate conventional commit title
         runs-on: ubuntu-latest
         steps:
-            - uses: amannn/action-semantic-pull-request@v6
+            - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,12 +98,58 @@ jobs:
               run: vp exec napi create-npm-dirs --cwd packages/webfont-generator
             - name: Move artifacts
               run: vp exec napi artifacts --cwd packages/webfont-generator
-            - name: List packages
-              run: ls -R ./packages/webfont-generator/npm
-              shell: bash
 
-            - name: Publish
-              run: vp pm publish --filter @atlowchemi/webfont-generator
+            # Prepare per-platform package.jsons (version bump, addon copy,
+            # main package's optionalDependencies entries) before staging,
+            # so the per-platform dirs are publish-ready. `prepublishOnly`
+            # would normally do this when the main package is published —
+            # we skip it via `--ignore-scripts` on the main stage step
+            # below so this work isn't duplicated.
+            - name: Prepare per-platform packages
+              run: vp exec napi pre-publish -t npm --no-gh-release --skip-optional-publish --cwd packages/webfont-generator
+
+            - name: List packages
+              id: list-packages
+              shell: bash
+              run: |
+                  ls -R ./packages/webfont-generator/npm
+                  {
+                      echo "dirs<<EOF"
+                      find packages/webfont-generator/npm -mindepth 1 -maxdepth 1 -type d
+                      echo "EOF"
+                  } >> "$GITHUB_OUTPUT"
+
+            # Per-platform packages stage *first* so the main package's
+            # optionalDependencies entries are already in the staging area
+            # by the time the main package is approved and promoted. Stage
+            # ids land in the workflow run summary for the maintainer to
+            # approve from a 2FA-enrolled machine.
+            - name: Stage publish per-platform binary packages
+              shell: bash
+              env:
+                  DIRS: ${{ steps.list-packages.outputs.dirs }}
+              run: |
+                  echo '## Staged: per-platform binary packages' >> "$GITHUB_STEP_SUMMARY"
+                  echo '' >> "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+                  while IFS= read -r dir; do
+                      [ -z "$dir" ] && continue
+                      pkg=$(basename "$dir")
+                      echo "--- $pkg ---" | tee -a "$GITHUB_STEP_SUMMARY"
+                      vp exec -c "pnpm stage publish '$dir' --no-git-checks" | tee -a "$GITHUB_STEP_SUMMARY"
+                  done <<< "$DIRS"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Stage publish main package
+              run: |
+                  echo '' >> "$GITHUB_STEP_SUMMARY"
+                  echo '## Staged: @atlowchemi/webfont-generator' >> "$GITHUB_STEP_SUMMARY"
+                  echo '' >> "$GITHUB_STEP_SUMMARY"
+                  echo 'Approve every entry above + this one with `pnpm stage approve <id> --otp <code>` from a 2FA-enrolled maintainer machine.' >> "$GITHUB_STEP_SUMMARY"
+                  echo '' >> "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+                  vp exec -c "pnpm stage publish --filter @atlowchemi/webfont-generator --no-git-checks --ignore-scripts" | tee -a "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
 
             - name: Upload to native release
               if: needs.release-please.outputs.native-released == 'true'
@@ -139,8 +185,15 @@ jobs:
                   run-install: true
                   cache: true
 
-            - name: Publish from tarball
-              run: vp run vite-svg-2-webfont#publish
+            - name: Stage publish from tarball
+              run: |
+                  echo '## Staged: vite-svg-2-webfont' >> "$GITHUB_STEP_SUMMARY"
+                  echo '' >> "$GITHUB_STEP_SUMMARY"
+                  echo 'Approve with `pnpm stage approve <id> --otp <code>` from a 2FA-enrolled maintainer machine.' >> "$GITHUB_STEP_SUMMARY"
+                  echo '' >> "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
+                  vp run vite-svg-2-webfont#publish | tee -a "$GITHUB_STEP_SUMMARY"
+                  echo '```' >> "$GITHUB_STEP_SUMMARY"
 
             - name: Upload release assets
               uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
             native-tag: ${{ steps.release.outputs['packages/webfont-generator--tag_name'] }}
             any-released: ${{ steps.release.outputs.releases_created }}
         steps:
-            - uses: googleapis/release-please-action@v5
+            - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
               id: release
               with:
                   config-file: release-please-config.json
@@ -31,13 +31,13 @@ jobs:
 
             - name: Checkout release PR branch
               if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ fromJSON(steps.release.outputs.prs)[0].headBranchName }}
 
             - name: Setup Vite+
               if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
-              uses: voidzero-dev/setup-vp@v1
+              uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
               with:
                   node-version-file: .node-version
                   run-install: true
@@ -45,7 +45,7 @@ jobs:
 
             - name: Setup Rust toolchain
               if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable@2026-05
 
             - name: Format changelog and sync Cargo.lock
               if: steps.release.outputs.prs && steps.release.outputs.prs != '[]' && steps.release.outputs.releases_created != 'true'
@@ -81,15 +81,15 @@ jobs:
         if: needs.release-please.outputs.native-released == 'true'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
               with:
                   node-version-file: .node-version
                   run-install: true
                   cache: true
 
             - name: Download all binding artifacts
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   path: packages/webfont-generator/artifacts
                   pattern: bindings-*
@@ -107,7 +107,7 @@ jobs:
 
             - name: Upload to native release
               if: needs.release-please.outputs.native-released == 'true'
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
               with:
                   tag_name: ${{ needs.release-please.outputs.native-tag }}
                   files: packages/webfont-generator/**/*.node
@@ -118,8 +118,8 @@ jobs:
         if: needs.release-please.outputs.native-released == 'true'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable@2026-05
             - name: Publish to crates.io
               working-directory: packages/webfont-generator
               run: cargo publish
@@ -132,8 +132,8 @@ jobs:
         if: needs.release-please.outputs.plugin-released == 'true'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: voidzero-dev/setup-vp@v1
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
               with:
                   node-version-file: .node-version
                   run-install: true
@@ -143,7 +143,7 @@ jobs:
               run: vp run vite-svg-2-webfont#publish
 
             - name: Upload release assets
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
               with:
                   tag_name: ${{ needs.release-please.outputs.plugin-tag }}
                   files: packages/vite-svg-2-webfont/*.tgz

--- a/packages/vite-svg-2-webfont/vite.config.ts
+++ b/packages/vite-svg-2-webfont/vite.config.ts
@@ -36,7 +36,7 @@ const config: UserProjectConfigExport = defineProject({
             },
             publish: {
                 cache: false,
-                command: 'vp exec -c "pnpm publish vite-svg-2-webfont-*.tgz --no-git-checks"',
+                command: 'vp exec -c "pnpm stage publish vite-svg-2-webfont-*.tgz --no-git-checks"',
                 dependsOn: ['pack:tgz'],
             },
         },


### PR DESCRIPTION
Three CI-hardening changes. Targets `feat/node-26-engines-native-glob` (PR #122) so the diff stays scoped to just the new work; the base rebases onto `main` once #122 merges.

## Commits

1. **`chore(ci): pin GitHub Actions to commit SHAs and add Dependabot`** — every `uses: <action>@<tag>` across the workflow files now resolves to an immutable commit SHA with the tag name in a trailing comment. Tags are mutable (a maintainer can re-tag, a compromised account can move them); SHAs aren't. Bundles five `major` bumps that all turned out to be Node 20 → Node 24 runtime moves with no API breakage: `actions/configure-pages` v5→v6, `actions/deploy-pages` v4→v5, `actions/upload-pages-artifact` v4→v5, `pnpm/action-setup` v5→v6.0.8 (adds pnpm v11 support — we're on 11.3), and `softprops/action-gh-release` v2→v3.0.0. Adds `.github/dependabot.yml` with a weekly GitHub-Actions group so the SHA pins don't go stale.

2. **`chore(ci): add Required checks fan-in job for branch protection`** — single `Required checks` job in `main.yaml` that depends on `ci`, `build`, `test-host`, `test-docker`, and `test-vite-compat`. Runs with `if: always()` and exits non-zero if any dependent ended in `failure`, `cancelled`, or `skipped`. Lets the branch protection rule require this one job instead of having to list ~15 dynamically-named matrix entries that would silently break protection every time the matrix changes.

3. **`chore(ci): route releases through pnpm stage publish`** — both publish jobs in `release.yaml` switch to npm's staged-publishing API.
    - Plugin (`vite-svg-2-webfont`): the `publish` task in its `vite.config.ts` calls `pnpm stage publish` instead of `pnpm publish`; the workflow step tees the stage id into `\$GITHUB_STEP_SUMMARY`.
    - Native (`@atlowchemi/webfont-generator`): the workflow now runs `napi pre-publish --skip-optional-publish` as an explicit preparation step, then stages each per-platform binary directory under `packages/webfont-generator/npm/<plat-arch>/`, then stages the main package via `pnpm stage publish --filter ... --ignore-scripts` so the now-redundant `prepublishOnly` hook is skipped. Per-platform packages stage *before* the main one so the main's `optionalDependencies` resolve when it's promoted. All stage ids land in the workflow summary.
    - The `List packages` step now also captures the per-platform directory list as a step output that the per-platform stage step iterates — single source of truth instead of re-globbing.

The `--skip-optional-publish` flag is real in `@napi-rs/cli@3.6.1`'s shipped code (`dist/cli.js:3194` declares the option; `dist/cli.js:3362` gates the optional-publish block on its negation) even though napi-rs's website docs don't list it.

## Configuration that must happen out-of-tree before this lands

- **npm Trusted Publisher entries** for `@atlowchemi/webfont-generator`, every `@atlowchemi/webfont-generator-<plat-arch>` sub-package, and `vite-svg-2-webfont` need to be set to the "stage-only" mode introduced in [the May 22 2026 npm changelog](https://github.blog/changelog/2026-05-22-staged-publishing-and-new-install-time-controls-for-npm/). The OIDC binding then rejects direct `npm publish` and only accepts `npm stage publish`, closing the bypass.
- After this PR runs once on a branch, the **`Required checks`** job name becomes available in the branch-protection ruleset's `+ Add checks` dropdown. Add it there, then flip the ruleset's Enforcement status to Active.