### PR TITLE
fix(webfont-generator): set repository.directory so npm resolves README images

### DIFF
--- a/packages/webfont-generator/package.json
+++ b/packages/webfont-generator/package.json
@@ -17,7 +17,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/atlowChemi/vite-svg-2-webfont"
+        "url": "git+https://github.com/atlowChemi/vite-svg-2-webfont",
+        "directory": "packages/webfont-generator"
     },
     "publishConfig": {
         "access": "public",


### PR DESCRIPTION
## Summary
- The npm package page for `@atlowchemi/webfont-generator` rendered a broken image for the logo because the README references `../docs/public/webfont-generator-logo.png` and npm had no anchor to resolve it from. The sibling `vite-svg-2-webfont` package works because its `package.json` carries `repository.directory`; this one didn't.
- Add `"directory": "packages/webfont-generator"` to the `repository` block so npm resolves relative paths against the package's location inside the monorepo.
- Drive-by: normalize `repository.url` to the `git+https://` form npm recommends and that the sibling package already uses.

Effect on the next published version: the logo and any other relative-path assets in the README will render correctly on the npm page.