### PR TITLE
ci: enable npm and cargo updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,21 @@ updates:
           actions:
               patterns:
                   - '*'
+
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+      groups:
+          npm:
+              patterns:
+                  - '*'
+
+    - package-ecosystem: cargo
+      directory: /packages/webfont-generator
+      schedule:
+          interval: weekly
+      groups:
+          cargo:
+              patterns:
+                  - '*'


### PR DESCRIPTION
## Summary
- Only `github-actions` was tracked in `.github/dependabot.yml`, so Node and Rust dependencies never received automated update PRs.
- Add `npm` at `/` (Dependabot reads `pnpm-workspace.yaml` and covers all workspace packages) and `cargo` at `/packages/webfont-generator` (the sole `Cargo.toml`).
- Each ecosystem uses a catch-all group, mirroring the existing `actions` group, so each runs as one consolidated weekly PR.

Catalog entries in `pnpm-workspace.yaml` (`vite`, `vite-plus`, `vitest`, `@vitest/coverage-v8`) may not be picked up depending on Dependabot's pnpm-catalog support — we'll adjust if the first wave of PRs shows gaps.