### PR TITLE
test: stop two flaky test races in watcher and compat suites

### DIFF
--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -1,6 +1,5 @@
 import { constants } from 'node:fs';
 import { access, readFile, rm, writeFile } from 'node:fs/promises';
-import { setInterval } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import type { IndexHtmlTransformContext, InlineConfig, PreviewServer, ViteDevServer } from 'vite';
 import { build, createServer, normalizePath, preview } from 'vite';
@@ -11,6 +10,9 @@ import { base64ToArrayBuffer } from './utils';
 const { generateWebfontsMock } = vi.hoisted(() => ({
     generateWebfontsMock: vi.fn<typeof import('@atlowchemi/webfont-generator').generateWebfonts>(),
 }));
+const { setupWatcherMock } = vi.hoisted(() => ({
+    setupWatcherMock: vi.fn<typeof import('./utils').setupWatcher>(),
+}));
 
 vi.mock('@atlowchemi/webfont-generator', async importOriginal => {
     const actual = await importOriginal<typeof import('@atlowchemi/webfont-generator')>();
@@ -19,6 +21,12 @@ vi.mock('@atlowchemi/webfont-generator', async importOriginal => {
         ...actual,
         generateWebfonts: generateWebfontsMock,
     };
+});
+
+vi.mock('./utils', async importOriginal => {
+    const actual = await importOriginal<typeof import('./utils')>();
+    setupWatcherMock.mockImplementation(actual.setupWatcher);
+    return { ...actual, setupWatcher: setupWatcherMock };
 });
 
 type ViteBuildResult = Awaited<ReturnType<typeof build>>;
@@ -596,11 +604,17 @@ describe('build:preloadFormats inlined-asset short-circuit', () => {
 });
 
 describe('serve - regenerates css when a new svg is added', () => {
-    const watcherSvgUrl = new URL('webfont-test/svg/__watcher-test__.svg', root);
+    const filename = '__watcher-test__.svg';
+    const watcherSvgUrl = new URL(`webfont-test/svg/${filename}`, root);
     const reloadedIds: string[] = [];
+    const { promise: waitForCssReload, resolve: markCssReloaded } = Promise.withResolvers<void>();
+    let watcherHandler: Parameters<typeof setupWatcherMock>[2];
     let server: ViteDevServer;
 
     beforeAll(async () => {
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
         const created = await createServer({
             logLevel: 'silent',
             root: fileURLToNormalizedPath(root),
@@ -610,12 +624,13 @@ describe('serve - regenerates css when a new svg is added', () => {
         const originalReload = created.reloadModule.bind(created);
         created.reloadModule = async mod => {
             reloadedIds.push(mod.id ?? '');
+            if (mod.id?.includes('vite-svg-2-webfont.css')) markCssReloaded();
             return originalReload(mod);
         };
         server = await created.listen();
         // Hit the font middleware so the plugin captures moduleGraph + reloadModule…
         await fetchBufferContent(server, '/iconfont.woff2');
-        // …and load the virtual module so getModuleById finds it after the watch event fires.
+        // …and load the virtual module so getModuleById finds it after the watch handler fires.
         await fetchTextContent(server, '/@id/__x00__virtual:vite-svg-2-webfont.css');
     });
 
@@ -625,22 +640,27 @@ describe('serve - regenerates css when a new svg is added', () => {
 
     it('reloads the virtual css module after a new svg appears', async () => {
         await writeFile(watcherSvgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h1024v1024H0z"/></svg>');
-        const isReloaded = () => reloadedIds.some(id => id.includes('vite-svg-2-webfont.css'));
-        for await (const startTime of setInterval(50, Date.now())) {
-            if (isReloaded() || Date.now() > startTime + 5000) break;
-        }
-        expect(isReloaded()).toBe(true);
+        await watcherHandler({ eventType: 'rename', filename });
+        await waitForCssReload;
+        expect(reloadedIds.some(id => id.includes('vite-svg-2-webfont.css'))).toBe(true);
     });
 });
 
 describe('serve - swallows reloadModule rejection from the watcher', () => {
-    const watcherSvgUrl = new URL('webfont-test/svg/__reload-reject-test__.svg', root);
+    const filename = '__reload-reject-test__.svg';
+    const watcherSvgUrl = new URL(`webfont-test/svg/${filename}`, root);
+    const { promise: waitForReloadCalled, resolve: markReloadCalled } = Promise.withResolvers<void>();
     const rejectingReload = vi.fn(async () => {
+        markReloadCalled();
         throw new Error('intentional reload failure');
     });
+    let watcherHandler: Parameters<typeof setupWatcherMock>[2];
     let server: ViteDevServer;
 
     beforeAll(async () => {
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
         const created = await createServer({
             logLevel: 'silent',
             root: fileURLToNormalizedPath(root),
@@ -659,9 +679,8 @@ describe('serve - swallows reloadModule rejection from the watcher', () => {
 
     it('does not crash the watcher when reloadModule rejects', async () => {
         await writeFile(watcherSvgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h512v512H0z"/></svg>');
-        for await (const startTime of setInterval(50, Date.now())) {
-            if (rejectingReload.mock.calls.length > 0 || Date.now() > startTime + 5000) break;
-        }
+        await watcherHandler({ eventType: 'rename', filename });
+        await waitForReloadCalled;
         expect(rejectingReload).toHaveBeenCalledOnce();
     });
 });

--- a/tests/webfonts-generator.compat.test.ts
+++ b/tests/webfonts-generator.compat.test.ts
@@ -272,20 +272,24 @@ function summarizeEot(buffer: Buffer) {
     };
 }
 
+// vusion wraps its WOFF return value with `new Buffer(font.buffer)` which exposes the entire
+// underlying Node Buffer pool, not just the WOFF bytes. The pool can carry residual WOFFs from
+// earlier tests in the same worker, so a forward `indexOf('wOFF')` finds the oldest one. Walk
+// backwards from the end and return the first WOFF whose declared size still fits — that is the
+// one this call just wrote into the pool.
 function normalizeWoffBuffer(buffer: Buffer) {
     const magic = Buffer.from('wOFF');
-    const offset = buffer.subarray(0, 4).equals(magic) ? 0 : buffer.indexOf(magic);
-
-    if (offset < 0 || offset + 12 > buffer.length) {
-        return buffer;
+    let searchEnd = buffer.length;
+    while (searchEnd >= magic.length) {
+        const offset = buffer.lastIndexOf(magic, searchEnd - 1);
+        if (offset < 0 || offset + 12 > buffer.length) break;
+        const declaredSize = buffer.readUInt32BE(offset + 8);
+        if (declaredSize > 0 && offset + declaredSize <= buffer.length) {
+            return buffer.subarray(offset, offset + declaredSize);
+        }
+        searchEnd = offset;
     }
-
-    const declaredSize = buffer.readUInt32BE(offset + 8);
-    if (declaredSize > 0 && offset + declaredSize <= buffer.length) {
-        return buffer.subarray(offset, offset + declaredSize);
-    }
-
-    return buffer.subarray(offset);
+    return buffer;
 }
 
 function summarizeWoff(buffer: Buffer) {


### PR DESCRIPTION
Two unrelated flakes surfaced on this PR's CI; both were latent test-side bugs. Fixing them together since they share a worktree.

## `vite-svg-2-webfont` watcher tests

The two watcher describe blocks in `packages/vite-svg-2-webfont/src/index.test.ts` flaked twice on this PR's CI:

- First as a 5003 ms timeout on `vite 7 + node 26` — poll budget exactly matched vitest's default `testTimeout`, so vitest's timer beat the loop's own break and surfaced `Test timed out in 5000ms` instead of an assertion failure.
- Then as a 15011 ms timeout on `aarch64-linux-musl` Docker — the first inotify event after the watcher attached was simply not delivered. A companion test in the same run completed in 5 ms.

Mock `setupWatcher` from `./utils` via a hoisted `setupWatcherMock` matching the existing `generateWebfontsMock` pattern. The two describes capture the handler the plugin passes and invoke it directly with a synthetic `FileChangeInfo`, so the OS event-delivery layer is no longer in the test path. The wait itself is a `Promise.withResolvers` deferred resolved inside the wrapped `reloadModule`; vitest's `testTimeout` is the single deadline. `handleWatchEvent` and `setupWatcher`'s dispatch loop already have full unit coverage in `utils.test.ts`.

## `tests/webfonts-generator.compat.test.ts`

`@vusion/webfonts-generator` returns its WOFF via `new Buffer(font.buffer)` — that exposes the entire underlying Node Buffer pool, not just the WOFF bytes. The pool can carry residual WOFFs from earlier tests in the same worker, so the original forward `indexOf('wOFF')` returned the offset of the *oldest* WOFF instead of the one this call wrote. When the prior WOFF had no metadata and the current one did, the side-by-side comparison read metadata fields from a stale header — the metadata test failed while every other WOFF test in the same describe passed.

`normalizeWoffBuffer` now walks backwards via `lastIndexOf` and returns the first WOFF whose declared size still fits in the buffer — that is the most recent allocation, which is the WOFF this call just wrote.