### PR TITLE
feat(webfont-generator): configurable WOFF2 compression quality

### DIFF
--- a/packages/docs/configuration.md
+++ b/packages/docs/configuration.md
@@ -228,7 +228,7 @@ viteSvgToWebfont({
 ## `formatOptions`
 
 - Type: `FormatOptions`
-- Description: Per-format options forwarded to the underlying [`@atlowchemi/webfont-generator`](/webfont-generator/). The shape is `{ svg?: SvgFormatOptions; ttf?: TtfFormatOptions; woff?: WoffFormatOptions }` — see the engine docs for the fields available on each.
+- Description: Per-format options forwarded to the underlying [`@atlowchemi/webfont-generator`](/webfont-generator/). The shape is `{ svg?: SvgFormatOptions; ttf?: TtfFormatOptions; woff?: WoffFormatOptions; woff2?: Woff2FormatOptions }` — see the engine docs for the fields available on each.
 - Reference: [`@atlowchemi/webfont-generator#formatOptions`](/webfont-generator/node#formatoptions)
 
 ## `moduleId`

--- a/packages/docs/configuration.md
+++ b/packages/docs/configuration.md
@@ -145,6 +145,17 @@ The plugin API consists of one required option and multiple optional options for
     - Available since v7 — exposes the underlying [`@atlowchemi/webfont-generator#optimizeOutput`](/webfont-generator/node#optimizeoutput) option through the plugin
     - Convenience alias for `formatOptions.svg.optimizeOutput`; the format-level option takes precedence when both are set
 
+## `woff2CompressionQuality`
+
+- Type: `number` (`0`–`11`)
+- Description: Brotli compression quality for WOFF2 output. Higher is smaller but slower to encode; every level decodes to an identical font.
+- Default: `undefined`
+- Notes:
+    - Convenience alias for `formatOptions.woff2.compressionQuality`; the format-level option takes precedence when both are set
+    - When left unset, the plugin uses a faster quality (`10`) during development (`serve`) so font rebuilds on icon changes are quicker, while production builds use the engine default (`11`) for the smallest output. The dev-served font renders identically to production — only its bytes differ.
+    - Set this to pin a single quality across both dev and build (e.g. `11` to make dev byte-for-byte match production)
+- Reference: [`@atlowchemi/webfont-generator#formatOptions`](/webfont-generator/node#formatoptions)
+
 ## `generateFiles`
 
 - Type: `boolean | string | string[]`

--- a/packages/docs/webfont-generator/node.md
+++ b/packages/docs/webfont-generator/node.md
@@ -223,7 +223,7 @@ const cssCustom = result.generateCss({ woff2: '/fonts/icons.woff2' });
 ### `formatOptions`
 
 - Type: `FormatOptions`
-- Description: Per-format configuration object with keys `svg`, `ttf`, and `woff`.
+- Description: Per-format configuration object with keys `svg`, `ttf`, `woff`, and `woff2`.
 
 ::: details FormatOptions type definition
 
@@ -232,6 +232,7 @@ interface FormatOptions {
     svg?: SvgFormatOptions;
     ttf?: TtfFormatOptions;
     woff?: WoffFormatOptions;
+    woff2?: Woff2FormatOptions;
 }
 
 interface SvgFormatOptions {
@@ -252,6 +253,14 @@ interface TtfFormatOptions {
 
 interface WoffFormatOptions {
     metadata?: string; // WOFF metadata XML string
+}
+
+interface Woff2FormatOptions {
+    // Brotli compression quality, 0 (fastest, largest) to 11 (slowest, smallest).
+    // Tunes compression effort only — never changes glyph fidelity. Defaults to 11
+    // (smallest output); lower it (e.g. to 10) for faster encoding at a marginal size
+    // cost. Must be between 0 and 11; other values are rejected.
+    compressionQuality?: number;
 }
 ```
 

--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -6,6 +6,7 @@ import { build, createServer, normalizePath, preview } from 'vite';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
 import { viteSvgToWebfont } from './index';
 import { base64ToArrayBuffer } from './utils';
+import type { IconPluginOptions } from './optionParser';
 
 const { generateWebfontsMock } = vi.hoisted(() => ({
     generateWebfontsMock: vi.fn<typeof import('@atlowchemi/webfont-generator').generateWebfonts>(),
@@ -52,7 +53,7 @@ const enum ConfigType {
     PreloadInline,
 }
 
-const getConfig = (configType: ConfigType): InlineConfig => {
+const getConfig = (configType: ConfigType, overrides?: Partial<IconPluginOptions>): InlineConfig => {
     const base: InlineConfig = {
         logLevel: 'silent',
         root: fileURLToNormalizedPath(root),
@@ -60,12 +61,12 @@ const getConfig = (configType: ConfigType): InlineConfig => {
     };
     switch (configType) {
         case ConfigType.Basic:
-            return { ...base, plugins: [viteSvgToWebfont({ context: webfontFolder })] };
+            return { ...base, plugins: [viteSvgToWebfont({ context: webfontFolder, ...overrides })] };
         case ConfigType.NoInline:
             return {
                 ...base,
                 build: { assetsInlineLimit: 0 },
-                plugins: [viteSvgToWebfont({ context: webfontFolder })],
+                plugins: [viteSvgToWebfont({ context: webfontFolder, ...overrides })],
             };
         case ConfigType.AllowWriteFilesInBuild:
             return {
@@ -78,6 +79,7 @@ const getConfig = (configType: ConfigType): InlineConfig => {
                         context: webfontFolder,
                         allowWriteFilesInBuild: true,
                         fontName: 'allowWriteFilesInBuild-test',
+                        ...overrides,
                     }),
                 ],
             };
@@ -91,6 +93,7 @@ const getConfig = (configType: ConfigType): InlineConfig => {
                         types: ['woff2', 'ttf'],
                         // @ts-ignore -- 'woff' is intentionally not in `types` — exercises the runtime filter that drops mismatched preload formats.
                         preloadFormats: ['woff2', 'woff'],
+                        ...overrides,
                     }),
                 ],
             };
@@ -98,7 +101,7 @@ const getConfig = (configType: ConfigType): InlineConfig => {
             return {
                 ...base,
                 build: { assetsInlineLimit: 0 },
-                plugins: [viteSvgToWebfont({ context: webfontFolder, inline: true, preloadFormats: ['woff2'], types: ['woff2'] })],
+                plugins: [viteSvgToWebfont({ context: webfontFolder, inline: true, preloadFormats: ['woff2'], types: ['woff2'], ...overrides })],
             };
         default:
             configType satisfies never;
@@ -153,7 +156,7 @@ const loadFileContent = async (path: string, encoding: BufferEncoding | 'buffer'
 // #endregion
 
 describe('serve - handles virtual import and has all font types available', () => {
-    const buildConfig = getConfig(ConfigType.Basic);
+    const buildConfig = getConfig(ConfigType.Basic, { formatOptions: { woff2: { compressionQuality: 11 } } });
 
     let server: ViteDevServer;
 
@@ -703,5 +706,85 @@ describe('build - throws when generator omits a requested font type', () => {
                 plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2', 'ttf'] })],
             }),
         ).rejects.toThrow(/Failed to generate font of type woff2/);
+    });
+});
+
+describe('WOFF2 compression quality by mode', () => {
+    let realGen: typeof import('@atlowchemi/webfont-generator').generateWebfonts;
+
+    beforeAll(async () => {
+        ({ generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator'));
+    });
+
+    // Capture the options the plugin forwards to the generator on the next call, while still
+    // running the real generator so the dev server / build behaves normally.
+    const captureNextGenerateOptions = () => {
+        const captured: { options?: Parameters<typeof generateWebfontsMock>[0] } = {};
+        generateWebfontsMock.mockImplementationOnce(async options => {
+            captured.options = options;
+            return realGen(options);
+        });
+        return captured;
+    };
+
+    it('serve mode forwards the faster compressionQuality (10) to the generator', async () => {
+        const captured = captureNextGenerateOptions();
+        const createdServer = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+        const server = await createdServer.listen();
+        await server.close();
+
+        expect(captured.options?.formatOptions?.woff2?.compressionQuality).toBe(10);
+    });
+
+    it('serve mode does not override user-specified compressionQuality', async () => {
+        const captured = captureNextGenerateOptions();
+        const createdServer = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'], formatOptions: { woff2: { compressionQuality: 5 } } })],
+        });
+        const server = await createdServer.listen();
+        await server.close();
+
+        expect(captured.options?.formatOptions?.woff2?.compressionQuality).toBe(5);
+    });
+
+    it('the top-level woff2CompressionQuality option overrides the dev default', async () => {
+        const captured = captureNextGenerateOptions();
+        const createdServer = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [
+                viteSvgToWebfont({
+                    context: webfontFolder,
+                    types: ['woff2'],
+                    woff2CompressionQuality: 7,
+                }),
+            ],
+        });
+        const server = await createdServer.listen();
+        await server.close();
+
+        expect(captured.options?.formatOptions?.woff2?.compressionQuality).toBe(7);
+    });
+
+    it('build mode leaves compressionQuality unset, so the engine default (11) applies', async () => {
+        const captured = captureNextGenerateOptions();
+        await build({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            build: { write: false },
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+
+        expect(captured.options?.formatOptions?.woff2?.compressionQuality).toBeUndefined();
     });
 });

--- a/packages/vite-svg-2-webfont/src/index.ts
+++ b/packages/vite-svg-2-webfont/src/index.ts
@@ -117,6 +117,12 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         },
         configResolved(_config) {
             isBuild = _config.command === 'build';
+            // In dev, default WOFF2 to a faster Brotli quality unless the user pinned one.
+            // Rebuilds run on every icon change and the dev-served font is never shipped, so the
+            // marginally larger output is irrelevant while the ~2x faster encode speeds up rebuilds.
+            if (!isBuild && processedOptions.formatOptions.woff2?.compressionQuality === undefined) {
+                processedOptions.formatOptions.woff2 = { ...processedOptions.formatOptions.woff2, compressionQuality: 10 };
+            }
         },
         resolveId(id) {
             if (id !== virtualModuleId) {

--- a/packages/vite-svg-2-webfont/src/optionParser.test.ts
+++ b/packages/vite-svg-2-webfont/src/optionParser.test.ts
@@ -586,6 +586,43 @@ describe('optionParser', () => {
             });
         });
 
+        it.concurrent('adds woff2CompressionQuality to formatOptions.woff2 only if defined in options', () => {
+            const resDefault = optionParser.parseOptions({ context });
+            expect(resDefault.formatOptions).not.toHaveProperty('woff2.compressionQuality');
+            const res = optionParser.parseOptions({ context, woff2CompressionQuality: 9 });
+            expect(res.formatOptions).toEqual({
+                woff2: {
+                    compressionQuality: 9,
+                },
+            });
+        });
+
+        it.concurrent('preserves existing formatOptions values when setting woff2CompressionQuality', () => {
+            const formatOptions = {
+                svg: { fontId: 'icons' },
+                woff: { metadata: '<metadata>woff</metadata>' },
+            };
+            const res = optionParser.parseOptions({ context, woff2CompressionQuality: 9, formatOptions });
+            expect(res.formatOptions).toEqual({
+                svg: { fontId: 'icons' },
+                woff: { metadata: '<metadata>woff</metadata>' },
+                woff2: { compressionQuality: 9 },
+            });
+        });
+
+        it.concurrent('does not override formatOptions.woff2.compressionQuality when both are defined', () => {
+            const res = optionParser.parseOptions({
+                context,
+                woff2CompressionQuality: 9,
+                formatOptions: {
+                    woff2: { compressionQuality: 11 },
+                },
+            });
+            expect(res.formatOptions).toEqual({
+                woff2: { compressionQuality: 11 },
+            });
+        });
+
         it.concurrent('sets normalize only if defined in options', () => {
             const resDefault = optionParser.parseOptions({ context });
             expect('normalize' in resDefault).toEqual(false);

--- a/packages/vite-svg-2-webfont/src/optionParser.ts
+++ b/packages/vite-svg-2-webfont/src/optionParser.ts
@@ -57,6 +57,17 @@ export interface IconPluginOptions<T extends FontType = FontType> {
      */
     optimizeOutput?: boolean;
     /**
+     * Brotli compression quality (`0`–`11`) for WOFF2 output. Convenience alias for
+     * {@link FormatOptions} `woff2.compressionQuality`; the format-level option takes
+     * precedence when both are set.
+     *
+     * When left unset, the plugin uses a faster quality (`10`) during development
+     * (`serve`) so font rebuilds on icon changes are quicker, while production builds
+     * use the engine default (`11`) for the smallest output. Set this to pin a single
+     * quality across both modes.
+     */
+    woff2CompressionQuality?: number;
+    /**
      * Path for generated CSS file.
      * - Relative to the {@link dest} property, unless set to an absolute path.
      * - Postfixed with {@link fontName} unless set to a file name with a file extension.
@@ -110,8 +121,8 @@ export interface IconPluginOptions<T extends FontType = FontType> {
     generateFiles?: boolean | FileType | FileType[];
     /**
      * Per-format options forwarded to the underlying webfont generator. See
-     * {@link FormatOptions} — its `svg`, `ttf`, and `woff` fields each carry
-     * their own typed and documented per-format options.
+     * {@link FormatOptions} — its `svg`, `ttf`, `woff`, and `woff2` fields each
+     * carry their own typed and documented per-format options.
      */
     formatOptions?: FormatOptions;
     /**
@@ -269,6 +280,7 @@ export function parseOptions<T extends FontType = FontType>(options: IconPluginO
     const generateFilesOptions = parseGenerateFilesOption(options);
     const formatOptions = options.formatOptions;
     const svgFormatOptions = formatOptions?.svg;
+    const woff2FormatOptions = formatOptions?.woff2;
     options.dest ||= resolve(options.context, '..', 'artifacts');
     options.fontName ||= 'iconfont';
     return {
@@ -292,6 +304,12 @@ export function parseOptions<T extends FontType = FontType>(options: IconPluginO
                 svg: {
                     centerVertically: options.centerVertically,
                     ...(typeof svgFormatOptions === 'object' && svgFormatOptions),
+                },
+            }),
+            ...(typeof options.woff2CompressionQuality !== 'undefined' && {
+                woff2: {
+                    compressionQuality: options.woff2CompressionQuality,
+                    ...(typeof woff2FormatOptions === 'object' && woff2FormatOptions),
                 },
             }),
         },

--- a/packages/webfont-generator/README.md
+++ b/packages/webfont-generator/README.md
@@ -18,8 +18,9 @@ This is a ground-up rewrite of [`@vusion/webfonts-generator`](https://github.com
 The API is largely compatible with `@vusion/webfonts-generator`, with a few differences:
 
 - The `cssContext` and `htmlContext` callbacks receive only the context object. The original also passed `options` and the `handlebars` instance as additional arguments — those are no longer available.
-- `formatOptions` is now strictly typed as `{ svg?: SvgFormatOptions; ttf?: TtfFormatOptions; woff?: WoffFormatOptions }`. The original accepted arbitrary `{ [format]: unknown }`; `woff2` and `eot` keys are no longer accepted (`woff2` has no format-specific options and `eot` is derived from the TTF output).
+- `formatOptions` is now strictly typed as `{ svg?: SvgFormatOptions; ttf?: TtfFormatOptions; woff?: WoffFormatOptions; woff2?: Woff2FormatOptions }`. The original accepted arbitrary `{ [format]: unknown }`; the `eot` key is no longer accepted (EOT is derived from the TTF output).
 - A new `optimizeOutput` option runs an SVG path optimizer over each glyph before assembling the font. Defaults to `false`; opt in for smaller output bytes at a small build-time cost. Also available as `formatOptions.svg.optimizeOutput`.
+- `formatOptions.woff2.compressionQuality` sets the Brotli compression quality (0–11) for WOFF2 output. Defaults to `11` (smallest output); lower it (e.g. to `10`) for faster encoding at a marginal size cost.
 - Generated font binaries (TTF, WOFF, etc.) may differ at the byte level because a different encoder is used, but the fonts are equally valid.
 - CSS, HTML, and template output is identical.
 

--- a/packages/webfont-generator/binding.d.ts
+++ b/packages/webfont-generator/binding.d.ts
@@ -86,8 +86,10 @@ export interface FormatOptions {
   svg?: SvgFormatOptions
   /** TTF-format options. */
   ttf?: TtfFormatOptions
-  /** WOFF1-format options. (WOFF2 has no format-specific options.) */
+  /** WOFF1-format options. */
   woff?: WoffFormatOptions
+  /** WOFF2-format options. */
+  woff2?: Woff2FormatOptions
 }
 
 /**
@@ -308,6 +310,19 @@ export interface TtfFormatOptions {
   url?: string
   /** Version string written to the TTF `name` table (record id 5). */
   version?: string
+}
+
+/** WOFF2-format–specific options. Affects only WOFF2 output. */
+export interface Woff2FormatOptions {
+  /**
+   * Brotli compression quality used when encoding WOFF2, from `0` (fastest,
+   * largest output) to `11` (slowest, smallest output). This tunes compression
+   * effort only and never changes glyph fidelity — the decompressed font is
+   * identical at every level. Defaults to `11` for the smallest output; lower it
+   * (e.g. to `10`) for faster encoding at a marginal size cost. Must be between
+   * `0` and `11`; other values are rejected.
+   */
+  compressionQuality?: number
 }
 
 /** WOFF-format–specific options. Affects only WOFF1 output; WOFF2 ignores these. */

--- a/packages/webfont-generator/index.d.ts
+++ b/packages/webfont-generator/index.d.ts
@@ -6,6 +6,7 @@ import type {
     HtmlContext as RawHtmlContext,
     SvgFormatOptions,
     TtfFormatOptions,
+    Woff2FormatOptions,
     WoffFormatOptions,
 } from './binding';
 import * as templates from './templates.js';
@@ -108,5 +109,6 @@ export {
      */
     templates,
     TtfFormatOptions,
+    Woff2FormatOptions,
     WoffFormatOptions,
 };

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -96,7 +96,7 @@ use util::to_napi_err;
 
 pub use types::{
     CssContext, FontType, FormatOptions, GenerateWebfontsOptions, GenerateWebfontsResult,
-    HtmlContext, SvgFormatOptions, TtfFormatOptions, WoffFormatOptions,
+    HtmlContext, SvgFormatOptions, TtfFormatOptions, Woff2FormatOptions, WoffFormatOptions,
 };
 use types::{
     DEFAULT_FONT_ORDER, LoadedSvgFile, ResolvedGenerateWebfontsOptions, resolved_font_types,
@@ -284,6 +284,21 @@ fn validate_generate_webfonts_options(options: &GenerateWebfontsOptions) -> std:
         ));
     }
 
+    if let Some(quality) = options
+        .format_options
+        .as_ref()
+        .and_then(|value| value.woff2.as_ref())
+        .and_then(|value| value.compression_quality)
+        && quality > 11
+    {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "\"options.formatOptions.woff2.compressionQuality\" must be between 0 and 11, got {quality}."
+            ),
+        ));
+    }
+
     Ok(())
 }
 
@@ -439,6 +454,12 @@ fn generate_webfonts_sync(
             .as_ref()
             .and_then(|value| value.woff.as_ref())
             .and_then(|value| value.metadata.as_deref());
+        let woff2_quality = options
+            .format_options
+            .as_ref()
+            .and_then(|value| value.woff2.as_ref())
+            .and_then(|value| value.compression_quality)
+            .unwrap_or(11);
 
         let (woff_font, (woff2_font, eot_font)) = join(
             || -> std::io::Result<Option<Vec<u8>>> {
@@ -452,7 +473,7 @@ fn generate_webfonts_sync(
                 join(
                     || -> std::io::Result<Option<Vec<u8>>> {
                         if wants_woff2 {
-                            woff::ttf_to_woff2(&raw_ttf).map(Some)
+                            woff::ttf_to_woff2(&raw_ttf, woff2_quality).map(Some)
                         } else {
                             Ok(None)
                         }
@@ -694,7 +715,10 @@ mod tests {
         resolve_generate_webfonts_options, resolved_font_types, validate_font_type_order,
         validate_generate_webfonts_options, woff,
     };
-    use crate::{FontType, GenerateWebfontsOptions, ttf::generate_ttf_font_bytes};
+    use crate::{
+        FontType, FormatOptions, GenerateWebfontsOptions, Woff2FormatOptions,
+        ttf::generate_ttf_font_bytes,
+    };
 
     #[test]
     fn generates_woff2_font_with_expected_header() {
@@ -712,7 +736,7 @@ mod tests {
         })
         .expect("expected ttf generation to succeed");
 
-        let result = woff::ttf_to_woff2(&ttf_result).expect("woff2 generation should succeed");
+        let result = woff::ttf_to_woff2(&ttf_result, 10).expect("woff2 generation should succeed");
 
         assert_eq!(&result[..4], b"wOF2");
     }
@@ -771,6 +795,42 @@ mod tests {
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
         assert!(error.to_string().contains("\"options.files\" is empty."));
+    }
+
+    fn options_with_woff2_quality(quality: u8) -> GenerateWebfontsOptions {
+        GenerateWebfontsOptions {
+            css: Some(false),
+            dest: "artifacts".to_owned(),
+            files: vec!["icon.svg".to_owned()],
+            font_name: Some("iconfont".to_owned()),
+            format_options: Some(FormatOptions {
+                woff2: Some(Woff2FormatOptions {
+                    compression_quality: Some(quality),
+                }),
+                ..Default::default()
+            }),
+            html: Some(false),
+            ligature: Some(false),
+            types: Some(vec![FontType::Woff2]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rejects_woff2_compression_quality_above_11() {
+        let error =
+            validate_generate_webfonts_options(&options_with_woff2_quality(12)).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains(
+            "\"options.formatOptions.woff2.compressionQuality\" must be between 0 and 11, got 12."
+        ));
+    }
+
+    #[test]
+    fn accepts_woff2_compression_quality_of_11() {
+        validate_generate_webfonts_options(&options_with_woff2_quality(11))
+            .expect("compression quality 11 is the upper bound and must be accepted");
     }
 
     #[test]

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -629,6 +629,7 @@ mod tests {
                 woff: Some(WoffFormatOptions {
                     metadata: Some("woff-meta".to_owned()),
                 }),
+                woff2: None,
             }),
             html: Some(false),
             font_height: Some(1000.0),

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -113,6 +113,19 @@ pub struct WoffFormatOptions {
     pub metadata: Option<String>,
 }
 
+/// WOFF2-format–specific options. Affects only WOFF2 output.
+#[cfg_attr(feature = "napi", napi(object))]
+#[derive(Clone)]
+pub struct Woff2FormatOptions {
+    /// Brotli compression quality used when encoding WOFF2, from `0` (fastest,
+    /// largest output) to `11` (slowest, smallest output). This tunes compression
+    /// effort only and never changes glyph fidelity — the decompressed font is
+    /// identical at every level. Defaults to `11` for the smallest output; lower it
+    /// (e.g. to `10`) for faster encoding at a marginal size cost. Must be between
+    /// `0` and `11`; other values are rejected.
+    pub compression_quality: Option<u8>,
+}
+
 /// Per-format configuration object. Each field carries options that only apply
 /// to the corresponding output format.
 #[cfg_attr(feature = "napi", napi(object))]
@@ -122,8 +135,10 @@ pub struct FormatOptions {
     pub svg: Option<SvgFormatOptions>,
     /// TTF-format options.
     pub ttf: Option<TtfFormatOptions>,
-    /// WOFF1-format options. (WOFF2 has no format-specific options.)
+    /// WOFF1-format options.
     pub woff: Option<WoffFormatOptions>,
+    /// WOFF2-format options.
+    pub woff2: Option<Woff2FormatOptions>,
 }
 
 /// Guaranteed fields supplied to a `cssContext` callback. Additional keys from

--- a/packages/webfont-generator/src/woff/mod.rs
+++ b/packages/webfont-generator/src/woff/mod.rs
@@ -18,8 +18,10 @@ pub(crate) fn ttf_to_woff1(ttf: &[u8], metadata: Option<&str>) -> Result<Vec<u8>
     Ok(woff_buf)
 }
 
-pub(crate) fn ttf_to_woff2(ttf: &[u8]) -> Result<Vec<u8>, Error> {
-    ::woff::version2::compress(ttf, "", 11, true)
+/// Encodes `ttf` as WOFF2. `quality` is the Brotli compression quality (0–11); callers
+/// are expected to have validated the range (see `validate_generate_webfonts_options`).
+pub(crate) fn ttf_to_woff2(ttf: &[u8], quality: u8) -> Result<Vec<u8>, Error> {
+    ::woff::version2::compress(ttf, "", quality.min(11) as usize, true)
         .ok_or_else(|| Error::new(ErrorKind::InvalidData, "WOFF2 compression failed"))
 }
 

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -444,10 +444,11 @@ function isMuslLinux(): boolean {
 }
 
 describe('output size (deterministic)', () => {
-    // Build one font from the first 300 real icons of @iconify-json/simple-icons.
-    // Output bytes are a pure function of the inputs + options, so these are exact
-    // regression guards.
+    // Build one font from the first 300 real icons of @iconify-json/simple-icons and generate
+    // every variant once. Output bytes are a pure function of the inputs + options, so these are
+    // exact regression guards.
     const ICON_COUNT = 300;
+    const woff2ByQuality = {} as Record<`q${9 | 10 | 11}`, number>;
     const perFormat = {} as Record<FontType, number>;
 
     beforeAll(async () => {
@@ -469,10 +470,39 @@ describe('output size (deterministic)', () => {
         );
 
         // `fontHeight` is pinned so the em square (and thus byte sizes) is stable.
-        const base: GenerateWebfontsInputOptions = { files, dest: `${dir}/`, fontName: 'size', fontHeight: 24, css: false, writeFiles: false, optimizeOutput: true };
+        const base: GenerateWebfontsInputOptions = {
+            files,
+            dest: `${dir}/`,
+            fontName: 'size',
+            fontHeight: 24,
+            css: false,
+            writeFiles: false,
+            optimizeOutput: true,
+            types: ['woff2'],
+        };
 
-        const all = await generateWebfonts({ ...base, types: ['svg', 'ttf', 'eot', 'woff', 'woff2'] });
+        const [nine, ten, eleven, all] = await Promise.all([
+            generateWebfonts({ ...base, formatOptions: { woff2: { compressionQuality: 9 } } }),
+            generateWebfonts({ ...base, formatOptions: { woff2: { compressionQuality: 10 } } }),
+            generateWebfonts({ ...base, formatOptions: { woff2: { compressionQuality: 11 } } }),
+            generateWebfonts({ ...base, types: ['svg', 'ttf', 'eot', 'woff', 'woff2'] }),
+        ]);
+        Object.assign(woff2ByQuality, { q9: nine.woff2.length, q10: ten.woff2.length, q11: eleven.woff2.length });
         Object.assign(perFormat, { svg: all.svg.length, ttf: all.ttf.length, eot: all.eot.length, woff: all.woff.length, woff2: all.woff2.length });
+    });
+
+    it('woff2 compression quality defaults to 11', () => {
+        expect(perFormat.woff2).toBe(woff2ByQuality.q11);
+    });
+
+    it('woff2 size by brotli compression quality', { skip: isMuslLinux() }, () => {
+        expect(woff2ByQuality).toMatchInlineSnapshot(`
+          {
+            "q10": 22876,
+            "q11": 22312,
+            "q9": 24964,
+          }
+        `);
     });
 
     it('per-format output sizes', { skip: isMuslLinux() }, () => {


### PR DESCRIPTION
Add `formatOptions.woff2.compressionQuality`, a Brotli quality knob (0–11)
for WOFF2 output. The option tunes compression effort only — every level
decodes to an identical font, so glyph fidelity is unchanged; out-of-range
values are rejected.

Defaults to 11 for the smallest output, matching the previous behavior.
Callers that prefer faster encoding can lower it (e.g. to 10) for a
marginally larger file.