### PR TITLE
refactor(webfont-generator): extract build_font_outputs from `generate_webfonts_sync`

### DIFF
--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -84,6 +84,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use tokio::task::JoinSet;
 
+use svg::types::{PreparedSvgFont, SvgOptions};
 use svg::{build_svg_font, prepare_svg_font, svg_options_from_options};
 #[cfg(feature = "napi")]
 use templates::{
@@ -99,7 +100,8 @@ pub use types::{
     HtmlContext, SvgFormatOptions, TtfFormatOptions, Woff2FormatOptions, WoffFormatOptions,
 };
 use types::{
-    DEFAULT_FONT_ORDER, LoadedSvgFile, ResolvedGenerateWebfontsOptions, resolved_font_types,
+    DEFAULT_FONT_ORDER, FontOutputs, LoadedSvgFile, ResolvedGenerateWebfontsOptions,
+    resolved_font_types,
 };
 
 #[cfg(all(test, feature = "napi"))]
@@ -415,26 +417,43 @@ fn generate_webfonts_sync(
     options: ResolvedGenerateWebfontsOptions,
     source_files: Vec<LoadedSvgFile>,
 ) -> std::io::Result<GenerateWebfontsResult> {
+    let svg_options = svg_options_from_options(&options);
+    let prepared = prepare_svg_font(&svg_options, &source_files)?;
+    let fonts = build_font_outputs(&options, &svg_options, &prepared)?;
+
+    Ok(GenerateWebfontsResult {
+        cached: std::sync::OnceLock::new(),
+        css_context: None,
+        fonts,
+        html_context: None,
+        options,
+        source_files,
+    })
+}
+
+/// Build every requested output format from an already-prepared glyph set.
+fn build_font_outputs(
+    options: &ResolvedGenerateWebfontsOptions,
+    svg_options: &SvgOptions<'_>,
+    prepared: &PreparedSvgFont,
+) -> std::io::Result<FontOutputs> {
     let wants_svg = options.types.contains(&FontType::Svg);
     let wants_ttf = options.types.contains(&FontType::Ttf);
     let wants_woff = options.types.contains(&FontType::Woff);
     let wants_woff2 = options.types.contains(&FontType::Woff2);
     let wants_eot = options.types.contains(&FontType::Eot);
 
-    let svg_options = svg_options_from_options(&options);
-    let prepared = prepare_svg_font(&svg_options, &source_files)?;
-
     let (svg_font, raw_ttf) = join(
         || -> std::io::Result<Option<String>> {
             if wants_svg {
-                Ok(Some(build_svg_font(&svg_options, &prepared)))
+                Ok(Some(build_svg_font(svg_options, prepared)))
             } else {
                 Ok(None)
             }
         },
         || -> std::io::Result<Option<Vec<u8>>> {
             if wants_ttf || wants_woff || wants_woff2 || wants_eot {
-                let ttf_options = ttf::ttf_options_from_options(&options);
+                let ttf_options = ttf::ttf_options_from_options(options);
                 ttf::generate_ttf_font_bytes_from_glyphs(ttf_options, &prepared.processed_glyphs)
                     .map(Some)
             } else {
@@ -499,17 +518,12 @@ fn generate_webfonts_sync(
         (None, None, None, None)
     };
 
-    Ok(GenerateWebfontsResult {
-        cached: std::sync::OnceLock::new(),
-        css_context: None,
-        eot_font,
-        html_context: None,
-        options,
-        source_files,
+    Ok(FontOutputs {
         svg_font,
         ttf_font,
-        woff2_font,
         woff_font,
+        woff2_font,
+        eot_font,
     })
 }
 
@@ -518,31 +532,31 @@ async fn write_generate_webfonts_result(result: &GenerateWebfontsResult) -> std:
     let font_name = result.options.font_name.clone();
     let dest = result.options.dest.clone();
 
-    if let Some(svg_font) = &result.svg_font {
+    if let Some(svg_font) = &result.fonts.svg_font {
         let path = default_output_dest(&dest, &font_name, "svg");
         let contents = Arc::clone(svg_font);
         tasks.spawn(async move { write_output_file(path, contents.as_bytes()).await });
     }
 
-    if let Some(ttf_font) = &result.ttf_font {
+    if let Some(ttf_font) = &result.fonts.ttf_font {
         let path = default_output_dest(&dest, &font_name, "ttf");
         let contents = Arc::clone(ttf_font);
         tasks.spawn(async move { write_output_file(path, &*contents).await });
     }
 
-    if let Some(woff_font) = &result.woff_font {
+    if let Some(woff_font) = &result.fonts.woff_font {
         let path = default_output_dest(&dest, &font_name, "woff");
         let contents = Arc::clone(woff_font);
         tasks.spawn(async move { write_output_file(path, &*contents).await });
     }
 
-    if let Some(woff2_font) = &result.woff2_font {
+    if let Some(woff2_font) = &result.fonts.woff2_font {
         let path = default_output_dest(&dest, &font_name, "woff2");
         let contents = Arc::clone(woff2_font);
         tasks.spawn(async move { write_output_file(path, &*contents).await });
     }
 
-    if let Some(eot_font) = &result.eot_font {
+    if let Some(eot_font) = &result.fonts.eot_font {
         let path = default_output_dest(&dest, &font_name, "eot");
         let contents = Arc::clone(eot_font);
         tasks.spawn(async move { write_output_file(path, &*contents).await });

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -352,48 +352,59 @@ pub(crate) struct CachedTemplateData {
     pub(crate) render_cache: Mutex<RenderCache>,
 }
 
+/// Rendered bytes for each requested output format. Held by [`GenerateWebfontsResult`] and
+/// produced by the generator's format pipeline; grouping them lets an incremental regenerate
+/// refresh every format in a single assignment.
+#[derive(Default)]
+pub(crate) struct FontOutputs {
+    pub(crate) svg_font: Option<Arc<String>>,
+    pub(crate) ttf_font: Option<Arc<Vec<u8>>>,
+    pub(crate) woff_font: Option<Arc<Vec<u8>>>,
+    pub(crate) woff2_font: Option<Arc<Vec<u8>>>,
+    pub(crate) eot_font: Option<Arc<Vec<u8>>>,
+}
+
 /// Result of a successful `generateWebfonts` call. Exposes the generated
 /// font bytes (or `null` for formats that were not requested) and methods to
 /// render the CSS and HTML preview.
 #[cfg_attr(feature = "napi", napi)]
 pub struct GenerateWebfontsResult {
+    pub(crate) cached: OnceLock<Result<CachedTemplateData, String>>,
     pub(crate) css_context: Option<Map<String, Value>>,
-    pub(crate) eot_font: Option<Arc<Vec<u8>>>,
+    pub(crate) fonts: FontOutputs,
     pub(crate) html_context: Option<Map<String, Value>>,
     pub(crate) options: ResolvedGenerateWebfontsOptions,
     pub(crate) source_files: Vec<LoadedSvgFile>,
-    pub(crate) svg_font: Option<Arc<String>>,
-    pub(crate) ttf_font: Option<Arc<Vec<u8>>>,
-    pub(crate) woff2_font: Option<Arc<Vec<u8>>>,
-    pub(crate) woff_font: Option<Arc<Vec<u8>>>,
-    pub(crate) cached: OnceLock<Result<CachedTemplateData, String>>,
 }
 
 // Pure Rust getters (always available)
 impl GenerateWebfontsResult {
     /// Returns the EOT font bytes, if generated.
     pub fn eot_bytes(&self) -> Option<&[u8]> {
-        self.eot_font.as_ref().map(|v| v.as_ref().as_slice())
+        self.fonts.eot_font.as_ref().map(|v| v.as_ref().as_slice())
     }
 
     /// Returns the SVG font string, if generated.
     pub fn svg_string(&self) -> Option<&str> {
-        self.svg_font.as_ref().map(|v| v.as_ref().as_str())
+        self.fonts.svg_font.as_ref().map(|v| v.as_ref().as_str())
     }
 
     /// Returns the TTF font bytes, if generated.
     pub fn ttf_bytes(&self) -> Option<&[u8]> {
-        self.ttf_font.as_ref().map(|v| v.as_ref().as_slice())
+        self.fonts.ttf_font.as_ref().map(|v| v.as_ref().as_slice())
     }
 
     /// Returns the WOFF font bytes, if generated.
     pub fn woff_bytes(&self) -> Option<&[u8]> {
-        self.woff_font.as_ref().map(|v| v.as_ref().as_slice())
+        self.fonts.woff_font.as_ref().map(|v| v.as_ref().as_slice())
     }
 
     /// Returns the WOFF2 font bytes, if generated.
     pub fn woff2_bytes(&self) -> Option<&[u8]> {
-        self.woff2_font.as_ref().map(|v| v.as_ref().as_slice())
+        self.fonts
+            .woff2_font
+            .as_ref()
+            .map(|v| v.as_ref().as_slice())
     }
 
     pub(crate) fn get_cached_io(&self) -> std::io::Result<&CachedTemplateData> {
@@ -561,7 +572,8 @@ impl GenerateWebfontsResult {
     /// EOT font bytes, or `null` if EOT was not in `types`.
     #[napi(getter)]
     pub fn eot(&self) -> Option<Uint8Array> {
-        self.eot_font
+        self.fonts
+            .eot_font
             .as_ref()
             .map(|v| Uint8Array::from(v.as_ref().clone()))
     }
@@ -569,13 +581,14 @@ impl GenerateWebfontsResult {
     /// SVG font XML string, or `null` if SVG was not in `types`.
     #[napi(getter)]
     pub fn svg(&self) -> Option<String> {
-        self.svg_font.as_ref().map(|v| v.as_ref().clone())
+        self.fonts.svg_font.as_ref().map(|v| v.as_ref().clone())
     }
 
     /// TTF font bytes, or `null` if TTF was not in `types`.
     #[napi(getter)]
     pub fn ttf(&self) -> Option<Uint8Array> {
-        self.ttf_font
+        self.fonts
+            .ttf_font
             .as_ref()
             .map(|v| Uint8Array::from(v.as_ref().clone()))
     }
@@ -583,7 +596,8 @@ impl GenerateWebfontsResult {
     /// WOFF2 font bytes, or `null` if WOFF2 was not in `types`.
     #[napi(getter)]
     pub fn woff2(&self) -> Option<Uint8Array> {
-        self.woff2_font
+        self.fonts
+            .woff2_font
             .as_ref()
             .map(|v| Uint8Array::from(v.as_ref().clone()))
     }
@@ -591,7 +605,8 @@ impl GenerateWebfontsResult {
     /// WOFF font bytes, or `null` if WOFF was not in `types`.
     #[napi(getter)]
     pub fn woff(&self) -> Option<Uint8Array> {
-        self.woff_font
+        self.fonts
+            .woff_font
             .as_ref()
             .map(|v| Uint8Array::from(v.as_ref().clone()))
     }
@@ -698,14 +713,10 @@ mod tests {
         let result = GenerateWebfontsResult {
             cached: std::sync::OnceLock::new(),
             css_context: None,
-            eot_font: None,
+            fonts: FontOutputs::default(),
             html_context: None,
             options: resolved,
             source_files,
-            svg_font: None,
-            ttf_font: None,
-            woff2_font: None,
-            woff_font: None,
         };
 
         if let Some(dir) = cleanup_dir {
@@ -971,14 +982,10 @@ mod tests {
         GenerateWebfontsResult {
             cached: std::sync::OnceLock::new(),
             css_context: None,
-            eot_font: None,
+            fonts: FontOutputs::default(),
             html_context: None,
             options: resolved,
             source_files,
-            svg_font: None,
-            ttf_font: None,
-            woff2_font: None,
-            woff_font: None,
         }
     }
 


### PR DESCRIPTION
Split the "from prepared glyphs onward" tail — format derivation (svg/ttf → woff/woff2/eot) — into a standalone build_font_outputs function, and group the five font byte fields into a FontOutputs struct that GenerateWebfontsResult now composes. generate_webfonts_sync prepares the glyph set once and delegates.

Pure refactor, no behavior change: the byte-deterministic snapshots and the full Rust/JS suites are unchanged, and the generated binding.d.ts (API + JSDoc) is byte-identical. The font fields stay behind the same napi getters, so the JS result shape is untouched. This isolates the byte-producing tail and gives an incremental regenerate path a single `result.fonts = build_font_outputs(...)` to refresh every format without duplicating the pipeline.