### PR TITLE
feat: add incremental webfont regeneration

### DIFF
--- a/packages/docs/webfont-generator/node.md
+++ b/packages/docs/webfont-generator/node.md
@@ -174,6 +174,12 @@ const cssCustom = result.generateCss({ woff2: '/fonts/icons.woff2' });
 - Default: `true`
 - Description: Scale icons to the height of the tallest icon.
 
+### `incremental`
+
+- Type: `boolean`
+- Default: `false`
+- Description: Retain parsed glyph data on the result so [`regenerate()`](#regenerate-changes) can rebuild after file changes without re-parsing the glyphs that didn't change. Enable for watch/dev; leave it off for one-shot builds so the parsed geometry isn't held in memory.
+
 ### `fixedWidth`
 
 - Type: `boolean`
@@ -311,6 +317,32 @@ Each font format is available as a property on the result. Formats that were not
 
 - Type: `(urls?: Partial<Record<FontType, string>>) => string`
 - Description: Returns the rendered HTML preview string. Pass `urls` to override font URLs in the embedded stylesheet.
+
+### `regenerate(files, changes)`
+
+- Type: `(files: string[], changes: GlyphChangeEntry[]) => void`
+- Requires: the result was produced with [`incremental: true`](#incremental) (throws otherwise).
+- Description: Rebuilds every requested font format after a batch of file changes, reusing cached geometry for the glyphs that didn't change (and reusing the rendered CSS/HTML when the glyph names and codepoints are unchanged). `files` is the complete file set after the change, in the order a fresh build would use (e.g. your glob result); the rebuilt glyphs are ordered to match it, so the result is byte-identical to a fresh `generateWebfonts()` of that set — additions included. Any file omitted from `files` is dropped; added/changed files named in `changes` are read from disk and re-parsed. Outputs are refreshed in memory, and — when the result was created with [`writeFiles: true`](#writefiles) — refreshed fonts are written to disk too, while unchanged CSS/HTML companion files are skipped. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run by the synchronous method. Intended for dev/watch rebuilds.
+
+```ts
+let files = ['/icons/add.svg', '/icons/search.svg'];
+const result = await generateWebfonts({ files, dest, incremental: true });
+// ...on a watch event:
+result.regenerate(files, [{ path: '/icons/add.svg', changeType: 'changed' }]);
+result.woff2; // refreshed bytes
+```
+
+Each entry is a `GlyphChangeEntry`:
+
+```ts
+interface GlyphChangeEntry {
+    path: string;
+    changeType: 'added' | 'changed' | 'removed';
+    // Resolved glyph name if you apply a custom rename. Added files default to
+    // the file stem; changed files default to the current name; removed files ignore it.
+    name?: string;
+}
+```
 
 ## Templates
 

--- a/packages/docs/webfont-generator/rust.md
+++ b/packages/docs/webfont-generator/rust.md
@@ -113,38 +113,39 @@ let result = webfont_generator::generate_sync(options, Some(rename)).unwrap();
 
 All fields except `dest` and `files` are optional and implement `Default`.
 
-| Field                   | Type                           | Default                | Description                          |
-| ----------------------- | ------------------------------ | ---------------------- | ------------------------------------ |
-| `dest`                  | `String`                       | --                     | Output directory (required)          |
-| `files`                 | `Vec<String>`                  | --                     | SVG file paths (required)            |
-| `font_name`             | `Option<String>`               | `"iconfont"`           | Font family name                     |
-| `types`                 | `Option<Vec<FontType>>`        | `[Eot, Woff, Woff2]`   | Font formats to generate             |
-| `order`                 | `Option<Vec<FontType>>`        | Filtered default order | `@font-face` src order               |
-| `css`                   | `Option<bool>`                 | `true`                 | Generate CSS file                    |
-| `html`                  | `Option<bool>`                 | `false`                | Generate HTML preview                |
-| `write_files`           | `Option<bool>`                 | `true`                 | Write output to disk                 |
-| `css_template`          | `Option<String>`               | Built-in template      | Custom Handlebars CSS template path  |
-| `html_template`         | `Option<String>`               | Built-in template      | Custom Handlebars HTML template path |
-| `css_fonts_url`         | `Option<String>`               | Relative path          | URL prefix for fonts in CSS          |
-| `css_dest`              | `Option<String>`               | `dest/fontName.css`    | CSS output path                      |
-| `html_dest`             | `Option<String>`               | `dest/fontName.html`   | HTML output path                     |
-| `codepoints`            | `Option<HashMap<String, u32>>` | Empty                  | Explicit glyph codepoints            |
-| `start_codepoint`       | `Option<u32>`                  | `0xF101`               | Starting auto-codepoint              |
-| `font_height`           | `Option<f64>`                  | --                     | Explicit font height                 |
-| `ascent`                | `Option<f64>`                  | --                     | Font ascent                          |
-| `descent`               | `Option<f64>`                  | --                     | Font descent                         |
-| `normalize`             | `Option<bool>`                 | `true`                 | Normalize glyph heights              |
-| `fixed_width`           | `Option<bool>`                 | --                     | Monospace font                       |
-| `center_horizontally`   | `Option<bool>`                 | --                     | Center glyphs horizontally           |
-| `center_vertically`     | `Option<bool>`                 | --                     | Center glyphs vertically             |
-| `ligature`              | `Option<bool>`                 | `true`                 | Enable ligatures                     |
-| `round`                 | `Option<f64>`                  | --                     | Path rounding precision              |
-| `preserve_aspect_ratio` | `Option<bool>`                 | --                     | Preserve SVG aspect ratio            |
-| `optimize_output`       | `Option<bool>`                 | --                     | Optimize SVG output                  |
-| `font_style`            | `Option<String>`               | --                     | CSS `font-style` value               |
-| `font_weight`           | `Option<String>`               | --                     | CSS `font-weight` value              |
-| `format_options`        | `Option<FormatOptions>`        | --                     | Per-format options                   |
-| `template_options`      | `Option<Map<String, Value>>`   | --                     | Extra template context               |
+| Field                   | Type                           | Default                | Description                           |
+| ----------------------- | ------------------------------ | ---------------------- | ------------------------------------- |
+| `dest`                  | `String`                       | --                     | Output directory (required)           |
+| `files`                 | `Vec<String>`                  | --                     | SVG file paths (required)             |
+| `font_name`             | `Option<String>`               | `"iconfont"`           | Font family name                      |
+| `types`                 | `Option<Vec<FontType>>`        | `[Eot, Woff, Woff2]`   | Font formats to generate              |
+| `order`                 | `Option<Vec<FontType>>`        | Filtered default order | `@font-face` src order                |
+| `css`                   | `Option<bool>`                 | `true`                 | Generate CSS file                     |
+| `html`                  | `Option<bool>`                 | `false`                | Generate HTML preview                 |
+| `write_files`           | `Option<bool>`                 | `true`                 | Write output to disk                  |
+| `css_template`          | `Option<String>`               | Built-in template      | Custom Handlebars CSS template path   |
+| `html_template`         | `Option<String>`               | Built-in template      | Custom Handlebars HTML template path  |
+| `css_fonts_url`         | `Option<String>`               | Relative path          | URL prefix for fonts in CSS           |
+| `css_dest`              | `Option<String>`               | `dest/fontName.css`    | CSS output path                       |
+| `html_dest`             | `Option<String>`               | `dest/fontName.html`   | HTML output path                      |
+| `codepoints`            | `Option<HashMap<String, u32>>` | Empty                  | Explicit glyph codepoints             |
+| `start_codepoint`       | `Option<u32>`                  | `0xF101`               | Starting auto-codepoint               |
+| `font_height`           | `Option<f64>`                  | --                     | Explicit font height                  |
+| `ascent`                | `Option<f64>`                  | --                     | Font ascent                           |
+| `descent`               | `Option<f64>`                  | --                     | Font descent                          |
+| `normalize`             | `Option<bool>`                 | `true`                 | Normalize glyph heights               |
+| `incremental`           | `Option<bool>`                 | `false`                | Retain parsed glyphs for `regenerate` |
+| `fixed_width`           | `Option<bool>`                 | --                     | Monospace font                        |
+| `center_horizontally`   | `Option<bool>`                 | --                     | Center glyphs horizontally            |
+| `center_vertically`     | `Option<bool>`                 | --                     | Center glyphs vertically              |
+| `ligature`              | `Option<bool>`                 | `true`                 | Enable ligatures                      |
+| `round`                 | `Option<f64>`                  | --                     | Path rounding precision               |
+| `preserve_aspect_ratio` | `Option<bool>`                 | --                     | Preserve SVG aspect ratio             |
+| `optimize_output`       | `Option<bool>`                 | --                     | Optimize SVG output                   |
+| `font_style`            | `Option<String>`               | --                     | CSS `font-style` value                |
+| `font_weight`           | `Option<String>`               | --                     | CSS `font-weight` value               |
+| `format_options`        | `Option<FormatOptions>`        | --                     | Per-format options                    |
+| `template_options`      | `Option<Map<String, Value>>`   | --                     | Extra template context                |
 
 ## `FontType`
 
@@ -183,6 +184,37 @@ Methods:
 | `generate_html_pure(urls?)` | `io::Result<String>` | Render HTML preview with optional URL overrides |
 
 Both methods accept `Option<HashMap<FontType, String>>` for the `urls` parameter. Results are cached internally for repeated calls with the same arguments.
+
+### Incremental rebuild
+
+| Method                               | Return type      | Description                                          |
+| ------------------------------------ | ---------------- | ---------------------------------------------------- |
+| `regenerate(ordered_paths, changes)` | `io::Result<()>` | Rebuild after file changes, reusing unchanged glyphs |
+
+Requires the result to have been generated with `incremental: Some(true)` (errors otherwise).
+`ordered_paths: &[String]` is the complete file set after the changes, in the order a fresh build
+would use (e.g. the glob result); the rebuilt glyphs are ordered to match it, so the result is
+byte-identical to a fresh build of that set — additions included, even when they sort before
+existing glyphs. Any path absent from `ordered_paths` is dropped. `changes: &[(String, GlyphChange)]`
+names the affected files: added/changed files are re-read from disk. Every format is refreshed in
+memory, and — when the result was built with `write_files` — refreshed fonts are written to disk
+too, while unchanged CSS/HTML companion files are skipped. Rendered
+CSS/HTML is reused when glyph names and codepoints are unchanged.
+
+For Node.js results, `regenerate()` errors if the initial build used `cssContext` or `htmlContext`
+callbacks because the synchronous method cannot re-run JavaScript callbacks during the rebuild.
+
+```rust
+pub enum GlyphChange {
+    Added { name: String },           // new file; `name` is the resolved glyph name
+    Changed { name: Option<String> }, // content changed; `name` overrides the glyph name
+    Removed,                          // file deleted
+}
+
+// result built with `incremental: Some(true)`
+let files = vec!["icons/add.svg".to_owned(), "icons/remove.svg".to_owned()];
+result.regenerate(&files, &[("icons/add.svg".to_owned(), GlyphChange::Changed { name: None })])?;
+```
 
 ## Full API reference
 

--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -1,5 +1,7 @@
 import { constants } from 'node:fs';
-import { access, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join as pathJoin } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import type { IndexHtmlTransformContext, InlineConfig, PreviewServer, ViteDevServer } from 'vite';
@@ -613,6 +615,27 @@ describe('serve - generateFiles writes css and html to disk in dev', () => {
     ] as const)('writes the generated %s file to disk', async (_kind, urlOf) => {
         await expect(access(urlOf(), constants.F_OK)).resolves.not.toThrow();
     });
+
+    it.each(['css', 'html'] as const)('supports writing only %s in dev', async kind => {
+        const singleKindArtifacts = new URL(`webfont-test/serve-${kind}-only-artifacts/`, root);
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [
+                viteSvgToWebfont({
+                    context: webfontFolder,
+                    dest: fileURLToNormalizedPath(singleKindArtifacts),
+                    fontName: `serve-${kind}-only-test`,
+                    generateFiles: kind,
+                }),
+            ],
+        });
+        const singleKindServer = await created.listen();
+        await singleKindServer.close();
+        await expect(access(new URL(`serve-${kind}-only-test.${kind}`, singleKindArtifacts), constants.F_OK)).resolves.not.toThrow();
+        await rm(singleKindArtifacts, { recursive: true, force: true });
+    });
 });
 
 describe('build:preloadFormats inlined-asset short-circuit', () => {
@@ -688,7 +711,7 @@ describe('serve - regenerates css when a new svg is added', () => {
 
     it('reloads the virtual css module after a new svg appears', async () => {
         await writeFile(watcherSvgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h1024v1024H0z"/></svg>');
-        await watcherHandler({ eventType: 'rename', filename });
+        await watcherHandler({ path: pathJoin(webfontFolder, filename), kind: 'added' });
         await waitForCssReload;
         expect(reloadedIds.some(id => id.includes('vite-svg-2-webfont.css'))).toBe(true);
     });
@@ -727,9 +750,227 @@ describe('serve - swallows reloadModule rejection from the watcher', () => {
 
     it('does not crash the watcher when reloadModule rejects', async () => {
         await writeFile(watcherSvgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h512v512H0z"/></svg>');
-        await watcherHandler({ eventType: 'rename', filename });
+        await watcherHandler({ path: pathJoin(webfontFolder, filename), kind: 'added' });
         await waitForReloadCalled;
         expect(rejectingReload).toHaveBeenCalledOnce();
+    });
+});
+
+describe('serve - incrementally regenerates on a content edit', () => {
+    type RegenResult = Awaited<ReturnType<typeof generateWebfontsMock>>;
+    const reloadedIds: string[] = [];
+    const { promise: waitForCssReload, resolve: markCssReloaded } = Promise.withResolvers<void>();
+    let watcherHandler: Parameters<typeof setupWatcherMock>[2];
+    const regenerateCalls: Array<Parameters<RegenResult['regenerate']>> = [];
+    let server: ViteDevServer;
+
+    beforeAll(async () => {
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
+        // Wrap the result's `regenerate` to prove the change goes through the incremental path
+        // (not the full-rebuild fallback) for a content edit, and to capture its arguments.
+        const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
+        generateWebfontsMock.mockImplementationOnce(async options => {
+            const result = await realGen(options);
+            const original = result.regenerate.bind(result);
+            result.regenerate = (...args: Parameters<RegenResult['regenerate']>) => {
+                regenerateCalls.push(args);
+                return original(...args);
+            };
+            return result;
+        });
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder })],
+        });
+        const originalReload = created.reloadModule.bind(created);
+        created.reloadModule = async mod => {
+            reloadedIds.push(mod.id ?? '');
+            if (mod.id?.includes('vite-svg-2-webfont.css')) markCssReloaded();
+            return originalReload(mod);
+        };
+        server = await created.listen();
+        await fetchBufferContent(server, '/iconfont.woff2');
+        await fetchTextContent(server, '/@id/__x00__virtual:vite-svg-2-webfont.css');
+    });
+
+    afterAll(async () => {
+        await server.close();
+    });
+
+    it('reuses cached glyphs via regenerate and reloads the css module', async () => {
+        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+        await waitForCssReload;
+        expect(regenerateCalls).toHaveLength(1);
+        const [files, changes] = regenerateCalls[0]!;
+        expect(files).toContain(pathJoin(webfontFolder, 'add.svg'));
+        expect(changes).toEqual([{ path: pathJoin(webfontFolder, 'add.svg'), changeType: 'changed' }]);
+        expect(reloadedIds.some(id => id.includes('vite-svg-2-webfont.css'))).toBe(true);
+    });
+
+    it('passes removed watcher events through regenerate', async () => {
+        await watcherHandler({ path: pathJoin(webfontFolder, '__already-removed__.svg'), kind: 'removed' });
+
+        expect(regenerateCalls.at(-1)?.[1]).toEqual([{ path: pathJoin(webfontFolder, '__already-removed__.svg'), changeType: 'removed' }]);
+    });
+});
+
+describe('serve - skips unchanged dev css/html writes', () => {
+    let watcherHandler: Parameters<typeof setupWatcherMock>[2];
+    let server: ViteDevServer;
+
+    beforeAll(async () => {
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, generateFiles: ['css', 'html'] })],
+        });
+        server = await created.listen();
+    });
+
+    afterAll(async () => {
+        await server.close();
+    });
+
+    it('does not rewrite dev companion files when rendered output is unchanged', async () => {
+        const writesBefore = ensureDirExistsAndWriteFileMock.mock.calls.length;
+        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+
+        expect(ensureDirExistsAndWriteFileMock).toHaveBeenCalledTimes(writesBefore);
+    });
+});
+
+describe('serve - falls back to full regenerate when incremental is unavailable', () => {
+    const reloadedIds: string[] = [];
+    const { promise: waitForCssReload, resolve: markCssReloaded } = Promise.withResolvers<void>();
+    let watcherHandler: Parameters<typeof setupWatcherMock>[2];
+    let server: ViteDevServer;
+
+    beforeAll(async () => {
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, cssContext: () => undefined })],
+        });
+        const originalReload = created.reloadModule.bind(created);
+        created.reloadModule = async mod => {
+            reloadedIds.push(mod.id ?? '');
+            if (mod.id?.includes('vite-svg-2-webfont.css')) markCssReloaded();
+            return originalReload(mod);
+        };
+        server = await created.listen();
+        await fetchBufferContent(server, '/iconfont.woff2');
+        await fetchTextContent(server, '/@id/__x00__virtual:vite-svg-2-webfont.css');
+    });
+
+    afterAll(async () => {
+        await server.close();
+    });
+
+    it('full-regenerates and reloads when cssContext disables incremental', async () => {
+        const callsBefore = generateWebfontsMock.mock.calls.length;
+        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+        await waitForCssReload;
+
+        expect(generateWebfontsMock).toHaveBeenCalledTimes(callsBefore + 1);
+        expect(reloadedIds.some(id => id.includes('vite-svg-2-webfont.css'))).toBe(true);
+    });
+});
+
+describe('serve - falls back when regenerate throws', () => {
+    type RegenResult = Awaited<ReturnType<typeof generateWebfontsMock>>;
+    const reloadedIds: string[] = [];
+    const { promise: waitForCssReload, resolve: markCssReloaded } = Promise.withResolvers<void>();
+    let watcherHandler: Parameters<typeof setupWatcherMock>[2];
+    let server: ViteDevServer;
+
+    beforeAll(async () => {
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
+        const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
+        generateWebfontsMock.mockImplementationOnce(async options => {
+            const result = await realGen(options);
+            result.regenerate = (() => {
+                throw new Error('intentional regenerate failure');
+            }) as RegenResult['regenerate'];
+            return result;
+        });
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder })],
+        });
+        const originalReload = created.reloadModule.bind(created);
+        created.reloadModule = async mod => {
+            reloadedIds.push(mod.id ?? '');
+            if (mod.id?.includes('vite-svg-2-webfont.css')) markCssReloaded();
+            return originalReload(mod);
+        };
+        server = await created.listen();
+        await fetchBufferContent(server, '/iconfont.woff2');
+        await fetchTextContent(server, '/@id/__x00__virtual:vite-svg-2-webfont.css');
+    });
+
+    afterAll(async () => {
+        await server.close();
+    });
+
+    it('full-regenerates and skips the normal incremental reload path', async () => {
+        const callsBefore = generateWebfontsMock.mock.calls.length;
+        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+        await waitForCssReload;
+
+        expect(generateWebfontsMock).toHaveBeenCalledTimes(callsBefore + 1);
+        expect(reloadedIds.some(id => id.includes('vite-svg-2-webfont.css'))).toBe(true);
+    });
+});
+
+describe('serve - writes refreshed fonts to disk when generateFiles includes fonts', () => {
+    const svgName = '__regen-disk-test__.svg';
+    const svgUrl = new URL(`webfont-test/svg/${svgName}`, root);
+    let dest: string;
+    let watcherHandler: Parameters<typeof setupWatcherMock>[2];
+    let server: ViteDevServer;
+
+    beforeAll(async () => {
+        dest = await mkdtemp(pathJoin(tmpdir(), 'vsw-regen-disk-'));
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, dest, fontName: 'iconfont', generateFiles: 'fonts', types: ['woff2'] })],
+        });
+        server = await created.listen();
+    });
+
+    afterAll(async () => {
+        await Promise.all([server.close(), rm(svgUrl, { force: true }), rm(dest, { force: true, recursive: true })]);
+    });
+
+    it('updates the on-disk font after a watched add', async () => {
+        const woff2Path = pathJoin(dest, 'iconfont.woff2');
+        // The initial build wrote the font to disk; capture it, then add an icon via the watcher.
+        const before = await readFile(woff2Path);
+        await writeFile(svgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h1024v1024H0z"/></svg>');
+        await watcherHandler({ path: pathJoin(webfontFolder, svgName), kind: 'added' });
+        const after = await readFile(woff2Path);
+        expect(after).not.toEqual(before);
     });
 });
 
@@ -831,5 +1072,46 @@ describe('WOFF2 compression quality by mode', () => {
         });
 
         expect(captured.options?.formatOptions?.woff2?.compressionQuality).toBeUndefined();
+    });
+
+    it('serve mode opts into incremental so watch rebuilds can reuse glyphs', async () => {
+        const captured = captureNextGenerateOptions();
+        const createdServer = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+        const server = await createdServer.listen();
+        await server.close();
+
+        expect(captured.options?.incremental).toBe(true);
+    });
+
+    it('serve mode skips incremental when cssContext is configured', async () => {
+        const captured = captureNextGenerateOptions();
+        const createdServer = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'], cssContext: () => undefined })],
+        });
+        const server = await createdServer.listen();
+        await server.close();
+
+        expect(captured.options?.incremental).toBeUndefined();
+    });
+
+    it('build mode does not request incremental', async () => {
+        const captured = captureNextGenerateOptions();
+        await build({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            build: { write: false },
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+
+        expect(captured.options?.incremental).toBeUndefined();
     });
 });

--- a/packages/vite-svg-2-webfont/src/index.ts
+++ b/packages/vite-svg-2-webfont/src/index.ts
@@ -3,7 +3,8 @@ import type { ModuleGraph, ModuleNode, Plugin } from 'vite';
 import { setupWatcher, MIME_TYPES, ensureDirExistsAndWriteFile, getTmpDir, getBufferHash, rmDir } from './utils';
 import { parseOptions, parseFiles, parsePreloadFormatsOption } from './optionParser';
 import * as templatesImport from '@atlowchemi/webfont-generator/templates';
-import type { FontType, GenerateWebfontsResult } from '@atlowchemi/webfont-generator';
+import type { WatchedChange } from './utils';
+import type { FontType, GenerateWebfontsResult, GlyphChangeEntry } from '@atlowchemi/webfont-generator';
 import type { IconPluginOptions } from './optionParser';
 import type { GeneratedWebfont } from './types/generatedWebfont';
 import type { PublicApi } from './types/publicApi';
@@ -20,6 +21,9 @@ function getVirtualModuleId<T extends string>(moduleId: T): `virtual:${T}` {
 function getResolvedVirtualModuleId<T extends string>(virtualModuleId: T): `\0${T}` {
     return `\0${virtualModuleId}`;
 }
+
+const toGlyphChange = (change: WatchedChange): GlyphChangeEntry =>
+    change.kind === 'removed' ? { path: change.path, changeType: 'removed' } : { path: change.path, changeType: change.kind };
 
 /** Ensure vp doesn't crash locally and in CI if the native binding doesn't exist yet.  */
 let _generateWebfonts: (typeof import('@atlowchemi/webfont-generator'))['generateWebfonts'] | undefined;
@@ -84,6 +88,39 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         }) as U;
     };
 
+    let lastCssOutput: string | undefined;
+    let lastHtmlOutput: string | undefined;
+
+    /** Write the companion CSS/HTML to disk in dev, skipping any file whose rendered output is unchanged. */
+    const writeDevFiles = async () => {
+        if (isBuild || processedOptions.writeFiles || !(processedOptions.css || processedOptions.html)) {
+            return;
+        }
+        const tasks: Array<Promise<void>> = [];
+        if (processedOptions.css) {
+            const css = inline(generatedFonts!.generateCss());
+            if (css !== lastCssOutput) {
+                lastCssOutput = css;
+                tasks.push(ensureDirExistsAndWriteFile(css, processedOptions.cssDest));
+            }
+        }
+        if (processedOptions.html) {
+            const html = generatedFonts!.generateHtml();
+            if (html !== lastHtmlOutput) {
+                lastHtmlOutput = html;
+                tasks.push(ensureDirExistsAndWriteFile(html, processedOptions.htmlDest));
+            }
+        }
+        await Promise.all(tasks);
+    };
+
+    const reloadVirtualModule = () => {
+        const module = _moduleGraph?.getModuleById(resolvedVirtualModuleId);
+        if (module && _reloadModule) {
+            _reloadModule(module).catch(() => null);
+        }
+    };
+
     const generate = async (updateFiles?: boolean) => {
         if (updateFiles) {
             processedOptions.files = parseFiles(options);
@@ -93,19 +130,31 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         }
         const generateWebfonts = await getGenerateWebfonts();
         generatedFonts = await generateWebfonts(processedOptions);
-        const hasFilesToSave = !processedOptions.writeFiles && (processedOptions.css || processedOptions.html);
-        if (!isBuild && hasFilesToSave) {
-            await Promise.all([
-                processedOptions.css && ensureDirExistsAndWriteFile(inline(generatedFonts.generateCss()), processedOptions.cssDest),
-                processedOptions.html && ensureDirExistsAndWriteFile(generatedFonts.generateHtml(), processedOptions.htmlDest),
-            ]);
-        }
+        await writeDevFiles();
         if (updateFiles) {
-            const module = _moduleGraph?.getModuleById(resolvedVirtualModuleId);
-            if (module && _reloadModule) {
-                _reloadModule(module).catch(() => null);
-            }
+            reloadVirtualModule();
         }
+    };
+
+    /** Rebuild on a watch event, incrementally reusing cached glyphs, else a full rebuild. */
+    const regenerateFromWatch = async (change: WatchedChange) => {
+        // Reuse cached glyphs, handing the engine the fresh glob order so additions land in their
+        // correct position (byte-identical to a fresh build). When `writeFiles` is set, `regenerate`
+        // refreshes the on-disk fonts itself; otherwise `writeDevFiles` handles the CSS/HTML below.
+        if (!generatedFonts || !processedOptions.incremental) {
+            await generate(true);
+            return;
+        }
+        try {
+            const orderedFiles = parseFiles(options);
+            processedOptions.files = orderedFiles;
+            generatedFonts.regenerate(orderedFiles, [toGlyphChange(change)]);
+        } catch {
+            await generate(true);
+            return;
+        }
+        await writeDevFiles();
+        reloadVirtualModule();
     };
     return {
         name: 'vite-svg-2-webfont',
@@ -117,11 +166,19 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         },
         configResolved(_config) {
             isBuild = _config.command === 'build';
-            // In dev, default WOFF2 to a faster Brotli quality unless the user pinned one.
-            // Rebuilds run on every icon change and the dev-served font is never shipped, so the
-            // marginally larger output is irrelevant while the ~2x faster encode speeds up rebuilds.
-            if (!isBuild && processedOptions.formatOptions.woff2?.compressionQuality === undefined) {
-                processedOptions.formatOptions.woff2 = { ...processedOptions.formatOptions.woff2, compressionQuality: 10 };
+            if (!isBuild) {
+                // Retain parsed glyphs so watch rebuilds can reuse them via `result.regenerate(...)`.
+                // cssContext runs in JS during generation; regenerate is sync, so skip the
+                // incremental path when callbacks would need to be replayed after a rebuild.
+                if (!processedOptions.cssContext) {
+                    processedOptions.incremental = true;
+                }
+                // In dev, default WOFF2 to a faster Brotli quality unless the user pinned one.
+                // Rebuilds run on every icon change and the dev-served font is never shipped, so the
+                // marginally larger output is irrelevant while the ~2x faster encode speeds up rebuilds.
+                if (processedOptions.formatOptions.woff2?.compressionQuality === undefined) {
+                    processedOptions.formatOptions.woff2 = { ...processedOptions.formatOptions.woff2, compressionQuality: 10 };
+                }
             }
         },
         resolveId(id) {
@@ -177,7 +234,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         },
         async buildStart() {
             if (!isBuild) {
-                setupWatcher(options.context, ac.signal, () => generate(true)).catch(() => null);
+                setupWatcher(options.context, ac.signal, change => regenerateFromWatch(change)).catch(() => null);
             }
             await generate();
             if (isBuild && !options.inline) {

--- a/packages/vite-svg-2-webfont/src/utils.test.ts
+++ b/packages/vite-svg-2-webfont/src/utils.test.ts
@@ -31,32 +31,38 @@ describe('utils', () => {
         });
 
         const validFileName = 'ex.svg';
-        const onIconAdded = vi.fn();
+        const onChange = vi.fn();
         const doesFileExist = vi.fn();
 
-        it("doesn't execute callback for file changes", async () => {
-            await utils.handleWatchEvent('', { eventType: 'change', filename: validFileName }, onIconAdded, doesFileExist);
-            expect(doesFileExist).not.toHaveBeenCalled();
-            expect(onIconAdded).not.toHaveBeenCalled();
-        });
-
         it("doesn't execute callback for non svg files", async () => {
-            await utils.handleWatchEvent('', { eventType: 'rename', filename: 'notsvg.png' }, onIconAdded, doesFileExist);
+            await utils.handleWatchEvent('', { eventType: 'rename', filename: 'notsvg.png' }, onChange, doesFileExist);
             expect(doesFileExist).not.toHaveBeenCalled();
-            expect(onIconAdded).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalled();
         });
 
-        it("doesn't execute callback for non existent files", async () => {
-            await utils.handleWatchEvent('', { eventType: 'rename', filename: validFileName }, onIconAdded, doesFileExist);
+        it("emits a 'removed' event for a change event on a missing file", async () => {
+            await utils.handleWatchEvent('', { eventType: 'change', filename: validFileName }, onChange, doesFileExist);
             expect(doesFileExist).toHaveBeenCalledOnce();
-            expect(onIconAdded).not.toHaveBeenCalled();
+            expect(onChange).toHaveBeenCalledExactlyOnceWith({ path: validFileName, kind: 'removed' });
         });
 
-        it('execute callback for new/renamed file', async () => {
+        it("emits a 'changed' event for an edited file", async () => {
             doesFileExist.mockResolvedValueOnce(true);
-            await utils.handleWatchEvent('', { eventType: 'rename', filename: validFileName }, onIconAdded, doesFileExist);
+            await utils.handleWatchEvent('', { eventType: 'change', filename: validFileName }, onChange, doesFileExist);
+            expect(onChange).toHaveBeenCalledExactlyOnceWith({ path: validFileName, kind: 'changed' });
+        });
+
+        it("emits a 'removed' event for a deleted file", async () => {
+            await utils.handleWatchEvent('', { eventType: 'rename', filename: validFileName }, onChange, doesFileExist);
             expect(doesFileExist).toHaveBeenCalledOnce();
-            expect(onIconAdded).toHaveBeenCalledOnce();
+            expect(onChange).toHaveBeenCalledExactlyOnceWith({ path: validFileName, kind: 'removed' });
+        });
+
+        it("emits an 'added' event for a new/renamed file", async () => {
+            doesFileExist.mockResolvedValueOnce(true);
+            await utils.handleWatchEvent('', { eventType: 'rename', filename: validFileName }, onChange, doesFileExist);
+            expect(doesFileExist).toHaveBeenCalledOnce();
+            expect(onChange).toHaveBeenCalledExactlyOnceWith({ path: validFileName, kind: 'added' });
         });
     });
 
@@ -80,7 +86,7 @@ describe('utils', () => {
             expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
         });
 
-        it('triggers the handler for files that exist', async () => {
+        it('triggers the handler for adds and removes alike', async () => {
             const { watch, access } = fs;
             const event = { eventType: 'rename', filename: 'ex.svg' };
             async function* mock() {
@@ -89,7 +95,7 @@ describe('utils', () => {
                 if (vi.isMockFunction(access)) {
                     access.mockRejectedValueOnce(new Error());
                 }
-                yield event;
+                yield event; // file gone -> still surfaces a 'removed' change
                 yield event;
             }
             if (vi.isMockFunction(watch)) {
@@ -97,7 +103,7 @@ describe('utils', () => {
             }
 
             expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
-            expect(handler).toBeCalledTimes(2);
+            expect(handler).toBeCalledTimes(3);
         });
     });
 

--- a/packages/vite-svg-2-webfont/src/utils.ts
+++ b/packages/vite-svg-2-webfont/src/utils.ts
@@ -25,23 +25,36 @@ export async function doesFileExist(folderPath: string, fileName: string): Promi
     }
 }
 
+/** A normalized SVG change surfaced by the watcher. `path` matches the `parseFiles` output. */
+export type WatchedChange = { path: string; kind: 'added' | 'changed' | 'removed' };
+
 export async function handleWatchEvent(
     folderPath: string,
     { eventType, filename }: FileChangeInfo<string>,
-    onIconAdded: (e: FileChangeInfo<string>) => void | Promise<void>,
+    onChange: (change: WatchedChange) => void | Promise<void>,
     _doesFileExist: typeof doesFileExist = doesFileExist,
 ): Promise<void> {
-    if (eventType !== 'rename' || !filename?.endsWith('.svg') || !(await _doesFileExist(folderPath, filename))) {
+    if (!filename?.endsWith('.svg')) {
         return;
     }
-    await onIconAdded({ eventType, filename });
+    // Match the path shape `parseFiles` produces (`join(context, file)`).
+    const path = pathJoin(folderPath, filename);
+    const exists = await _doesFileExist(folderPath, filename);
+    if (eventType === 'change') {
+        // Content edit. A delete can also surface as 'change' on some platforms, so guard on existence.
+        await onChange({ path, kind: exists ? 'changed' : 'removed' });
+        return;
+    }
+    // 'rename' covers both create and delete; existence disambiguates.
+    await onChange({ path, kind: exists ? 'added' : 'removed' });
 }
 
-export async function setupWatcher(folderPath: string, signal: AbortSignal, handler: (e: FileChangeInfo<string>) => void | Promise<void>): Promise<void> {
+export async function setupWatcher(folderPath: string, signal: AbortSignal, onChange: (change: WatchedChange) => void | Promise<void>): Promise<void> {
     try {
         watcher = watch(folderPath, { signal });
         for await (const event of watcher) {
-            await handleWatchEvent(folderPath, event, handler);
+            // A single failed rebuild (e.g. an unreadable file) must not tear down the watcher.
+            await handleWatchEvent(folderPath, event, onChange).catch(() => undefined);
         }
     } catch (err: unknown) {
         if (err && typeof err === 'object' && 'name' in err && err.name === 'AbortError') {

--- a/packages/webfont-generator/README.md
+++ b/packages/webfont-generator/README.md
@@ -21,10 +21,25 @@ The API is largely compatible with `@vusion/webfonts-generator`, with a few diff
 - `formatOptions` is now strictly typed as `{ svg?: SvgFormatOptions; ttf?: TtfFormatOptions; woff?: WoffFormatOptions; woff2?: Woff2FormatOptions }`. The original accepted arbitrary `{ [format]: unknown }`; the `eot` key is no longer accepted (EOT is derived from the TTF output).
 - A new `optimizeOutput` option runs an SVG path optimizer over each glyph before assembling the font. Defaults to `false`; opt in for smaller output bytes at a small build-time cost. Also available as `formatOptions.svg.optimizeOutput`.
 - `formatOptions.woff2.compressionQuality` sets the Brotli compression quality (0–11) for WOFF2 output. Defaults to `11` (smallest output); lower it (e.g. to `10`) for faster encoding at a marginal size cost.
+- A new `incremental` option (default `false`) retains parsed glyph data on the result so `result.regenerate(files, changes)` can rebuild after file changes without re-parsing the glyphs that didn't change — for dev/watch rebuilds. It refreshes the outputs in memory and, when the result was generated with `writeFiles`, writes refreshed fonts to disk too while skipping unchanged CSS/HTML companion files. You pass the full file set (in the order a fresh build would use) plus what changed; the result is byte-identical to a fresh `generateWebfonts()` of that set, additions included.
 - Generated font binaries (TTF, WOFF, etc.) may differ at the byte level because a different encoder is used, but the fonts are equally valid.
 - CSS, HTML, and template output is identical.
 
 Performance scales better with glyph count — for larger icon sets the native pipeline is significantly faster.
+
+### Incremental regeneration
+
+```js
+let files = ['./icons/home.svg', './icons/search.svg'];
+const result = await generateWebfonts({ files, dest, fontName: 'my-icons', incremental: true });
+
+// On a watch event, rebuild reusing cached geometry for unchanged glyphs. Pass the full file set
+// (in fresh-build order) so additions land in the right position, plus what changed:
+result.regenerate(files, [{ path: './icons/home.svg', changeType: 'changed' }]);
+result.woff2; // refreshed bytes
+```
+
+The first argument is the complete file set after the change, in the order a fresh build would use (e.g. your glob result) — any file omitted from it is dropped. Each change is `{ path, changeType: 'added' | 'changed' | 'removed', name? }`, where `name` is the resolved glyph name if you apply a custom rename; otherwise added files derive their name from the file stem, changed files keep their current name, and removed files ignore it. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run by the synchronous method.
 
 ## Node.js (npm)
 

--- a/packages/webfont-generator/binding.d.ts
+++ b/packages/webfont-generator/binding.d.ts
@@ -29,6 +29,19 @@ export declare class GenerateWebfontsResult {
    * supply are overridden). The result is cached per `urls` value.
    */
   generateHtml(urls?: Partial<Record<FontType, string>>): string
+  /**
+   * Rebuild the font after a batch of file changes, reusing cached glyph geometry for files
+   * whose contents are unchanged. Requires the font to have been generated with
+   * `incremental: true`. `files` is the complete file set after the changes, in the order a
+   * fresh build would use (e.g. the glob result) — the rebuilt glyphs are ordered to match it,
+   * so the output bytes are identical to a fresh `generateWebfonts` of that set. `changes`
+   * describes the affected files: added/changed files are re-read from disk; any file absent
+   * from `files` is dropped. Every requested format is refreshed in memory, and — like
+   * `generateWebfonts` — when the result was built with `writeFiles` enabled the refreshed
+   * fonts are written to disk too, while CSS/HTML companion files are skipped if their rendered
+   * bytes are unchanged since the last write.
+   */
+  regenerate(files: Array<string>, changes: Array<GlyphChangeEntry>): void
 }
 
 /**
@@ -175,6 +188,12 @@ export interface GenerateWebfontsOptions {
   /** Path to a custom Handlebars template for HTML preview generation. */
   htmlTemplate?: string
   /**
+   * Retain parsed glyph data on the result so `regenerate` can rebuild after file changes
+   * without re-parsing unchanged glyphs. Defaults to `false`; enable for watch/dev. One-shot
+   * builds (CLI, production) should leave it off to avoid holding the parsed geometry in memory.
+   */
+  incremental?: boolean
+  /**
    * Explicit output font height in units per em. Overrides the height
    * computed from the source glyphs.
    */
@@ -230,6 +249,23 @@ export interface GenerateWebfontsOptions {
    * in-memory usage. Defaults to `true`.
    */
   writeFiles?: boolean
+}
+
+/**
+ * One entry in the `changes` array passed to the Node binding's `regenerate`. The complete
+ * ordered file list passed alongside it controls final glyph order; this only describes which
+ * files need re-reading, renaming, or removal.
+ */
+export interface GlyphChangeEntry {
+  /** Path of the changed file. */
+  path: string
+  /** What happened to the file. */
+  changeType: 'added' | 'changed' | 'removed'
+  /**
+   * Resolved glyph name (with the caller's `rename` already applied). Optional for `'added'`
+   * and `'changed'` (defaults to the file stem/current name); ignored for `'removed'`.
+   */
+  name?: string
 }
 
 /**

--- a/packages/webfont-generator/index.d.ts
+++ b/packages/webfont-generator/index.d.ts
@@ -3,6 +3,7 @@ import type {
     FormatOptions,
     GenerateWebfontsOptions,
     GenerateWebfontsResult as RawGenerateWebfontsResult,
+    GlyphChangeEntry,
     HtmlContext as RawHtmlContext,
     SvgFormatOptions,
     TtfFormatOptions,
@@ -80,7 +81,7 @@ type FontValue<F extends FontType> = F extends 'svg' ? string : Uint8Array;
  */
 export type GenerateWebfontsResult<T extends FontType = FontType> = {
     [F in FontType]: F extends T ? FontValue<F> : null;
-} & Pick<RawGenerateWebfontsResult, 'generateCss' | 'generateHtml'>;
+} & Pick<RawGenerateWebfontsResult, 'generateCss' | 'generateHtml' | 'regenerate'>;
 
 /**
  * Generate a webfont from a set of SVG files.
@@ -102,6 +103,7 @@ export declare namespace generateWebfonts {
 export {
     FormatOptions,
     GenerateWebfontsOptions,
+    GlyphChangeEntry,
     RawGenerateWebfontsResult,
     SvgFormatOptions,
     /**

--- a/packages/webfont-generator/src/incremental/mod.rs
+++ b/packages/webfont-generator/src/incremental/mod.rs
@@ -1,0 +1,231 @@
+#[cfg(test)]
+mod tests;
+
+use std::io::ErrorKind;
+use std::path::Path;
+
+use crate::svg::{prepare_svg_font_incremental, source_content_hash, svg_options_from_options};
+use crate::types::{GenerateWebfontsResult, GlyphChange, LoadedSvgFile};
+use crate::write::write_generate_webfonts_result_sync;
+use crate::{build_font_outputs, finalize_generate_webfonts_options, validate_glyph_names};
+
+impl GenerateWebfontsResult {
+    /// Rebuild after a batch of file changes, reusing cached glyph geometry for files whose
+    /// contents are unchanged. Requires the result to have been generated with `incremental`
+    /// enabled. `ordered_paths` is the complete file set after the changes, in the order a fresh
+    /// build would use (e.g. the glob result); the rebuilt glyphs are ordered to match it, so
+    /// auto-assigned codepoints and glyph order — and therefore the output bytes — are identical
+    /// to a fresh `generate` of that set, including for additions that sort before existing
+    /// glyphs. `changes` describes what to do per affected file: added/changed files are read from
+    /// disk and re-parsed; any file absent from `ordered_paths` is dropped (an explicit `Removed`
+    /// is optional but harmless). Every requested format is rebuilt in memory, and — matching
+    /// `generate` — when the result was built with `write_files` enabled the refreshed fonts are
+    /// written to disk too, while CSS/HTML companion files are skipped if their rendered bytes are
+    /// unchanged from the previous write. Rendered CSS/HTML is reused when the glyph names and
+    /// codepoints the templates read are unchanged (a content edit), and re-rendered otherwise.
+    ///
+    /// ```rust,no_run
+    /// use webfont_generator::{
+    ///     generate_sync, FontType, GenerateWebfontsOptions, GlyphChange,
+    /// };
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let files = vec![
+    ///     "icons/add.svg".to_owned(),
+    ///     "icons/remove.svg".to_owned(),
+    /// ];
+    /// let mut result = generate_sync(
+    ///     GenerateWebfontsOptions {
+    ///         dest: "dist".to_owned(),
+    ///         files: files.clone(),
+    ///         incremental: Some(true),
+    ///         types: Some(vec![FontType::Woff2]),
+    ///         write_files: Some(false),
+    ///         ..Default::default()
+    ///     },
+    ///     None,
+    /// )?;
+    ///
+    /// result.regenerate(
+    ///     &files,
+    ///     &[(
+    ///         "icons/add.svg".to_owned(),
+    ///         GlyphChange::Changed { name: None },
+    ///     )],
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn regenerate(
+        &mut self,
+        ordered_paths: &[String],
+        changes: &[(String, GlyphChange)],
+    ) -> std::io::Result<()> {
+        if self.css_context.is_some() || self.html_context.is_some() {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "regenerate is not supported for results generated with cssContext/htmlContext callbacks.",
+            ));
+        }
+
+        let mut cache = self.glyph_cache.clone().ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "regenerate requires the font to be generated with `incremental` enabled.",
+            )
+        })?;
+        let mut source_files = self.source_files.clone();
+        let mut options = self.options.clone();
+
+        // Snapshot the inputs the CSS/HTML templates depend on (glyph names + codepoints) so we
+        // can tell, after rebuilding, whether the rendered output could have changed.
+        let prev_names: Vec<String> = self
+            .source_files
+            .iter()
+            .map(|f| f.glyph_name.clone())
+            .collect();
+        let prev_codepoints = self.options.codepoints.clone();
+
+        let order_changed = self
+            .source_files
+            .iter()
+            .map(|file| file.path.as_str())
+            .ne(ordered_paths.iter().map(String::as_str));
+        let mut changed_inputs = order_changed;
+
+        for (path, change) in changes {
+            match change {
+                GlyphChange::Removed => {
+                    let before = source_files.len();
+                    source_files.retain(|file| &file.path != path);
+                    cache.entries.remove(path);
+                    cache.content_hashes.remove(path);
+                    changed_inputs |= source_files.len() != before;
+                }
+                GlyphChange::Added { name } => {
+                    let contents = std::fs::read_to_string(path)?;
+                    let hash = source_content_hash(&contents);
+                    upsert_source_file(&mut source_files, path, contents, name.clone());
+                    // Reuse identical SVG geometry if another path already parsed these bytes;
+                    // otherwise prepare_svg_font_incremental will parse and populate the cache.
+                    if let Some(cached) = cache.by_content_hash.get(&hash) {
+                        cache.entries.insert(path.clone(), cached.clone());
+                        cache.content_hashes.insert(path.clone(), hash);
+                    } else {
+                        cache.entries.remove(path);
+                        cache.content_hashes.remove(path);
+                    }
+                    changed_inputs = true;
+                }
+                GlyphChange::Changed { name } => {
+                    let contents = std::fs::read_to_string(path)?;
+                    let hash = source_content_hash(&contents);
+                    let content_changed = cache.content_hashes.get(path) != Some(&hash);
+                    let name_changed = name.as_ref().is_some_and(|name| {
+                        source_files
+                            .iter()
+                            .find(|file| &file.path == path)
+                            .is_none_or(|file| file.glyph_name != *name)
+                    });
+
+                    if !content_changed && !name_changed {
+                        continue;
+                    }
+
+                    upsert_source_file(&mut source_files, path, contents, name.clone());
+                    if content_changed {
+                        if let Some(cached) = cache.by_content_hash.get(&hash) {
+                            cache.entries.insert(path.clone(), cached.clone());
+                            cache.content_hashes.insert(path.clone(), hash);
+                        } else {
+                            cache.entries.remove(path);
+                            cache.content_hashes.remove(path);
+                        }
+                    }
+                    changed_inputs = true;
+                }
+            }
+        }
+
+        if !changed_inputs {
+            return Ok(());
+        }
+
+        // Reorder to the caller's order so additions land in their fresh-build position rather than
+        // at the tail. `ordered_paths` is authoritative for membership: any file not listed is
+        // dropped here (handling removals), and every listed path must resolve to a known file.
+        let mut by_path: std::collections::HashMap<String, LoadedSvgFile> = source_files
+            .into_iter()
+            .map(|file| (file.path.clone(), file))
+            .collect();
+        let mut reordered = Vec::with_capacity(ordered_paths.len());
+        for path in ordered_paths {
+            let file = by_path.remove(path).ok_or_else(|| {
+                std::io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("regenerate: `{path}` is in the ordered set but was not loaded; declare it as an added change."),
+                )
+            })?;
+            reordered.push(file);
+        }
+        source_files = reordered;
+        validate_glyph_names(&source_files)?;
+
+        // Re-resolve codepoints for the (possibly changed) set from the stable explicit base, so
+        // auto-assigned codepoints match what a fresh build of the new set would produce.
+        finalize_generate_webfonts_options(&mut options, &source_files)?;
+
+        let svg_options = svg_options_from_options(&options);
+        let prepared = prepare_svg_font_incremental(&svg_options, &source_files, &mut cache)?;
+        let fonts = build_font_outputs(&options, &svg_options, &prepared)?;
+
+        // Rebuild the template data fresh (the font hash changed), but keep the rendered CSS/HTML
+        // that can't have changed: only when the glyph names and codepoints the templates read are
+        // unchanged (e.g. a pure content edit). reset_render_cache carries the safe entries.
+        let names_unchanged = source_files
+            .iter()
+            .map(|file| file.glyph_name.as_str())
+            .eq(prev_names.iter().map(String::as_str));
+        let reuse_renders = names_unchanged && options.codepoints == prev_codepoints;
+        self.source_files = source_files;
+        self.options = options;
+        self.fonts = fonts;
+        self.glyph_cache = Some(cache);
+        self.reset_render_cache(reuse_renders);
+
+        // Match `generate`'s write behavior: refresh font files, and skip unchanged CSS/HTML.
+        if self.options.write_files {
+            write_generate_webfonts_result_sync(self)?;
+        }
+        Ok(())
+    }
+}
+
+/// Insert or update a source file by path: update an existing entry's contents (and name, if
+/// given), or append a new entry (deriving the glyph name from the file stem when none is given).
+fn upsert_source_file(
+    source_files: &mut Vec<LoadedSvgFile>,
+    path: &str,
+    contents: String,
+    name: Option<String>,
+) {
+    if let Some(file) = source_files.iter_mut().find(|file| file.path == path) {
+        file.contents = contents;
+        if let Some(name) = name {
+            file.glyph_name = name;
+        }
+    } else {
+        let glyph_name = name.unwrap_or_else(|| {
+            Path::new(path)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or_default()
+                .to_owned()
+        });
+        source_files.push(LoadedSvgFile {
+            contents,
+            glyph_name,
+            path: path.to_owned(),
+        });
+    }
+}

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -1,0 +1,539 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::types::{FontType, GenerateWebfontsResult, GlyphChange, LoadedSvgFile};
+use crate::{FormatOptions, GenerateWebfontsOptions, TtfFormatOptions};
+use crate::{
+    finalize_generate_webfonts_options, generate_webfonts_sync, resolve_generate_webfonts_options,
+};
+
+const D1: &str = "M2 2 L22 2 L22 22 Z";
+const D2: &str = "M2 2 L22 2 L12 22 Z";
+const D3: &str = "M4 4 L20 4 L20 20 L4 20 Z";
+const D_CHANGED: &str = "M0 0 L24 0 L24 24 Z";
+const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
+
+fn stable_format_options() -> FormatOptions {
+    FormatOptions {
+        ttf: Some(TtfFormatOptions {
+            copyright: None,
+            description: None,
+            ts: Some(TEST_TTF_TIMESTAMP),
+            url: None,
+            version: None,
+        }),
+        ..Default::default()
+    }
+}
+
+fn temp_dir() -> std::path::PathBuf {
+    // Process id + a monotonic counter so parallel tests never collide on the same dir.
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let unique = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("recalc-ut-{}-{unique}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write_icon(dir: &Path, name: &str, d: &str) -> String {
+    let path = dir.join(format!("{name}.svg"));
+    std::fs::write(
+        &path,
+        format!("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{d}\"/></svg>"),
+    )
+    .unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+fn load(paths: &[String]) -> Vec<LoadedSvgFile> {
+    paths
+        .iter()
+        .map(|path| LoadedSvgFile {
+            contents: std::fs::read_to_string(path).unwrap(),
+            glyph_name: Path::new(path)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or_default()
+                .to_owned(),
+            path: path.clone(),
+        })
+        .collect()
+}
+
+fn generate(paths: Vec<String>, incremental: bool) -> GenerateWebfontsResult {
+    let mut resolved = resolve_generate_webfonts_options(GenerateWebfontsOptions {
+        css: Some(false),
+        dest: "artifacts".to_owned(),
+        files: paths,
+        html: Some(false),
+        font_name: Some("rc".to_owned()),
+        format_options: Some(stable_format_options()),
+        ligature: Some(false),
+        incremental: Some(incremental),
+        // These tests assert in-memory parity; don't touch the disk on regenerate.
+        write_files: Some(false),
+        types: Some(vec![
+            FontType::Svg,
+            FontType::Ttf,
+            FontType::Eot,
+            FontType::Woff,
+            FontType::Woff2,
+        ]),
+        ..Default::default()
+    })
+    .unwrap();
+    let source_files = load(&resolved.files);
+    finalize_generate_webfonts_options(&mut resolved, &source_files).unwrap();
+    generate_webfonts_sync(resolved, source_files).unwrap()
+}
+
+fn assert_same(actual: &GenerateWebfontsResult, expected: &GenerateWebfontsResult) {
+    assert_eq!(actual.svg_string(), expected.svg_string(), "svg mismatch");
+    assert_eq!(actual.ttf_bytes(), expected.ttf_bytes(), "ttf mismatch");
+    assert_eq!(actual.eot_bytes(), expected.eot_bytes(), "eot mismatch");
+    assert_eq!(actual.woff_bytes(), expected.woff_bytes(), "woff mismatch");
+    assert_eq!(
+        actual.woff2_bytes(),
+        expected.woff2_bytes(),
+        "woff2 mismatch"
+    );
+}
+
+#[test]
+fn regenerate_after_content_change_matches_fresh() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+
+    let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_after_add_matches_fresh() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+
+    let mut result = generate(vec![a.clone(), b.clone()], true);
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(
+                c.clone(),
+                GlyphChange::Added {
+                    name: Some("c".to_owned()),
+                },
+            )],
+        )
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_after_mid_order_add_matches_fresh() {
+    let dir = temp_dir();
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+
+    let mut result = generate(vec![b.clone(), c.clone()], true);
+    let a = write_icon(&dir, "a", D1);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(a.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_after_remove_matches_fresh() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+
+    let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
+    result
+        .regenerate(&[a.clone(), c.clone()], &[(b, GlyphChange::Removed)])
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_without_incremental_errors() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let mut result = generate(vec![a.clone()], false);
+    let changes = [(a.clone(), GlyphChange::Changed { name: None })];
+    let error = result
+        .regenerate(std::slice::from_ref(&a), &changes)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_noop_changed_event_returns_before_parsing() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let mut result = generate(vec![a.clone(), b.clone()], true);
+    let before = result.glyph_cache.as_ref().unwrap().parse_count;
+
+    result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b, GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.glyph_cache.as_ref().unwrap().parse_count,
+        before,
+        "unchanged watcher events should return before SVG parsing"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_added_duplicate_reuses_content_addressed_cache() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let mut result = generate(vec![a.clone(), b.clone()], true);
+    let c = write_icon(&dir, "c", D1);
+    let before = result.glyph_cache.as_ref().unwrap().parse_count;
+
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(
+                c.clone(),
+                GlyphChange::Added {
+                    name: Some("c".to_owned()),
+                },
+            )],
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.glyph_cache.as_ref().unwrap().parse_count,
+        before,
+        "added files with SVG bytes already in the cache should not be parsed again"
+    );
+    assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_with_context_callback_state_errors() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let mut result = generate(vec![a.clone()], true);
+    result.css_context = Some(Default::default());
+
+    let error = result
+        .regenerate(&[a], &[])
+        .expect_err("regenerate must reject pre-mutated callback contexts");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(error.to_string().contains("cssContext/htmlContext"));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_failure_preserves_incremental_state_for_retry() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = dir.join("c.svg").to_string_lossy().into_owned();
+    let mut result = generate(vec![a.clone(), b.clone()], true);
+    let before = result.svg_string().unwrap().to_owned();
+
+    let error = result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(
+                c.clone(),
+                GlyphChange::Added {
+                    name: Some("c".to_owned()),
+                },
+            )],
+        )
+        .expect_err("missing added file should fail");
+    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    assert!(
+        result.glyph_cache.is_some(),
+        "failed regenerate must leave the incremental cache available"
+    );
+    assert_eq!(result.svg_string().unwrap(), before);
+
+    write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(
+                c.clone(),
+                GlyphChange::Added {
+                    name: Some("c".to_owned()),
+                },
+            )],
+        )
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_rejects_duplicate_glyph_names() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let mut result = generate(vec![a.clone(), b.clone()], true);
+    let before = result.svg_string().unwrap().to_owned();
+
+    let error = result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(
+                b.clone(),
+                GlyphChange::Changed {
+                    name: Some("a".to_owned()),
+                },
+            )],
+        )
+        .expect_err("duplicate names should match fresh generate validation");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(error.to_string().contains("must be unique"));
+    assert!(result.glyph_cache.is_some());
+    assert_eq!(result.svg_string().unwrap(), before);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+fn generate_with_css(paths: Vec<String>, incremental: bool) -> GenerateWebfontsResult {
+    let mut resolved = resolve_generate_webfonts_options(GenerateWebfontsOptions {
+        css: Some(true),
+        dest: "artifacts".to_owned(),
+        files: paths,
+        html: Some(false),
+        font_name: Some("rc".to_owned()),
+        format_options: Some(stable_format_options()),
+        ligature: Some(false),
+        incremental: Some(incremental),
+        // These tests assert in-memory parity; don't touch the disk on regenerate.
+        write_files: Some(false),
+        types: Some(vec![FontType::Woff2]),
+        ..Default::default()
+    })
+    .unwrap();
+    let source_files = load(&resolved.files);
+    finalize_generate_webfonts_options(&mut resolved, &source_files).unwrap();
+    generate_webfonts_sync(resolved, source_files).unwrap()
+}
+
+#[test]
+fn regenerate_reuses_provided_url_css_on_content_edit() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let urls = HashMap::from([(FontType::Woff2, "/static/icons.woff2".to_owned())]);
+
+    let mut result = generate_with_css(vec![a.clone(), b.clone()], true);
+    let before = result.generate_css_pure(Some(urls.clone())).unwrap();
+
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+    let after = result.generate_css_pure(Some(urls.clone())).unwrap();
+
+    assert_eq!(
+        before, after,
+        "provided-url CSS is independent of the font bytes"
+    );
+    let fresh = generate_with_css(vec![a, b], false);
+    assert_eq!(after, fresh.generate_css_pure(Some(urls)).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_rerenders_default_css_on_content_edit() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+
+    let mut result = generate_with_css(vec![a.clone(), b.clone()], true);
+    let before = result.generate_css_pure(None).unwrap();
+
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+    let after = result.generate_css_pure(None).unwrap();
+
+    assert_ne!(
+        before, after,
+        "default CSS embeds the source hash, which changed"
+    );
+    let fresh = generate_with_css(vec![a, b], false);
+    assert_eq!(after, fresh.generate_css_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_rerenders_css_on_rename() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let urls = HashMap::from([(FontType::Woff2, "/static/icons.woff2".to_owned())]);
+
+    let mut result = generate_with_css(vec![a.clone(), b.clone()], true);
+    let before = result.generate_css_pure(Some(urls.clone())).unwrap();
+
+    result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(
+                b.clone(),
+                GlyphChange::Changed {
+                    name: Some("renamed".to_owned()),
+                },
+            )],
+        )
+        .unwrap();
+    let after = result.generate_css_pure(Some(urls)).unwrap();
+
+    assert_ne!(before, after, "a renamed glyph must re-render");
+    assert!(
+        after.contains("renamed"),
+        "new glyph name should appear in the CSS"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+fn generate_writing(paths: Vec<String>, dest: &Path) -> GenerateWebfontsResult {
+    let mut resolved = resolve_generate_webfonts_options(GenerateWebfontsOptions {
+        css: Some(true),
+        dest: dest.to_string_lossy().into_owned(),
+        files: paths,
+        html: Some(false),
+        font_name: Some("rc".to_owned()),
+        format_options: Some(stable_format_options()),
+        ligature: Some(false),
+        incremental: Some(true),
+        write_files: Some(true),
+        types: Some(vec![FontType::Woff2]),
+        ..Default::default()
+    })
+    .unwrap();
+    let source_files = load(&resolved.files);
+    finalize_generate_webfonts_options(&mut resolved, &source_files).unwrap();
+    generate_webfonts_sync(resolved, source_files).unwrap()
+}
+
+#[test]
+fn regenerate_writes_changed_outputs_and_skips_unchanged() {
+    let dir = temp_dir();
+    let dest = dir.join("out");
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let files = vec![a.clone(), b.clone()];
+
+    let mut result = generate_writing(files.clone(), &dest);
+    let woff2_path = dest.join("rc.woff2");
+    let css_path = dest.join("rc.css");
+
+    // This helper builds in memory only, so this first regenerate performs the initial write.
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(&files, &[(b.clone(), GlyphChange::Changed { name: None })])
+        .unwrap();
+
+    let on_disk = std::fs::read(&woff2_path).unwrap();
+    assert_eq!(on_disk.as_slice(), result.woff2_bytes().unwrap());
+    let fresh = generate_with_css(files.clone(), false);
+    assert_eq!(on_disk.as_slice(), fresh.woff2_bytes().unwrap());
+    assert!(css_path.exists(), "CSS is written to disk too");
+
+    // Re-running with no real change reproduces identical bytes, so the write is skipped: a
+    // deleted output is NOT recreated.
+    std::fs::remove_file(&woff2_path).unwrap();
+    result
+        .regenerate(&files, &[(b.clone(), GlyphChange::Changed { name: None })])
+        .unwrap();
+    assert!(
+        !woff2_path.exists(),
+        "an unchanged output must not be rewritten"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn initial_write_seeds_skip_map_for_first_regenerate() {
+    let dir = temp_dir();
+    let dest = dir.join("out");
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let files = vec![a.clone(), b.clone()];
+
+    let mut result = crate::generate_sync(
+        GenerateWebfontsOptions {
+            css: Some(false),
+            dest: dest.to_string_lossy().into_owned(),
+            files: files.clone(),
+            html: Some(false),
+            font_name: Some("rc".to_owned()),
+            format_options: Some(stable_format_options()),
+            ligature: Some(false),
+            incremental: Some(true),
+            write_files: Some(true),
+            types: Some(vec![FontType::Woff2]),
+            ..Default::default()
+        },
+        None,
+    )
+    .unwrap();
+
+    let woff2_path = dest.join("rc.woff2");
+    assert!(woff2_path.exists(), "the initial build wrote the font");
+
+    // No real change -> identical output -> skipped because the initial write seeded the hash.
+    std::fs::remove_file(&woff2_path).unwrap();
+    result
+        .regenerate(&files, &[(b.clone(), GlyphChange::Changed { name: None })])
+        .unwrap();
+    assert!(
+        !woff2_path.exists(),
+        "first regenerate must skip an output unchanged since the seeded initial write"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -60,6 +60,7 @@
 //! - **`napi`**: Enables Node.js NAPI bindings for use as a native addon.
 
 mod eot;
+mod incremental;
 mod svg;
 mod templates;
 #[cfg(test)]
@@ -68,6 +69,7 @@ mod ttf;
 mod types;
 mod util;
 mod woff;
+mod write;
 
 #[cfg(feature = "napi")]
 use napi::threadsafe_function::ThreadsafeFunction;
@@ -84,20 +86,23 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use tokio::task::JoinSet;
 
-use svg::types::{PreparedSvgFont, SvgOptions};
-use svg::{build_svg_font, prepare_svg_font, svg_options_from_options};
+use svg::types::{GlyphCache, PreparedSvgFont, SvgOptions};
+use svg::{
+    build_svg_font, prepare_svg_font, prepare_svg_font_incremental, svg_options_from_options,
+};
 #[cfg(feature = "napi")]
 use templates::{
     SharedTemplateData, apply_context_function, build_css_context, build_html_context,
     build_html_registry,
 };
-use templates::{render_css_with_hbs_context, render_html_with_hbs_context};
 #[cfg(feature = "napi")]
 use util::to_napi_err;
+use write::write_generate_webfonts_result;
 
 pub use types::{
     CssContext, FontType, FormatOptions, GenerateWebfontsOptions, GenerateWebfontsResult,
-    HtmlContext, SvgFormatOptions, TtfFormatOptions, Woff2FormatOptions, WoffFormatOptions,
+    GlyphChange, GlyphChangeEntry, HtmlContext, SvgFormatOptions, TtfFormatOptions,
+    Woff2FormatOptions, WoffFormatOptions,
 };
 use types::{
     DEFAULT_FONT_ORDER, FontOutputs, LoadedSvgFile, ResolvedGenerateWebfontsOptions,
@@ -209,8 +214,11 @@ pub async fn generate_webfonts(
         }));
     }
 
-    if result.options.write_files {
-        write_generate_webfonts_result(&result).await?;
+    if result.options.write_files
+        && let Some(written) = write_generate_webfonts_result(&result).await?
+    {
+        // Only incremental results can call `regenerate`, so only they need write-skip state.
+        result.written_outputs = written;
     }
 
     Ok(result)
@@ -231,13 +239,16 @@ pub async fn generate(
     let mut resolved_options = resolve_generate_webfonts_options(options)?;
     finalize_generate_webfonts_options(&mut resolved_options, &source_files)?;
 
-    let result =
+    let mut result =
         tokio::task::spawn_blocking(move || generate_webfonts_sync(resolved_options, source_files))
             .await
             .map_err(std::io::Error::other)??;
 
-    if result.options.write_files {
-        write_generate_webfonts_result(&result).await?;
+    if result.options.write_files
+        && let Some(written) = write_generate_webfonts_result(&result).await?
+    {
+        // Only incremental results can call `regenerate`, so only they need write-skip state.
+        result.written_outputs = written;
     }
 
     Ok(result)
@@ -320,6 +331,8 @@ pub(crate) fn resolve_generate_webfonts_options(
         .html_dest
         .unwrap_or_else(|| default_output_dest(&options.dest, &font_name, "html"));
     let write_files = options.write_files.unwrap_or(true);
+    let explicit_codepoints: std::collections::BTreeMap<String, u32> =
+        options.codepoints.unwrap_or_default().into_iter().collect();
 
     let svg_format = options
         .format_options
@@ -350,7 +363,8 @@ pub(crate) fn resolve_generate_webfonts_options(
             }
             other => other,
         },
-        codepoints: options.codepoints.unwrap_or_default().into_iter().collect(),
+        codepoints: explicit_codepoints.clone(),
+        explicit_codepoints,
         css_fonts_url: options.css_fonts_url,
         descent: options.descent,
         dest: options.dest,
@@ -368,6 +382,7 @@ pub(crate) fn resolve_generate_webfonts_options(
             }
             other => other,
         },
+        incremental: options.incremental.unwrap_or(false),
         font_height: options.font_height,
         font_name,
         font_style: options.font_style,
@@ -389,8 +404,11 @@ pub(crate) fn finalize_generate_webfonts_options(
     options: &mut ResolvedGenerateWebfontsOptions,
     source_files: &[LoadedSvgFile],
 ) -> std::io::Result<()> {
-    options.codepoints =
-        resolve_codepoints(source_files, &options.codepoints, options.start_codepoint)?;
+    options.codepoints = resolve_codepoints(
+        source_files,
+        &options.explicit_codepoints,
+        options.start_codepoint,
+    )?;
 
     Ok(())
 }
@@ -418,16 +436,28 @@ fn generate_webfonts_sync(
     source_files: Vec<LoadedSvgFile>,
 ) -> std::io::Result<GenerateWebfontsResult> {
     let svg_options = svg_options_from_options(&options);
-    let prepared = prepare_svg_font(&svg_options, &source_files)?;
+    // When incremental, retain the parsed-glyph cache so a later `regenerate` can reuse the
+    // glyphs whose source didn't change. Otherwise the geometry is dropped as soon as the font
+    // is built, so one-shot builds carry no extra memory.
+    let (prepared, glyph_cache) = if options.incremental {
+        let mut cache = GlyphCache::default();
+        let prepared = prepare_svg_font_incremental(&svg_options, &source_files, &mut cache)?;
+        (prepared, Some(cache))
+    } else {
+        (prepare_svg_font(&svg_options, &source_files)?, None)
+    };
     let fonts = build_font_outputs(&options, &svg_options, &prepared)?;
 
     Ok(GenerateWebfontsResult {
         cached: std::sync::OnceLock::new(),
+        carried_render: None,
         css_context: None,
         fonts,
+        glyph_cache,
         html_context: None,
         options,
         source_files,
+        written_outputs: std::collections::HashMap::new(),
     })
 }
 
@@ -525,83 +555,6 @@ fn build_font_outputs(
         woff2_font,
         eot_font,
     })
-}
-
-async fn write_generate_webfonts_result(result: &GenerateWebfontsResult) -> std::io::Result<()> {
-    let mut tasks = JoinSet::new();
-    let font_name = result.options.font_name.clone();
-    let dest = result.options.dest.clone();
-
-    if let Some(svg_font) = &result.fonts.svg_font {
-        let path = default_output_dest(&dest, &font_name, "svg");
-        let contents = Arc::clone(svg_font);
-        tasks.spawn(async move { write_output_file(path, contents.as_bytes()).await });
-    }
-
-    if let Some(ttf_font) = &result.fonts.ttf_font {
-        let path = default_output_dest(&dest, &font_name, "ttf");
-        let contents = Arc::clone(ttf_font);
-        tasks.spawn(async move { write_output_file(path, &*contents).await });
-    }
-
-    if let Some(woff_font) = &result.fonts.woff_font {
-        let path = default_output_dest(&dest, &font_name, "woff");
-        let contents = Arc::clone(woff_font);
-        tasks.spawn(async move { write_output_file(path, &*contents).await });
-    }
-
-    if let Some(woff2_font) = &result.fonts.woff2_font {
-        let path = default_output_dest(&dest, &font_name, "woff2");
-        let contents = Arc::clone(woff2_font);
-        tasks.spawn(async move { write_output_file(path, &*contents).await });
-    }
-
-    if let Some(eot_font) = &result.fonts.eot_font {
-        let path = default_output_dest(&dest, &font_name, "eot");
-        let contents = Arc::clone(eot_font);
-        tasks.spawn(async move { write_output_file(path, &*contents).await });
-    }
-
-    // Only render CSS/HTML templates when those files need to be written.
-    if result.options.css || result.options.html {
-        let cached = result.get_cached_io()?;
-
-        if result.options.css {
-            let ctx = cached.css_hbs_context.lock().unwrap();
-            let css = render_css_with_hbs_context(&cached.shared, &ctx, &cached.css_context)?;
-            drop(ctx);
-            let css_dest = result.options.css_dest.clone();
-            let css = Arc::new(css);
-            tasks.spawn(async move { write_output_file(css_dest, css.as_bytes()).await });
-        }
-
-        if result.options.html {
-            let ctx = cached.html_hbs_context.lock().unwrap();
-            let html = render_html_with_hbs_context(
-                cached.html_registry.as_ref(),
-                &ctx,
-                &cached.html_context,
-            )?;
-            let html_dest = result.options.html_dest.clone();
-            tasks.spawn(async move { write_output_file(html_dest, html.into_bytes()).await });
-        }
-    }
-
-    while let Some(result) = tasks.join_next().await {
-        result.map_err(|error| {
-            std::io::Error::other(format!("Native write task failed: {error}"))
-        })??;
-    }
-
-    Ok(())
-}
-
-async fn write_output_file(path: String, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
-    if let Some(parent) = Path::new(&path).parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-
-    tokio::fs::write(path, contents).await
 }
 
 fn validate_font_type_order(
@@ -702,7 +655,7 @@ async fn load_svg_files_napi(
     Ok(source_files)
 }
 
-fn validate_glyph_names(source_files: &[LoadedSvgFile]) -> std::io::Result<()> {
+pub(crate) fn validate_glyph_names(source_files: &[LoadedSvgFile]) -> std::io::Result<()> {
     let mut seen_names = HashSet::with_capacity(source_files.len());
 
     for source_file in source_files {

--- a/packages/webfont-generator/src/svg/mod.rs
+++ b/packages/webfont-generator/src/svg/mod.rs
@@ -6,12 +6,13 @@ mod tests;
 pub(crate) mod types;
 
 use rayon::prelude::*;
+use std::collections::{HashMap, HashSet};
 use std::io::{Error, ErrorKind};
 
 use parse::parse_svg_glyph;
 use process::process_glyph;
 pub(crate) use serialize::build_svg_font;
-use types::{GlyphWorkItem, PreparedSvgFont, SvgOptions};
+use types::{CachedGlyph, GlyphCache, GlyphWorkItem, ParsedGlyph, PreparedSvgFont, SvgOptions};
 
 use crate::types::{LoadedSvgFile, ResolvedGenerateWebfontsOptions};
 
@@ -48,6 +49,19 @@ pub(crate) fn prepare_svg_font(
     options: &SvgOptions,
     source_files: &[LoadedSvgFile],
 ) -> Result<PreparedSvgFont, Error> {
+    let glyphs = parse_glyphs(options, source_files)?;
+    finalize_glyphs(options, glyphs)
+}
+
+/// Parse each SVG file into a [`ParsedGlyph`] (geometry + assigned codepoint/index/name). This
+/// is the per-file half of [`prepare_svg_font`]: every glyph is independent and content-derived,
+/// which is what lets an incremental rebuild reuse the ones whose source didn't change. The
+/// global, set-dependent work (metrics, normalization, glyph processing) lives in
+/// [`finalize_glyphs`].
+pub(crate) fn parse_glyphs(
+    options: &SvgOptions,
+    source_files: &[LoadedSvgFile],
+) -> Result<Vec<ParsedGlyph>, Error> {
     if source_files.is_empty() {
         return Err(Error::new(
             ErrorKind::InvalidInput,
@@ -55,15 +69,9 @@ pub(crate) fn prepare_svg_font(
         ));
     }
 
-    let mut work_items = Vec::with_capacity(source_files.len());
-    let normalize = options.normalize;
-    let fixed_width = options.fixed_width.unwrap_or(false);
-    let center_horizontally = options.center_horizontally.unwrap_or(false);
-    let center_vertically = options.center_vertically.unwrap_or(false);
-    let ligature = options.ligature;
     let preserve_aspect_ratio = options.preserve_aspect_ratio.unwrap_or(false);
-    let round = options.round.unwrap_or(10e12);
 
+    let mut work_items = Vec::with_capacity(source_files.len());
     for (index, source_file) in source_files.iter().enumerate() {
         let name = &source_file.glyph_name;
         let codepoint = options
@@ -91,6 +99,23 @@ pub(crate) fn prepare_svg_font(
         .collect::<Result<Vec<_>, Error>>()
         .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
     glyphs.sort_by_key(|glyph| glyph.index);
+    Ok(glyphs)
+}
+
+/// Turn parsed glyphs into a [`PreparedSvgFont`]: compute the set-wide metrics (tallest/widest,
+/// font height/width, ascent/descent) and run per-glyph processing (normalize, center, round,
+/// optimize). This is the global half of [`prepare_svg_font`] — it depends on the whole glyph
+/// set, so an incremental rebuild must re-run it even when only one glyph changed.
+pub(crate) fn finalize_glyphs(
+    options: &SvgOptions,
+    glyphs: Vec<ParsedGlyph>,
+) -> Result<PreparedSvgFont, Error> {
+    let normalize = options.normalize;
+    let fixed_width = options.fixed_width.unwrap_or(false);
+    let center_horizontally = options.center_horizontally.unwrap_or(false);
+    let center_vertically = options.center_vertically.unwrap_or(false);
+    let ligature = options.ligature;
+    let round = options.round.unwrap_or(10e12);
 
     let max_glyph_height = glyphs
         .iter()
@@ -156,4 +181,148 @@ pub(crate) fn prepare_svg_font(
         metadata,
         processed_glyphs,
     })
+}
+
+/// Like [`prepare_svg_font`], but reuses cached glyph geometry instead of re-parsing. A file
+/// present in `cache` is treated as unchanged and reused; anything else is parsed and cached.
+/// Drives both the first (incremental) build — empty cache, so every glyph is parsed and stored —
+/// and a later rebuild, where the caller (`regenerate`) has evicted the paths it knows changed.
+/// The global [`finalize_glyphs`] pass still runs over the whole set, so the output is
+/// byte-identical to [`prepare_svg_font`] for the same inputs.
+pub(crate) fn prepare_svg_font_incremental(
+    options: &SvgOptions,
+    source_files: &[LoadedSvgFile],
+    cache: &mut GlyphCache,
+) -> Result<PreparedSvgFont, Error> {
+    let glyphs = parse_glyphs_incremental(options, source_files, cache)?;
+    finalize_glyphs(options, glyphs)
+}
+
+pub(crate) fn source_content_hash(contents: &str) -> [u8; 16] {
+    md5::compute(contents.as_bytes()).0
+}
+
+fn parse_glyphs_incremental(
+    options: &SvgOptions,
+    source_files: &[LoadedSvgFile],
+    cache: &mut GlyphCache,
+) -> Result<Vec<ParsedGlyph>, Error> {
+    if source_files.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Expected at least one SVG file for native generation.",
+        ));
+    }
+
+    let preserve_aspect_ratio = options.preserve_aspect_ratio.unwrap_or(false);
+
+    // Forget cache entries for files no longer in the set.
+    let current: HashSet<&str> = source_files.iter().map(|file| file.path.as_str()).collect();
+    cache
+        .entries
+        .retain(|path, _| current.contains(path.as_str()));
+    cache
+        .content_hashes
+        .retain(|path, _| current.contains(path.as_str()));
+
+    // Rehydrate path entries from content-addressed geometry where possible. This handles added
+    // files whose SVG bytes match an existing glyph (including rename-like remove/add events).
+    for source_file in source_files {
+        if cache.entries.contains_key(&source_file.path) {
+            continue;
+        }
+        let hash = source_content_hash(&source_file.contents);
+        if let Some(cached) = cache.by_content_hash.get(&hash) {
+            cache
+                .entries
+                .insert(source_file.path.clone(), cached.clone());
+            cache.content_hashes.insert(source_file.path.clone(), hash);
+        }
+    }
+
+    // Resolve each file's codepoint up front.
+    let mut codepoints = Vec::with_capacity(source_files.len());
+    for source_file in source_files {
+        let codepoint = options
+            .codepoints
+            .get(source_file.glyph_name.as_str())
+            .copied()
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidInput,
+                    format!(
+                        "Missing resolved codepoint for glyph '{}'.",
+                        source_file.glyph_name
+                    ),
+                )
+            })?;
+        codepoints.push(codepoint);
+    }
+
+    // Parse (in parallel) only files not already cached — a present entry is reused as-is.
+    let parsed: Vec<(usize, ParsedGlyph)> = source_files
+        .par_iter()
+        .enumerate()
+        .filter(|(_, source_file)| !cache.entries.contains_key(&source_file.path))
+        .map(|(index, source_file)| {
+            let work = GlyphWorkItem {
+                codepoint: codepoints[index],
+                index,
+                name: &source_file.glyph_name,
+                source_file,
+            };
+            parse_svg_glyph(&work, preserve_aspect_ratio).map(|glyph| (index, glyph))
+        })
+        .collect::<Result<Vec<_>, Error>>()
+        .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
+
+    #[cfg(test)]
+    {
+        cache.parse_count += parsed.len();
+    }
+
+    // Cache the freshly-parsed geometry.
+    for (index, glyph) in &parsed {
+        let source_file = &source_files[*index];
+        let hash = source_content_hash(&source_file.contents);
+        let cached = CachedGlyph {
+            height: glyph.height,
+            paths: glyph.paths.clone(),
+            width: glyph.width,
+        };
+        cache.by_content_hash.insert(hash, cached.clone());
+        cache.content_hashes.insert(source_file.path.clone(), hash);
+        cache.entries.insert(source_file.path.clone(), cached);
+    }
+
+    let active_hashes: HashSet<[u8; 16]> = cache.content_hashes.values().copied().collect();
+    cache
+        .by_content_hash
+        .retain(|hash, _| active_hashes.contains(hash));
+
+    // Assemble the full set: freshly-parsed glyphs by move, unchanged ones cloned from cache.
+    let mut freshly_parsed: HashMap<usize, ParsedGlyph> = parsed.into_iter().collect();
+    let mut glyphs = Vec::with_capacity(source_files.len());
+    for (index, source_file) in source_files.iter().enumerate() {
+        let glyph = match freshly_parsed.remove(&index) {
+            Some(glyph) => glyph,
+            None => {
+                let cached = cache
+                    .entries
+                    .get(&source_file.path)
+                    .expect("an unchanged file must have a cache entry");
+                ParsedGlyph {
+                    codepoint: codepoints[index],
+                    height: cached.height,
+                    index,
+                    name: source_file.glyph_name.clone(),
+                    paths: cached.paths.clone(),
+                    width: cached.width,
+                }
+            }
+        };
+        glyphs.push(glyph);
+    }
+    glyphs.sort_by_key(|glyph| glyph.index);
+    Ok(glyphs)
 }

--- a/packages/webfont-generator/src/svg/tests.rs
+++ b/packages/webfont-generator/src/svg/tests.rs
@@ -2,7 +2,11 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::{build_svg_font, prepare_svg_font, svg_options_from_options};
+use super::types::GlyphCache;
+use super::{
+    build_svg_font, prepare_svg_font, prepare_svg_font_incremental, source_content_hash,
+    svg_options_from_options,
+};
 
 use crate::{
     FormatOptions, GenerateWebfontsOptions, LoadedSvgFile, SvgFormatOptions,
@@ -575,5 +579,86 @@ fn svg_font_does_not_deduplicate_identical_glyphs() {
         glyph_names,
         vec!["plus", "plus-copy"],
         "SVG font should not deduplicate — each glyph gets its own <glyph> element"
+    );
+}
+
+#[test]
+fn incremental_prepare_matches_full_prepare_and_reuses_cache() {
+    let dir = icons_root().join("cleanicons");
+    let make_options = || GenerateWebfontsOptions {
+        css: Some(false),
+        dest: "artifacts".to_string(),
+        files: svg_files(&dir),
+        html: Some(false),
+        font_name: Some("iconfont".to_string()),
+        ligature: Some(false),
+        ..Default::default()
+    };
+
+    let mut resolved = resolve_generate_webfonts_options(make_options()).unwrap();
+    let source_files = load_source_files(&resolved.files);
+    finalize_generate_webfonts_options(&mut resolved, &source_files).unwrap();
+    let svg_options = svg_options_from_options(&resolved);
+
+    // The SVG font string encodes every glyph's path data plus the font metrics, so equality
+    // proves the prepared fonts match.
+    let full = build_svg_font(
+        &svg_options,
+        &prepare_svg_font(&svg_options, &source_files).unwrap(),
+    );
+
+    let mut cache = GlyphCache::default();
+    let fresh = build_svg_font(
+        &svg_options,
+        &prepare_svg_font_incremental(&svg_options, &source_files, &mut cache).unwrap(),
+    );
+    assert_eq!(
+        full, fresh,
+        "incremental build with an empty cache must match the full build"
+    );
+    assert_eq!(
+        cache.entries.len(),
+        source_files.len(),
+        "every glyph should be cached after the first incremental build"
+    );
+
+    // A second pass with no content change must serve entirely from the cache and still match.
+    let reused = build_svg_font(
+        &svg_options,
+        &prepare_svg_font_incremental(&svg_options, &source_files, &mut cache).unwrap(),
+    );
+    assert_eq!(
+        full, reused,
+        "a cache-reuse build must match the full build"
+    );
+}
+
+#[test]
+fn incremental_prepare_prunes_stale_content_hash_entries() {
+    let dir = icons_root().join("cleanicons");
+    let mut resolved = resolve_generate_webfonts_options(GenerateWebfontsOptions {
+        css: Some(false),
+        dest: "artifacts".to_string(),
+        files: svg_files(&dir),
+        html: Some(false),
+        font_name: Some("iconfont".to_string()),
+        ligature: Some(false),
+        ..Default::default()
+    })
+    .unwrap();
+    let mut source_files = load_source_files(&resolved.files);
+    finalize_generate_webfonts_options(&mut resolved, &source_files).unwrap();
+    let svg_options = svg_options_from_options(&resolved);
+
+    let mut cache = GlyphCache::default();
+    prepare_svg_font_incremental(&svg_options, &source_files, &mut cache).unwrap();
+
+    let removed = source_files.pop().expect("fixture should contain files");
+    let removed_hash = source_content_hash(&removed.contents);
+    prepare_svg_font_incremental(&svg_options, &source_files, &mut cache).unwrap();
+
+    assert!(
+        !cache.by_content_hash.contains_key(&removed_hash),
+        "removed glyph geometry should not stay in the content-addressed cache"
     );
 }

--- a/packages/webfont-generator/src/svg/types.rs
+++ b/packages/webfont-generator/src/svg/types.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use usvg::tiny_skia_path::Path as TinyPath;
 
@@ -58,4 +58,29 @@ pub(crate) struct PreparedSvgFont {
     pub font_width: f64,
     pub metadata: String,
     pub processed_glyphs: Vec<ProcessedGlyph>,
+}
+
+/// The content-derived geometry of one parsed glyph (everything in [`ParsedGlyph`] except the
+/// assigned `codepoint`/`index`/`name`, which are reassigned on every build). Cached so an
+/// incremental rebuild can reuse a glyph whose SVG source didn't change.
+#[derive(Clone)]
+pub(crate) struct CachedGlyph {
+    pub height: f64,
+    pub paths: Vec<TinyPath>,
+    pub width: f64,
+}
+
+/// Per-file parsed-glyph cache keyed by file path, retained on a `GenerateWebfontsResult` when
+/// `incremental` is enabled. A present entry is treated as up to date: `regenerate` evicts the
+/// paths it was told changed, so the rest can be reused without re-reading or re-hashing them.
+#[derive(Clone, Default)]
+pub(crate) struct GlyphCache {
+    /// Parsed geometry keyed by path for the current/last known file set.
+    pub entries: HashMap<String, CachedGlyph>,
+    /// Last seen source hash per path, used to ignore no-op watcher events.
+    pub content_hashes: HashMap<String, [u8; 16]>,
+    /// Parsed geometry keyed by SVG source bytes so added/renamed duplicate icons can reuse it.
+    pub by_content_hash: HashMap<[u8; 16], CachedGlyph>,
+    #[cfg(test)]
+    pub parse_count: usize,
 }

--- a/packages/webfont-generator/src/ttf/mod.rs
+++ b/packages/webfont-generator/src/ttf/mod.rs
@@ -1067,7 +1067,7 @@ mod tests {
     #[test]
     fn collapses_a_near_straight_quadratic_to_a_line() {
         // Control point sits ~0.1 units off the chord — within tolerance.
-        assert!(SIMPLIFY_TOLERANCE > 0.1);
+        const { assert!(SIMPLIFY_TOLERANCE > 0.1) };
         let path = quadratic_path_from_svg_path_data("M0,0 Q5,0.1 10,0").unwrap();
         assert!(
             !path

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -8,12 +8,39 @@ use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 use serde_json::{Map, Value};
 
+use crate::svg::types::GlyphCache;
 use crate::templates::{
     SharedTemplateData, build_css_context, build_html_context, build_html_registry, make_src,
     render_css_with_hbs_context, render_css_with_src_mutate, render_default_html_with_styles,
     render_html_with_hbs_context,
 };
 use crate::util::to_io_err;
+
+/// What happened to a file, for [`GenerateWebfontsResult::regenerate`]. `name` is the
+/// caller-resolved glyph name (the `rename` callback, if any, is applied by the caller).
+pub enum GlyphChange {
+    /// A new file. `name` overrides the file-stem glyph name when `Some`.
+    Added { name: Option<String> },
+    /// An existing file's contents changed. `name` overrides the glyph name when `Some`.
+    Changed { name: Option<String> },
+    /// The file was deleted.
+    Removed,
+}
+
+/// One entry in the `changes` array passed to the Node binding's `regenerate`. The complete
+/// ordered file list passed alongside it controls final glyph order; this only describes which
+/// files need re-reading, renaming, or removal.
+#[cfg_attr(feature = "napi", napi(object))]
+pub struct GlyphChangeEntry {
+    /// Path of the changed file.
+    pub path: String,
+    /// What happened to the file.
+    #[cfg_attr(feature = "napi", napi(ts_type = "'added' | 'changed' | 'removed'"))]
+    pub change_type: String,
+    /// Resolved glyph name (with the caller's `rename` already applied). Optional for `'added'`
+    /// and `'changed'` (defaults to the file stem/current name); ignored for `'removed'`.
+    pub name: Option<String>,
+}
 
 /// Font output format. Used in the `types` and `order` options to control which
 /// formats are generated and the order they appear in the CSS `@font-face`
@@ -228,6 +255,10 @@ pub struct GenerateWebfontsOptions {
     pub html_dest: Option<String>,
     /// Path to a custom Handlebars template for HTML preview generation.
     pub html_template: Option<String>,
+    /// Retain parsed glyph data on the result so `regenerate` can rebuild after file changes
+    /// without re-parsing unchanged glyphs. Defaults to `false`; enable for watch/dev. One-shot
+    /// builds (CLI, production) should leave it off to avoid holding the parsed geometry in memory.
+    pub incremental: Option<bool>,
     /// Explicit output font height in units per em. Overrides the height
     /// computed from the source glyphs.
     pub font_height: Option<f64>,
@@ -288,6 +319,7 @@ pub(crate) fn resolved_font_types(options: &GenerateWebfontsOptions) -> Vec<Font
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct ResolvedGenerateWebfontsOptions {
     pub ascent: Option<f64>,
     pub center_horizontally: Option<bool>,
@@ -295,7 +327,12 @@ pub(crate) struct ResolvedGenerateWebfontsOptions {
     pub css: bool,
     pub css_dest: String,
     pub css_template: Option<String>,
+    /// Fully-resolved codepoints for the current glyph set (explicit + auto-assigned). Rebuilt
+    /// by `finalize_generate_webfonts_options` from `explicit_codepoints` whenever the set changes.
     pub codepoints: BTreeMap<String, u32>,
+    /// The user-supplied codepoints, kept as the stable base so re-resolving after an
+    /// incremental add/remove assigns the same codepoints a fresh build would.
+    pub explicit_codepoints: BTreeMap<String, u32>,
     pub css_fonts_url: Option<String>,
     pub descent: Option<f64>,
     pub dest: String,
@@ -303,6 +340,7 @@ pub(crate) struct ResolvedGenerateWebfontsOptions {
     pub fixed_width: Option<bool>,
     pub format_options: Option<FormatOptions>,
     pub html: bool,
+    pub incremental: bool,
     pub html_dest: String,
     pub html_template: Option<String>,
     pub font_height: Option<f64>,
@@ -321,14 +359,17 @@ pub(crate) struct ResolvedGenerateWebfontsOptions {
     pub write_files: bool,
 }
 
+#[derive(Clone)]
 pub(crate) struct LoadedSvgFile {
     pub contents: String,
     pub glyph_name: String,
     pub path: String,
 }
 
-/// Caches the last rendered CSS/HTML result for repeated calls with the same urls.
-#[derive(Default)]
+/// Caches the last rendered CSS/HTML result for repeated calls with the same urls. Cloneable so
+/// an incremental `regenerate` can carry the still-valid entries (provided-URL renders, which
+/// don't depend on the font hash) forward into the rebuilt template data.
+#[derive(Clone, Default)]
 pub(crate) struct RenderCache {
     /// Result of generateCss() with no urls (computed once).
     css_no_urls: Option<String>,
@@ -370,11 +411,22 @@ pub(crate) struct FontOutputs {
 #[cfg_attr(feature = "napi", napi)]
 pub struct GenerateWebfontsResult {
     pub(crate) cached: OnceLock<Result<CachedTemplateData, String>>,
+    /// Render-cache entries carried across an incremental `regenerate` (set by
+    /// [`reset_render_cache`]) to seed the rebuilt [`CachedTemplateData`], so CSS/HTML that
+    /// doesn't depend on what changed isn't re-rendered. `None` for a normal build.
+    pub(crate) carried_render: Option<RenderCache>,
     pub(crate) css_context: Option<Map<String, Value>>,
     pub(crate) fonts: FontOutputs,
+    /// Parsed-glyph cache for incremental `regenerate`; `Some` only when `incremental` is set.
+    pub(crate) glyph_cache: Option<GlyphCache>,
     pub(crate) html_context: Option<Map<String, Value>>,
     pub(crate) options: ResolvedGenerateWebfontsOptions,
     pub(crate) source_files: Vec<LoadedSvgFile>,
+    /// Hash per CSS/HTML output path of what was last written to disk. Seeded by the initial write
+    /// when `write_files` is enabled, then updated by incremental `regenerate` writes so unchanged
+    /// rendered companion files are not rewritten. Font outputs are written directly after real
+    /// rebuilds because they almost always change and hashing them is slower than writing them.
+    pub(crate) written_outputs: HashMap<String, [u8; 16]>,
 }
 
 // Pure Rust getters (always available)
@@ -434,11 +486,42 @@ impl GenerateWebfontsResult {
                     html_context,
                     html_hbs_context: Mutex::new(html_hbs_context),
                     html_registry,
-                    render_cache: Mutex::new(RenderCache::default()),
+                    // Seed with any entries carried across a regenerate (see reset_render_cache);
+                    // these are renders that don't depend on what changed, so reusing them is safe.
+                    render_cache: Mutex::new(self.carried_render.clone().unwrap_or_default()),
                 })
             })
             .as_ref()
             .map_err(to_io_err)
+    }
+
+    /// Reset the lazily-built template/render cache after an incremental `regenerate`. The
+    /// template data (font hash, `src`, contexts) is always rebuilt fresh so default/no-URL
+    /// renders pick up the new font. When `reuse_renders` is true (the glyph names and codepoints
+    /// the templates read are unchanged), the still-valid rendered strings are carried forward to
+    /// seed the rebuilt cache: provided-URL renders always (they don't embed the font hash), and
+    /// no-URL renders only when the CSS template doesn't reference `src` (so it can't embed the
+    /// hash either). Everything else is dropped and re-rendered on next use.
+    pub(crate) fn reset_render_cache(&mut self, reuse_renders: bool) {
+        let carried = reuse_renders
+            .then(|| self.cached.get().and_then(|cached| cached.as_ref().ok()))
+            .flatten()
+            .map(|cached| {
+                let rc = cached.render_cache.lock().unwrap();
+                let keep_no_urls = !cached.shared.css_template_uses_src;
+                RenderCache {
+                    css_no_urls: keep_no_urls.then(|| rc.css_no_urls.clone()).flatten(),
+                    html_no_urls: keep_no_urls.then(|| rc.html_no_urls.clone()).flatten(),
+                    css_last_urls: rc.css_last_urls.clone(),
+                    css_last_result: rc.css_last_result.clone(),
+                    html_last_urls: rc.html_last_urls.clone(),
+                    html_last_result: rc.html_last_result.clone(),
+                }
+            });
+        self.cached = OnceLock::new();
+        self.css_context = None;
+        self.html_context = None;
+        self.carried_render = carried;
     }
 
     /// Generate a CSS string for this webfont result.
@@ -631,6 +714,42 @@ impl GenerateWebfontsResult {
         self.generate_html_pure(urls)
             .map_err(crate::util::to_napi_err)
     }
+
+    /// Rebuild the font after a batch of file changes, reusing cached glyph geometry for files
+    /// whose contents are unchanged. Requires the font to have been generated with
+    /// `incremental: true`. `files` is the complete file set after the changes, in the order a
+    /// fresh build would use (e.g. the glob result) — the rebuilt glyphs are ordered to match it,
+    /// so the output bytes are identical to a fresh `generateWebfonts` of that set. `changes`
+    /// describes the affected files: added/changed files are re-read from disk; any file absent
+    /// from `files` is dropped. Every requested format is refreshed in memory, and — like
+    /// `generateWebfonts` — when the result was built with `writeFiles` enabled the refreshed
+    /// fonts are written to disk too, while CSS/HTML companion files are skipped if their rendered
+    /// bytes are unchanged since the last write.
+    #[napi(js_name = "regenerate")]
+    pub fn regenerate_from_js(
+        &mut self,
+        files: Vec<String>,
+        changes: Vec<GlyphChangeEntry>,
+    ) -> napi::Result<()> {
+        let changes = changes
+            .into_iter()
+            .map(|entry| {
+                let change = match entry.change_type.as_str() {
+                    "added" => GlyphChange::Added { name: entry.name },
+                    "changed" => GlyphChange::Changed { name: entry.name },
+                    "removed" => GlyphChange::Removed,
+                    other => {
+                        return Err(napi::Error::from_reason(format!(
+                            "Unknown changeType '{other}'; expected 'added', 'changed', or 'removed'."
+                        )));
+                    }
+                };
+                Ok((entry.path, change))
+            })
+            .collect::<napi::Result<Vec<_>>>()?;
+        self.regenerate(&files, &changes)
+            .map_err(crate::util::to_napi_err)
+    }
 }
 
 #[cfg(feature = "napi")]
@@ -712,11 +831,14 @@ mod tests {
 
         let result = GenerateWebfontsResult {
             cached: std::sync::OnceLock::new(),
+            carried_render: None,
             css_context: None,
             fonts: FontOutputs::default(),
+            glyph_cache: None,
             html_context: None,
             options: resolved,
             source_files,
+            written_outputs: Default::default(),
         };
 
         if let Some(dir) = cleanup_dir {
@@ -981,11 +1103,14 @@ mod tests {
 
         GenerateWebfontsResult {
             cached: std::sync::OnceLock::new(),
+            carried_render: None,
             css_context: None,
             fonts: FontOutputs::default(),
+            glyph_cache: None,
             html_context: None,
             options: resolved,
             source_files,
+            written_outputs: Default::default(),
         }
     }
 

--- a/packages/webfont-generator/src/write.rs
+++ b/packages/webfont-generator/src/write.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio::task::JoinSet;
+
+use crate::default_output_dest;
+use crate::templates::{render_css_with_hbs_context, render_html_with_hbs_context};
+use crate::types::GenerateWebfontsResult;
+
+enum OutputContents {
+    Bytes(Arc<Vec<u8>>),
+    Text(Arc<String>),
+    Owned(Vec<u8>),
+}
+
+impl OutputContents {
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Bytes(bytes) => bytes.as_slice(),
+            Self::Text(text) => text.as_bytes(),
+            Self::Owned(bytes) => bytes.as_slice(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for OutputContents {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+struct OutputFile {
+    path: String,
+    contents: OutputContents,
+    skip_unchanged: bool,
+}
+
+fn collect_write_outputs(result: &GenerateWebfontsResult) -> std::io::Result<Vec<OutputFile>> {
+    let mut outputs = Vec::new();
+    let font_name = result.options.font_name.clone();
+    let dest = result.options.dest.clone();
+
+    if let Some(svg_font) = &result.fonts.svg_font {
+        outputs.push(OutputFile {
+            path: default_output_dest(&dest, &font_name, "svg"),
+            contents: OutputContents::Text(Arc::clone(svg_font)),
+            skip_unchanged: false,
+        });
+    }
+    if let Some(ttf_font) = &result.fonts.ttf_font {
+        outputs.push(OutputFile {
+            path: default_output_dest(&dest, &font_name, "ttf"),
+            contents: OutputContents::Bytes(Arc::clone(ttf_font)),
+            skip_unchanged: false,
+        });
+    }
+    if let Some(woff_font) = &result.fonts.woff_font {
+        outputs.push(OutputFile {
+            path: default_output_dest(&dest, &font_name, "woff"),
+            contents: OutputContents::Bytes(Arc::clone(woff_font)),
+            skip_unchanged: false,
+        });
+    }
+    if let Some(woff2_font) = &result.fonts.woff2_font {
+        outputs.push(OutputFile {
+            path: default_output_dest(&dest, &font_name, "woff2"),
+            contents: OutputContents::Bytes(Arc::clone(woff2_font)),
+            skip_unchanged: false,
+        });
+    }
+    if let Some(eot_font) = &result.fonts.eot_font {
+        outputs.push(OutputFile {
+            path: default_output_dest(&dest, &font_name, "eot"),
+            contents: OutputContents::Bytes(Arc::clone(eot_font)),
+            skip_unchanged: false,
+        });
+    }
+
+    // Only render CSS/HTML templates when those files need to be written.
+    if result.options.css || result.options.html {
+        let cached = result.get_cached_io()?;
+        if result.options.css {
+            let ctx = cached.css_hbs_context.lock().unwrap();
+            let css = render_css_with_hbs_context(&cached.shared, &ctx, &cached.css_context)?;
+            drop(ctx);
+            outputs.push(OutputFile {
+                path: result.options.css_dest.clone(),
+                contents: OutputContents::Owned(css.into_bytes()),
+                skip_unchanged: true,
+            });
+        }
+        if result.options.html {
+            let ctx = cached.html_hbs_context.lock().unwrap();
+            let html = render_html_with_hbs_context(
+                cached.html_registry.as_ref(),
+                &ctx,
+                &cached.html_context,
+            )?;
+            drop(ctx);
+            outputs.push(OutputFile {
+                path: result.options.html_dest.clone(),
+                contents: OutputContents::Owned(html.into_bytes()),
+                skip_unchanged: true,
+            });
+        }
+    }
+
+    Ok(outputs)
+}
+
+/// Write every output to disk concurrently. For incremental results, also return hashes for
+/// CSS/HTML outputs so a later `regenerate` can skip companion files unchanged from this initial
+/// write.
+pub(crate) async fn write_generate_webfonts_result(
+    result: &GenerateWebfontsResult,
+) -> std::io::Result<Option<HashMap<String, [u8; 16]>>> {
+    let mut tasks = JoinSet::new();
+    let mut written = result.options.incremental.then(HashMap::new);
+
+    for output in collect_write_outputs(result)? {
+        if output.skip_unchanged {
+            record_written_output(&mut written, &output.path, output.contents.as_bytes());
+        }
+        tasks.spawn(async move { write_output_file(output.path, output.contents).await });
+    }
+
+    while let Some(result) = tasks.join_next().await {
+        result.map_err(|error| {
+            std::io::Error::other(format!("Native write task failed: {error}"))
+        })??;
+    }
+
+    Ok(written)
+}
+
+fn record_written_output(
+    written: &mut Option<HashMap<String, [u8; 16]>>,
+    path: &str,
+    bytes: &[u8],
+) {
+    if let Some(written) = written {
+        written.insert(path.to_owned(), output_hash(bytes));
+    }
+}
+
+async fn write_output_file(path: String, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
+    if let Some(parent) = Path::new(&path).parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    tokio::fs::write(path, contents).await
+}
+
+/// Content hash used to skip rewriting unchanged CSS/HTML companion files.
+fn output_hash(bytes: &[u8]) -> [u8; 16] {
+    md5::compute(bytes).0
+}
+
+/// Synchronous counterpart to [`write_generate_webfonts_result`] used by [`GenerateWebfontsResult::regenerate`].
+///
+/// `regenerate` is sync (it borrows `&mut self`, which can't be held across an `.await` in a NAPI
+/// async method), and the rebuild it follows is CPU-bound and already runs on the caller's thread,
+/// so a handful of blocking `std::fs` writes here is simpler than introducing an async write path.
+/// Font outputs are written directly after a real rebuild; only CSS/HTML are hash-checked because
+/// they often remain byte-identical after a geometry-only edit.
+pub(crate) fn write_generate_webfonts_result_sync(
+    result: &mut GenerateWebfontsResult,
+) -> std::io::Result<()> {
+    let outputs = collect_write_outputs(result)?;
+
+    // Write everything, updating `written_outputs` in place. Updating in place (rather than
+    // taking the map and restoring it at the end) means a mid-write failure keeps the hashes of the
+    // outputs already written, so a retry doesn't needlessly rewrite them.
+    let written = &mut result.written_outputs;
+    for output in outputs {
+        if output.skip_unchanged {
+            write_output_file_if_changed(written, output.path, output.contents.as_bytes())?;
+        } else {
+            write_output_file_sync(output.path, output.contents.as_bytes())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_output_file_sync(path: String, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = Path::new(&path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, bytes)
+}
+
+/// Write `bytes` to `path` unless an identical payload was written there before (tracked in `written`).
+fn write_output_file_if_changed(
+    written: &mut HashMap<String, [u8; 16]>,
+    path: String,
+    bytes: &[u8],
+) -> std::io::Result<()> {
+    let hash = output_hash(bytes);
+
+    if written.get(&path) == Some(&hash) {
+        return Ok(());
+    }
+    if let Some(parent) = Path::new(&path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, bytes)?;
+    written.insert(path, hash);
+    Ok(())
+}

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -517,3 +517,141 @@ describe('output size (deterministic)', () => {
         `);
     });
 });
+
+const REGEN_PATHS: Record<string, string> = {
+    a: 'M2 2 L22 2 L22 22 Z',
+    b: 'M2 2 L22 2 L12 22 Z',
+    c: 'M4 4 L20 4 L20 20 L4 20 Z',
+    changed: 'M0 0 L24 0 L24 24 Z',
+};
+const regenIcon = (d: string) => `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="${d}"/></svg>`;
+
+async function writeRegenIcon(dir: string, name: string, key: string) {
+    const path = join(dir, `${name}.svg`);
+    await writeFile(path, regenIcon(REGEN_PATHS[key]));
+    return path;
+}
+
+const regenBaseOpts = (dir: string, files: string[]): GenerateWebfontsInputOptions => ({
+    files,
+    dest: `${dir}/`,
+    fontName: 'rc',
+    fontHeight: 24,
+    css: false,
+    writeFiles: false,
+    types: ['svg', 'ttf', 'eot', 'woff', 'woff2'],
+});
+
+// Normalize to a plain Uint8Array so a Node Buffer from `readFile` compares equal to a font getter.
+const toBytes = (value: Uint8Array) => Uint8Array.from(value);
+
+function assertSameFonts(actual: Awaited<ReturnType<typeof generateWebfonts>>, expected: Awaited<ReturnType<typeof generateWebfonts>>) {
+    expect(actual.svg).toBe(expected.svg);
+    expect(actual.ttf).toEqual(expected.ttf);
+    expect(actual.eot).toEqual(expected.eot);
+    expect(actual.woff).toEqual(expected.woff);
+    expect(actual.woff2).toEqual(expected.woff2);
+}
+
+describe('regenerate (incremental)', () => {
+    it('matches a fresh build after a content change', async () => {
+        const dir = await createTempDir('regen-change-');
+        const [a, b, c] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b'), writeRegenIcon(dir, 'c', 'c')]);
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a, b, c]), incremental: true });
+
+        await writeFile(b, regenIcon(REGEN_PATHS.changed));
+        result.regenerate([a, b, c], [{ path: b, changeType: 'changed' }]);
+
+        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, b, c])));
+    });
+
+    it('matches a fresh build after adding a file', async () => {
+        const dir = await createTempDir('regen-add-');
+        const [a, b] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b')]);
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a, b]), incremental: true });
+
+        const c = await writeRegenIcon(dir, 'c', 'c');
+        result.regenerate([a, b, c], [{ path: c, changeType: 'added' }]);
+
+        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, b, c])));
+    });
+
+    it('matches a fresh build after adding a file that sorts before existing glyphs', async () => {
+        const dir = await createTempDir('regen-add-mid-');
+        const [b, c] = await Promise.all([writeRegenIcon(dir, 'b', 'b'), writeRegenIcon(dir, 'c', 'c')]);
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [b, c]), incremental: true });
+
+        const a = await writeRegenIcon(dir, 'a', 'a');
+        // The fresh-build order is [a, b, c]; passing it ensures the addition lands first, not at the tail.
+        result.regenerate([a, b, c], [{ path: a, changeType: 'added' }]);
+
+        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, b, c])));
+    });
+
+    it('matches a fresh build after removing a file', async () => {
+        const dir = await createTempDir('regen-remove-');
+        const [a, b, c] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b'), writeRegenIcon(dir, 'c', 'c')]);
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a, b, c]), incremental: true });
+
+        result.regenerate([a, c], [{ path: b, changeType: 'removed' }]);
+
+        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, c])));
+    });
+
+    it('reuses the CSS render on a content edit and re-renders on rename', async () => {
+        const dir = await createTempDir('regen-css-');
+        const [a, b] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b')]);
+        const urls = { woff2: '/static/icons.woff2' };
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a, b]), incremental: true });
+        const before = result.generateCss(urls);
+
+        // Content edit keeps names/codepoints → CSS reused verbatim and equal to a fresh build.
+        await writeFile(b, regenIcon(REGEN_PATHS.changed));
+        result.regenerate([a, b], [{ path: b, changeType: 'changed' }]);
+        expect(result.generateCss(urls)).toBe(before);
+        const fresh = await generateWebfonts(regenBaseOpts(dir, [a, b]));
+        expect(result.generateCss(urls)).toBe(fresh.generateCss(urls));
+
+        // A rename changes a glyph name the template reads → CSS must re-render.
+        result.regenerate([a, b], [{ path: b, changeType: 'changed', name: 'renamed' }]);
+        expect(result.generateCss(urls)).not.toBe(before);
+        expect(result.generateCss(urls)).toContain('renamed');
+    });
+
+    it('refreshes on-disk outputs when writeFiles is true, and skips unchanged ones', async () => {
+        const dir = await createTempDir('regen-write-src-');
+        const dest = await createTempDir('regen-write-out-');
+        const [a, b] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b')]);
+        const opts: GenerateWebfontsInputOptions = { files: [a, b], dest, fontName: 'rc', fontHeight: 24, css: true, writeFiles: true, incremental: true, types: ['woff2'] };
+        const result = await generateWebfonts(opts);
+
+        const woff2Path = join(dest, 'rc.woff2');
+        const cssPath = join(dest, 'rc.css');
+        const [woff2Before, cssBefore] = await Promise.all([readFile(woff2Path), readFile(cssPath)]);
+
+        await writeFile(b, regenIcon(REGEN_PATHS.changed));
+        result.regenerate([a, b], [{ path: b, changeType: 'changed' }]);
+
+        const [woff2After, cssAfter] = await Promise.all([readFile(woff2Path), readFile(cssPath)]);
+        expect(woff2After).not.toEqual(woff2Before);
+        expect(cssAfter).not.toEqual(cssBefore);
+        // Disk matches the rebuilt in-memory bytes, and a fresh build of the new set.
+        expect(toBytes(woff2After)).toEqual(toBytes(result.woff2));
+        const fresh = await generateWebfonts({ ...opts, writeFiles: false, incremental: false });
+        expect(toBytes(woff2After)).toEqual(toBytes(fresh.woff2));
+
+        // A no-op regenerate reproduces identical output, so the write is skipped: a deleted file
+        // is not recreated.
+        await rm(woff2Path);
+        result.regenerate([a, b], [{ path: b, changeType: 'changed' }]);
+        await expect(readFile(woff2Path)).rejects.toThrow(/ENOENT/);
+    });
+
+    it('throws when regenerate is called without incremental', async () => {
+        const dir = await createTempDir('regen-noinc-');
+        const a = await writeRegenIcon(dir, 'a', 'a');
+        const result = await generateWebfonts(regenBaseOpts(dir, [a]));
+
+        expect(() => result.regenerate([a], [{ path: a, changeType: 'changed' }])).toThrow(/incremental/);
+    });
+});

--- a/tests/webfonts-generator.bench.ts
+++ b/tests/webfonts-generator.bench.ts
@@ -1,6 +1,6 @@
 // oxlint-disable jest/no-standalone-expect
 import { join } from 'node:path';
-import { rmSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -303,4 +303,295 @@ describe.each([5, 300])('generateCss / generateHtml — %i glyphs', numGlyphs =>
             bench('new core', () => expect(newCore.generateHtml(templateUrls)).toBeDefined(), benchOpts);
         });
     });
+});
+
+// Incremental rebuild: full regen vs reusing unchanged glyphs.
+const DEV_FORMAT = { formatOptions: { woff2: { compressionQuality: 10 } } };
+const EDIT_SVG_A = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>';
+const EDIT_SVG_B = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20L12 22z"/></svg>';
+
+async function makeEditableFiles(numGlyphs: number, label: string): Promise<string[]> {
+    const editFile = join(bulkFixtureDir, `${label}-${numGlyphs}-edit.svg`);
+    await writeFile(editFile, EDIT_SVG_A);
+    return [editFile, ...bulkFiles.slice(1, numGlyphs)];
+}
+
+const incrementalResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].map(async numGlyphs => {
+        const result = await generateWebfonts(baseOpts(bulkFiles.slice(0, numGlyphs), { incremental: true, ...DEV_FORMAT }));
+        incrementalResults.set(numGlyphs, result);
+    }),
+);
+
+describe.each([100, 300, 600])('changed event with unchanged contents — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const opts = baseOpts(files, DEV_FORMAT);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const result = incrementalResults.get(numGlyphs)!;
+    const change = [{ path: files[0]!, changeType: 'changed' as const }];
+
+    bench('upstream — full regen', () => expect(upstreamDirect(opts)).resolves.toBeDefined(), benchOpts);
+    bench('new core — full regen (legacy)', () => expect(generateWebfonts(opts)).resolves.toBeDefined(), benchOpts);
+    bench('new core — incremental regenerate', () => expect(result.regenerate(files, change)).toBeUndefined(), benchOpts);
+});
+
+const contentEditFiles = new Map<number, string[]>();
+const contentEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].map(async numGlyphs => {
+        const files = await makeEditableFiles(numGlyphs, 'regen-content');
+        const result = await generateWebfonts(baseOpts(files, { incremental: true, ...DEV_FORMAT }));
+        contentEditFiles.set(numGlyphs, files);
+        contentEditResults.set(numGlyphs, result);
+    }),
+);
+
+describe.each([100, 300, 600])('rebuild after a 1-file content edit — %i glyphs', numGlyphs => {
+    const files = contentEditFiles.get(numGlyphs)!;
+    const opts = baseOpts(files, DEV_FORMAT);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const result = contentEditResults.get(numGlyphs)!;
+    const change = [{ path: files[0]!, changeType: 'changed' as const }];
+    let toggle = false;
+
+    bench('upstream — full regen', () => expect(upstreamDirect(opts)).resolves.toBeDefined(), benchOpts);
+    bench('new core — full regen (legacy)', () => expect(generateWebfonts(opts)).resolves.toBeDefined(), benchOpts);
+    bench(
+        'new core — incremental regenerate',
+        () => {
+            toggle = !toggle;
+            writeFileSync(files[0]!, toggle ? EDIT_SVG_B : EDIT_SVG_A);
+            expect(result.regenerate(files, change)).toBeUndefined();
+        },
+        benchOpts,
+    );
+});
+
+// Rebuild plus CSS render; provided URLs make content-only edits cacheable.
+const RENDER_URLS = { svg: '/f.svg', ttf: '/f.ttf', eot: '/f.eot', woff: '/f.woff', woff2: '/f.woff2' };
+const ADD_POSITIONS = ['start', 'middle', 'end'] as const;
+const extraSvgs = new Map<(typeof ADD_POSITIONS)[number], string>();
+await Promise.all(
+    ADD_POSITIONS.map(async position => {
+        const path = join(bulkFixtureDir, `icon-extra-${position}.svg`);
+        await writeFile(path, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>');
+        extraSvgs.set(position, path);
+    }),
+);
+
+function insertAtPosition(files: string[], extra: string, position: (typeof ADD_POSITIONS)[number]): string[] {
+    if (position === 'start') {
+        return [extra, ...files];
+    }
+    if (position === 'end') {
+        return [...files, extra];
+    }
+    const index = Math.floor(files.length / 2);
+    return [...files.slice(0, index), extra, ...files.slice(index)];
+}
+
+describe.each([100, 300, 600])('changed event + CSS with unchanged contents — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const opts = baseOpts(files, DEV_FORMAT);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const result = incrementalResults.get(numGlyphs)!;
+    const change = [{ path: files[0]!, changeType: 'changed' as const }];
+
+    bench('new core — full regen + render CSS', () => expect(generateWebfonts(opts).then(r => r.generateCss(RENDER_URLS))).resolves.toBeDefined(), benchOpts);
+    bench(
+        'new core — incremental regenerate + reuse CSS',
+        () => {
+            result.regenerate(files, change);
+            expect(result.generateCss(RENDER_URLS)).toBeDefined();
+        },
+        benchOpts,
+    );
+});
+
+const contentEditCssFiles = new Map<number, string[]>();
+const contentEditCssResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].map(async numGlyphs => {
+        const files = await makeEditableFiles(numGlyphs, 'regen-content-css');
+        const result = await generateWebfonts(baseOpts(files, { incremental: true, ...DEV_FORMAT }));
+        contentEditCssFiles.set(numGlyphs, files);
+        contentEditCssResults.set(numGlyphs, result);
+    }),
+);
+
+describe.each([100, 300, 600])('rebuild + CSS after a 1-file content edit — %i glyphs', numGlyphs => {
+    const files = contentEditCssFiles.get(numGlyphs)!;
+    const opts = baseOpts(files, DEV_FORMAT);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const result = contentEditCssResults.get(numGlyphs)!;
+    const change = [{ path: files[0]!, changeType: 'changed' as const }];
+    let toggle = false;
+
+    bench('new core — full regen + render CSS', () => expect(generateWebfonts(opts).then(r => r.generateCss(RENDER_URLS))).resolves.toBeDefined(), benchOpts);
+    bench(
+        'new core — incremental regenerate + reuse CSS',
+        () => {
+            toggle = !toggle;
+            writeFileSync(files[0]!, toggle ? EDIT_SVG_B : EDIT_SVG_A);
+            result.regenerate(files, change);
+            expect(result.generateCss(RENDER_URLS)).toBeDefined();
+        },
+        benchOpts,
+    );
+});
+
+// writeFiles path: regenerate should update disk outputs when enabled.
+const writeResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].map(async numGlyphs => {
+        const dest = join(bulkFixtureDir, `regen-write-${numGlyphs}`);
+        const result = await generateWebfonts(baseOpts(bulkFiles.slice(0, numGlyphs), { incremental: true, writeFiles: true, dest, ...DEV_FORMAT }));
+        writeResults.set(numGlyphs, result);
+    }),
+);
+
+describe.each([100, 300, 600])('rebuild + writeFiles after a 1-file change — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const result = writeResults.get(numGlyphs)!;
+    const change = [{ path: files[0]!, changeType: 'changed' as const }];
+
+    bench(
+        'new core — full regen + writeFiles',
+        () => expect(generateWebfonts(baseOpts(files, { writeFiles: true, dest: join(bulkFixtureDir, `full-write-${numGlyphs}`), ...DEV_FORMAT }))).resolves.toBeDefined(),
+        benchOpts,
+    );
+    bench('new core — incremental regenerate + writeFiles', () => expect(result.regenerate(files, change)).toBeUndefined(), benchOpts);
+});
+
+const contentEditWriteFiles = new Map<number, string[]>();
+const contentEditWriteResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].map(async numGlyphs => {
+        const files = await makeEditableFiles(numGlyphs, 'regen-content-write');
+        const dest = join(bulkFixtureDir, `regen-content-write-${numGlyphs}`);
+        const result = await generateWebfonts(baseOpts(files, { incremental: true, writeFiles: true, dest, ...DEV_FORMAT }));
+        contentEditWriteFiles.set(numGlyphs, files);
+        contentEditWriteResults.set(numGlyphs, result);
+    }),
+);
+
+describe.each([100, 300, 600])('rebuild + writeFiles after a 1-file content edit — %i glyphs', numGlyphs => {
+    const files = contentEditWriteFiles.get(numGlyphs)!;
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const result = contentEditWriteResults.get(numGlyphs)!;
+    const change = [{ path: files[0]!, changeType: 'changed' as const }];
+    let toggle = false;
+
+    bench(
+        'new core — full regen + writeFiles',
+        () => expect(generateWebfonts(baseOpts(files, { writeFiles: true, dest: join(bulkFixtureDir, `full-content-write-${numGlyphs}`), ...DEV_FORMAT }))).resolves.toBeDefined(),
+        benchOpts,
+    );
+    bench(
+        'new core — incremental regenerate + writeFiles',
+        () => {
+            toggle = !toggle;
+            writeFileSync(files[0]!, toggle ? EDIT_SVG_B : EDIT_SVG_A);
+            expect(result.regenerate(files, change)).toBeUndefined();
+        },
+        benchOpts,
+    );
+});
+
+// No-op content change isolates write-skip overhead when rebuilt bytes are unchanged.
+const writeSkipResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].map(async numGlyphs => {
+        const dest = join(bulkFixtureDir, `regen-write-skip-${numGlyphs}`);
+        const result = await generateWebfonts(
+            baseOpts(bulkFiles.slice(0, numGlyphs), {
+                css: true,
+                html: true,
+                incremental: true,
+                writeFiles: true,
+                dest,
+                ...DEV_FORMAT,
+            }),
+        );
+        writeSkipResults.set(numGlyphs, result);
+    }),
+);
+
+describe.each([100, 300, 600])('write-skip on unchanged outputs — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const result = writeSkipResults.get(numGlyphs)!;
+    const change = [{ path: files[0]!, changeType: 'changed' as const }];
+
+    bench(
+        'new core — full regen + writeFiles',
+        () =>
+            expect(
+                generateWebfonts(baseOpts(files, { css: true, html: true, writeFiles: true, dest: join(bulkFixtureDir, `full-write-skip-${numGlyphs}`), ...DEV_FORMAT })),
+            ).resolves.toBeDefined(),
+        benchOpts,
+    );
+    bench('new core — incremental regenerate + write-skip', () => expect(result.regenerate(files, change)).toBeUndefined(), benchOpts);
+});
+
+// Ordered regenerate should keep adds/removes byte-identical at any insertion point.
+const addRemoveResults = new Map<string, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].flatMap(numGlyphs =>
+        ADD_POSITIONS.map(async position => {
+            const result = await generateWebfonts(baseOpts(bulkFiles.slice(0, numGlyphs), { incremental: true, ...DEV_FORMAT }));
+            addRemoveResults.set(`${numGlyphs}-${position}`, result);
+        }),
+    ),
+);
+
+describe.each([100, 300, 600])('ordered add/remove regenerate — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+
+    describe.each(ADD_POSITIONS)('add at %s', position => {
+        const extra = extraSvgs.get(position)!;
+        const filesWithExtra = insertAtPosition(files, extra, position);
+        const result = addRemoveResults.get(`${numGlyphs}-${position}`)!;
+        let hasExtra = false;
+
+        bench('new core — full regen after add', () => expect(generateWebfonts(baseOpts(filesWithExtra, DEV_FORMAT))).resolves.toBeDefined(), benchOpts);
+        bench('new core — full regen after remove', () => expect(generateWebfonts(baseOpts(files, DEV_FORMAT))).resolves.toBeDefined(), benchOpts);
+        bench(
+            'new core — incremental add/remove toggle',
+            () => {
+                if (hasExtra) {
+                    result.regenerate(files, [{ path: extra, changeType: 'removed' }]);
+                } else {
+                    result.regenerate(filesWithExtra, [{ path: extra, changeType: 'added', name: `icon-extra-${position}` }]);
+                }
+                hasExtra = !hasExtra;
+                expect(result.svg).toBeDefined();
+            },
+            benchOpts,
+        );
+    });
+});
+
+// WOFF2 quality: isolate brotli speed at q9/q10/q11.
+describe.each([100, 300, 600])('woff2 quality — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const woff2Opts = (quality: number) => baseOpts(files, { types: ['woff2'], formatOptions: { woff2: { compressionQuality: quality } } });
+
+    bench('upstream', () => expect(upstreamDirect(baseOpts(files, { types: ['woff2'] }))).resolves.toBeDefined(), benchOpts);
+    bench('new core — q11', () => expect(generateWebfonts(woff2Opts(11))).resolves.toBeDefined(), benchOpts);
+    bench('new core — q10', () => expect(generateWebfonts(woff2Opts(10))).resolves.toBeDefined(), benchOpts);
+    bench('new core — q9', () => expect(generateWebfonts(woff2Opts(9))).resolves.toBeDefined(), benchOpts);
+});
+
+// Initial-build overhead of retaining parsed glyphs for regenerate().
+describe.each([100, 300, 600])('incremental population — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+
+    bench('new core — incremental: false', () => expect(generateWebfonts(baseOpts(files, { incremental: false }))).resolves.toBeDefined(), benchOpts);
+    bench('new core — incremental: true', () => expect(generateWebfonts(baseOpts(files, { incremental: true }))).resolves.toBeDefined(), benchOpts);
 });


### PR DESCRIPTION
## Summary
- Add `incremental` generation and `GenerateWebfontsResult::regenerate()` to the Rust/Node webfont generator.
- Reuse parsed glyph geometry with content-addressed source hashes, skip no-op changed events, and skip unchanged CSS/HTML writes during incremental rebuilds.
- Use incremental regeneration from the Vite plugin watch path with fallback to full generation, while keeping `cssContext` on full generation.
- Add docs, API declarations, tests, and benchmarks for incremental rebuild behavior.

## Performance
- No-op changed events are ~383x-1078x faster than the new full-regeneration path.
- Real one-file content edits are ~1.13x-1.17x faster.
- Write-skip no-op paths are ~413x-1073x faster than full regeneration with writes.

## Notes
- `vp test --coverage` still emits the existing mixed Vitest/coverage version warning.
- Docs build still emits the existing VitePress chunk-size warning.