### PR TITLE
test(webfont-generator): add rust criterion benchmarks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
         "source.fixAll.oxc": "explicit"
     },
     "rust-analyzer.linkedProjects": ["packages/webfont-generator/Cargo.toml"],
-    "rust-analyzer.cargo.features": ["cli", "napi"]
+    "rust-analyzer.cargo.features": ["cli", "napi", "bench"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ When changing the public API (adding/removing/renaming options, functions, types
 
 - [ ] Run `vp install` after pulling remote changes and before getting started.
 - [ ] Run `vp check` and `vp run test` to validate changes.
+- [ ] Run `vp run @atlowchemi/webfont-generator#bench --no-run` after changing Rust benchmark targets or benchmark-only support code; run targeted Criterion filters when changing measured behavior.
 - [ ] Run `vp run @atlowchemi/vite-svg-webfont-docs#build` when changing the docs site, docs config, or docs deployment workflow.
 - [ ] After adding/removing/modifying SVG icons in `packages/vite-svg-2-webfont/src/fixtures/webfont-test/svg/`, run `vp run vite-svg-2-webfont#test:fixtures:refresh` to regenerate expected font fixtures.
 - [ ] Use conventional commit messages.

--- a/packages/webfont-generator/Cargo.lock
+++ b/packages/webfont-generator/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +159,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -216,6 +270,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +329,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -518,6 +614,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "handlebars"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,10 +681,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -587,6 +720,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kurbo"
@@ -762,10 +906,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxvg_parse"
@@ -780,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdff6083c950ef9268d9646efd268ab8839ca1f63970887062578879f32c4571"
 dependencies = [
  "bitflags",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "oxvg_parse",
  "ryu",
@@ -848,6 +1004,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polycool"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +1089,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1137,12 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustybuzz"
@@ -948,6 +1167,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1126,6 +1354,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,10 +1515,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webfont-generator"
 version = "0.4.0"
 dependencies = [
  "clap",
+ "criterion",
  "flate2",
  "handlebars",
  "kurbo",
@@ -1297,6 +1601,15 @@ dependencies = [
  "usvg",
  "woff",
  "write-fonts",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1343,6 +1656,26 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/packages/webfont-generator/Cargo.toml
+++ b/packages/webfont-generator/Cargo.toml
@@ -21,6 +21,7 @@ required-features = ["cli"]
 default = []
 napi = ["dep:napi", "dep:napi-derive"]
 cli = ["dep:clap"]
+bench = []
 
 [dependencies]
 clap = { version = "4", features = ["derive"], optional = true }
@@ -41,7 +42,20 @@ usvg = "0.47.0"
 write-fonts = { version = "0.49.1", features = ["read"] }
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[[bench]]
+name = "incremental"
+harness = false
+
+[[bench]]
+name = "pipeline"
+harness = false
+
+[[bench]]
+name = "features"
+harness = false
 
 [build-dependencies]
 napi-build = "2.3.2"

--- a/packages/webfont-generator/Cargo.toml
+++ b/packages/webfont-generator/Cargo.toml
@@ -48,14 +48,17 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 [[bench]]
 name = "incremental"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "pipeline"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "features"
 harness = false
+required-features = ["bench"]
 
 [build-dependencies]
 napi-build = "2.3.2"

--- a/packages/webfont-generator/benches/features.rs
+++ b/packages/webfont-generator/benches/features.rs
@@ -10,6 +10,7 @@ use webfont_generator::{
 };
 
 const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
+const BENCH_DEST: &str = "/tmp/webfont-generator-feature-bench-out";
 
 struct FixtureSet {
     dir: PathBuf,
@@ -181,7 +182,7 @@ fn template_file(dir: &Path, name: &str, contents: &str) -> String {
 fn base_options(paths: Vec<String>, types: Vec<FontType>) -> GenerateWebfontsOptions {
     GenerateWebfontsOptions {
         css: Some(false),
-        dest: temp_dir("out").to_string_lossy().into_owned(),
+        dest: BENCH_DEST.to_owned(),
         files: paths,
         font_name: Some("bench".to_owned()),
         format_options: Some(FormatOptions {

--- a/packages/webfont-generator/benches/features.rs
+++ b/packages/webfont-generator/benches/features.rs
@@ -1,0 +1,560 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use serde_json::Value;
+use webfont_generator::{
+    FontType, FormatOptions, GenerateWebfontsOptions, RenameFn, SvgFormatOptions, TtfFormatOptions,
+    Woff2FormatOptions,
+};
+
+const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
+
+struct FixtureSet {
+    dir: PathBuf,
+    paths: Vec<String>,
+}
+
+impl Drop for FixtureSet {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.dir).ok();
+    }
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "webfont-generator-feature-bench-{prefix}-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn heavy_path(index: usize) -> String {
+    let mut d = String::new();
+    let start_x = 2.0 + (index % 5) as f64 * 0.35;
+    let start_y = 2.0 + (index % 7) as f64 * 0.25;
+    d.push_str(&format!("M{start_x:.2} {start_y:.2}"));
+    for segment in 0..16 {
+        let t = (index + segment) as f64;
+        let x1 = 3.0 + ((t * 1.7) % 18.0);
+        let y1 = 3.0 + ((t * 2.3) % 18.0);
+        let x2 = 3.0 + ((t * 3.1 + 5.0) % 18.0);
+        let y2 = 3.0 + ((t * 1.3 + 7.0) % 18.0);
+        let x = 3.0 + ((t * 2.9 + 11.0) % 18.0);
+        let y = 3.0 + ((t * 3.7 + 13.0) % 18.0);
+        d.push_str(&format!(" C{x1:.2} {y1:.2} {x2:.2} {y2:.2} {x:.2} {y:.2}"));
+    }
+    d.push_str(" Z");
+    d
+}
+
+fn svg_path(d: &str) -> String {
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{d}\"/></svg>"
+    )
+}
+
+fn svg_for(kind: &str, index: usize) -> String {
+    match kind {
+        "simple" => svg_path(&format!(
+            "M2 2 L{} 2 L{} {} L2 {} Z",
+            12 + index % 10,
+            20,
+            20,
+            20
+        )),
+        "multipath" => format!(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{}\"/><path d=\"{}\"/></svg>",
+            heavy_path(index),
+            heavy_path(index + 17)
+        ),
+        "shapes" => format!(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><rect x=\"2\" y=\"2\" width=\"{}\" height=\"{}\"/><circle cx=\"12\" cy=\"12\" r=\"{}\"/></svg>",
+            8 + index % 12,
+            8 + index % 10,
+            2 + index % 7
+        ),
+        "transformed" => format!(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><g transform=\"translate(2 1) rotate({})\"><path d=\"{}\"/></g></svg>",
+            index % 45,
+            heavy_path(index)
+        ),
+        "hidden" => format!(
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{}\"/><path display=\"none\" d=\"{}\"/></svg>",
+            heavy_path(index),
+            heavy_path(index + 23)
+        ),
+        "duplicate" => svg_path(&heavy_path(0)),
+        _ => svg_path(&heavy_path(index)),
+    }
+}
+
+fn iconify_json_path(icon_set: &str) -> Option<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let direct = root
+        .join("node_modules")
+        .join("@iconify-json")
+        .join(icon_set)
+        .join("icons.json");
+    if direct.exists() {
+        return Some(direct);
+    }
+
+    let pnpm = root.join("node_modules/.pnpm");
+    let prefix = format!("@iconify-json+{icon_set}@");
+    for entry in std::fs::read_dir(pnpm).ok()? {
+        let entry = entry.ok()?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if !file_name.starts_with(&prefix) {
+            continue;
+        }
+        let path = entry
+            .path()
+            .join("node_modules")
+            .join("@iconify-json")
+            .join(icon_set)
+            .join("icons.json");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn iconify_svgs(size: usize) -> Option<Vec<(String, String)>> {
+    let icon_set = std::env::var("BENCH_ICON_SET").unwrap_or_else(|_| "simple-icons".to_owned());
+    let path = iconify_json_path(&icon_set)?;
+    let json: Value = serde_json::from_slice(&std::fs::read(path).ok()?).ok()?;
+    let default_width = json.get("width").and_then(Value::as_u64).unwrap_or(24);
+    let default_height = json.get("height").and_then(Value::as_u64).unwrap_or(24);
+    let icons = json.get("icons")?.as_object()?;
+    let mut svgs = Vec::with_capacity(size);
+    for (index, (name, icon)) in icons.iter().take(size).enumerate() {
+        let width = icon
+            .get("width")
+            .and_then(Value::as_u64)
+            .unwrap_or(default_width);
+        let height = icon
+            .get("height")
+            .and_then(Value::as_u64)
+            .unwrap_or(default_height);
+        let body = icon.get("body")?.as_str()?;
+        let view_width = width + (index as u64 % 5) * (width / 2).max(1);
+        let view_height = height + ((index as u64 * 3) % 7) * (height / 3).max(1);
+        svgs.push((
+            name.replace(['/', ':'], "-"),
+            format!(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {view_width} {view_height}\">{body}</svg>"
+            ),
+        ));
+    }
+    (svgs.len() == size).then_some(svgs)
+}
+
+fn fixtures(size: usize, kind: &str) -> FixtureSet {
+    let dir = temp_dir(kind);
+    let mut paths = Vec::with_capacity(size);
+    let iconify = (kind == "iconify").then(|| iconify_svgs(size)).flatten();
+    for index in 0..size {
+        let (name, contents) = iconify
+            .as_ref()
+            .and_then(|icons| icons.get(index).cloned())
+            .unwrap_or_else(|| (format!("{kind}-{index:04}"), svg_for(kind, index)));
+        let path = dir.join(format!("{name}.svg"));
+        std::fs::write(&path, contents).unwrap();
+        paths.push(path.to_string_lossy().into_owned());
+    }
+    FixtureSet { dir, paths }
+}
+
+fn template_file(dir: &Path, name: &str, contents: &str) -> String {
+    let path = dir.join(name);
+    std::fs::write(&path, contents).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+fn base_options(paths: Vec<String>, types: Vec<FontType>) -> GenerateWebfontsOptions {
+    GenerateWebfontsOptions {
+        css: Some(false),
+        dest: temp_dir("out").to_string_lossy().into_owned(),
+        files: paths,
+        font_name: Some("bench".to_owned()),
+        format_options: Some(FormatOptions {
+            ttf: Some(TtfFormatOptions {
+                copyright: None,
+                description: None,
+                ts: Some(TEST_TTF_TIMESTAMP),
+                url: None,
+                version: None,
+            }),
+            woff2: Some(Woff2FormatOptions {
+                compression_quality: Some(10),
+            }),
+            ..Default::default()
+        }),
+        html: Some(false),
+        ligature: Some(false),
+        types: Some(types),
+        write_files: Some(false),
+        ..Default::default()
+    }
+}
+
+fn urls() -> HashMap<FontType, String> {
+    HashMap::from([
+        (FontType::Svg, "/font.svg".to_owned()),
+        (FontType::Ttf, "/font.ttf".to_owned()),
+        (FontType::Eot, "/font.eot".to_owned()),
+        (FontType::Woff, "/font.woff".to_owned()),
+        (FontType::Woff2, "/font.woff2".to_owned()),
+    ])
+}
+
+fn bench_template_rendering(c: &mut Criterion) {
+    let mut group = c.benchmark_group("template_rendering");
+    group.sample_size(10);
+    let fixture = fixtures(300, "heavy");
+    let mut opts = base_options(fixture.paths.clone(), vec![FontType::Woff2]);
+    opts.css = Some(true);
+    opts.html = Some(true);
+    let result = webfont_generator::generate_sync(opts.clone(), None).unwrap();
+
+    group.bench_function("css_first/default/300", |b| {
+        b.iter_batched(
+            || webfont_generator::generate_sync(opts.clone(), None).unwrap(),
+            |result| result.generate_css_pure(None).unwrap(),
+            BatchSize::SmallInput,
+        )
+    });
+    result.generate_css_pure(None).unwrap();
+    group.bench_function("css_cached/default/300", |b| {
+        b.iter(|| result.generate_css_pure(None).unwrap())
+    });
+    group.bench_function("css_urls/default/300", |b| {
+        b.iter(|| result.generate_css_pure(Some(urls())).unwrap())
+    });
+    group.bench_function("html_first/default/300", |b| {
+        b.iter_batched(
+            || webfont_generator::generate_sync(opts.clone(), None).unwrap(),
+            |result| result.generate_html_pure(None).unwrap(),
+            BatchSize::SmallInput,
+        )
+    });
+    result.generate_html_pure(None).unwrap();
+    group.bench_function("html_cached/default/300", |b| {
+        b.iter(|| result.generate_html_pure(None).unwrap())
+    });
+
+    let template_dir = temp_dir("templates");
+    let css_template = template_file(
+        &template_dir,
+        "bench.css.hbs",
+        "{{fontName}} {{#each codepoints}}{{@key}}:{{this}};{{/each}} {{{src}}}",
+    );
+    let html_template = template_file(
+        &template_dir,
+        "bench.html.hbs",
+        "<html>{{fontName}}{{#each names}}<i>{{this}}</i>{{/each}}<style>{{{styles}}}</style></html>",
+    );
+    let mut custom_opts = opts.clone();
+    custom_opts.css_template = Some(css_template);
+    custom_opts.html_template = Some(html_template);
+    group.bench_function("css_first/custom/300", |b| {
+        b.iter_batched(
+            || webfont_generator::generate_sync(custom_opts.clone(), None).unwrap(),
+            |result| result.generate_css_pure(None).unwrap(),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("html_first/custom/300", |b| {
+        b.iter_batched(
+            || webfont_generator::generate_sync(custom_opts.clone(), None).unwrap(),
+            |result| result.generate_html_pure(None).unwrap(),
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_write_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("write_paths");
+    group.sample_size(10);
+    let fixture = fixtures(100, "heavy");
+    group.bench_function("initial_write/100", |b| {
+        b.iter_batched(
+            || {
+                let mut opts = base_options(fixture.paths.clone(), vec![FontType::Woff2]);
+                opts.css = Some(true);
+                opts.html = Some(true);
+                opts.dest = temp_dir("write").to_string_lossy().into_owned();
+                opts.write_files = Some(true);
+                opts
+            },
+            |opts| webfont_generator::generate_sync(opts, None).unwrap(),
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("incremental_write_skip/100", |b| {
+        b.iter_batched(
+            || {
+                let mut opts = base_options(fixture.paths.clone(), vec![FontType::Woff2]);
+                opts.css = Some(true);
+                opts.dest = temp_dir("write-skip").to_string_lossy().into_owned();
+                opts.incremental = Some(true);
+                opts.write_files = Some(true);
+                let result = webfont_generator::generate_sync(opts, None).unwrap();
+                (result, fixture.paths[0].clone())
+            },
+            |(mut result, changed)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(
+                            changed,
+                            webfont_generator::GlyphChange::Changed { name: None },
+                        )],
+                    )
+                    .unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_input_complexity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("input_complexity");
+    group.sample_size(10);
+    for kind in [
+        "simple",
+        "heavy",
+        "multipath",
+        "shapes",
+        "transformed",
+        "hidden",
+        "iconify",
+    ] {
+        let fixture = fixtures(100, kind);
+        group.bench_function(format!("{kind}/100"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(
+                    base_options(fixture.paths.clone(), vec![FontType::Svg]),
+                    None,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_geometry_options(c: &mut Criterion) {
+    let mut group = c.benchmark_group("geometry_options");
+    group.sample_size(10);
+    let fixture = fixtures(300, "heavy");
+    for name in [
+        "normalize_false",
+        "normalize_true",
+        "fixed_width",
+        "center_h",
+        "center_v",
+        "preserve_aspect",
+        "round_2",
+        "optimize_output",
+    ] {
+        group.bench_function(format!("{name}/300"), |b| {
+            b.iter(|| {
+                let mut opts = base_options(fixture.paths.clone(), vec![FontType::Svg]);
+                match name {
+                    "normalize_false" => opts.normalize = Some(false),
+                    "normalize_true" => opts.normalize = Some(true),
+                    "fixed_width" => opts.fixed_width = Some(true),
+                    "center_h" => opts.center_horizontally = Some(true),
+                    "center_v" => opts.center_vertically = Some(true),
+                    "preserve_aspect" => opts.preserve_aspect_ratio = Some(true),
+                    "round_2" => opts.round = Some(2.0),
+                    "optimize_output" => {
+                        opts.format_options.get_or_insert_with(Default::default).svg =
+                            Some(SvgFormatOptions {
+                                optimize_output: Some(true),
+                                ..Default::default()
+                            });
+                    }
+                    _ => unreachable!(),
+                }
+                webfont_generator::generate_sync(opts, None).unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_ttf_features(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ttf_features");
+    group.sample_size(10);
+    for (name, fixture, ligature, explicit) in [
+        (
+            "ligatures_false_unique",
+            fixtures(300, "heavy"),
+            false,
+            false,
+        ),
+        ("ligatures_true_unique", fixtures(300, "heavy"), true, false),
+        ("explicit_codepoints", fixtures(300, "heavy"), false, true),
+        (
+            "duplicate_outlines",
+            fixtures(300, "duplicate"),
+            false,
+            false,
+        ),
+    ] {
+        group.bench_function(format!("{name}/300"), |b| {
+            b.iter(|| {
+                let mut opts = base_options(fixture.paths.clone(), vec![FontType::Ttf]);
+                opts.ligature = Some(ligature);
+                if explicit {
+                    opts.codepoints = Some(
+                        fixture
+                            .paths
+                            .iter()
+                            .enumerate()
+                            .map(|(index, path)| {
+                                let name = Path::new(path)
+                                    .file_stem()
+                                    .and_then(|stem| stem.to_str())
+                                    .unwrap_or_default()
+                                    .to_owned();
+                                (name, 0xE000 + index as u32)
+                            })
+                            .collect(),
+                    );
+                }
+                webfont_generator::generate_sync(opts, None).unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_error_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("error_paths");
+    group.sample_size(10);
+    let fixture = fixtures(10, "heavy");
+    let missing = temp_dir("missing")
+        .join("missing.svg")
+        .to_string_lossy()
+        .into_owned();
+    let invalid_dir = temp_dir("invalid");
+    let invalid = invalid_dir
+        .join("invalid.svg")
+        .to_string_lossy()
+        .into_owned();
+    std::fs::write(&invalid, "<svg><path></svg>").unwrap();
+    group.bench_function("empty_files", |b| {
+        b.iter(|| {
+            let result = webfont_generator::generate_sync(
+                base_options(Vec::new(), vec![FontType::Svg]),
+                None,
+            );
+            assert!(result.is_err());
+        })
+    });
+    group.bench_function("missing_file", |b| {
+        b.iter(|| {
+            let result = webfont_generator::generate_sync(
+                base_options(vec![missing.clone()], vec![FontType::Svg]),
+                None,
+            );
+            assert!(result.is_err());
+        })
+    });
+    group.bench_function("invalid_svg", |b| {
+        b.iter(|| {
+            let result = webfont_generator::generate_sync(
+                base_options(vec![invalid.clone()], vec![FontType::Svg]),
+                None,
+            );
+            assert!(result.is_err());
+        })
+    });
+    group.bench_function("duplicate_glyph_names", |b| {
+        b.iter(|| {
+            let rename: RenameFn = Box::new(|_| "duplicate".to_owned());
+            let result = webfont_generator::generate_sync(
+                base_options(fixture.paths.clone(), vec![FontType::Svg]),
+                Some(rename),
+            );
+            assert!(result.is_err());
+        })
+    });
+    group.finish();
+}
+
+fn bench_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scaling");
+    group.sample_size(10);
+    for size in [15, 100, 300, 600, 1000] {
+        let fixture = fixtures(size, "heavy");
+        group.bench_function(format!("woff2/{size}"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(
+                    base_options(fixture.paths.clone(), vec![FontType::Woff2]),
+                    None,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_async_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("async_overhead");
+    group.sample_size(10);
+    let fixture = fixtures(15, "heavy");
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    group.bench_function("generate_sync/15", |b| {
+        b.iter(|| {
+            webfont_generator::generate_sync(
+                base_options(fixture.paths.clone(), vec![FontType::Svg]),
+                None,
+            )
+            .unwrap()
+        })
+    });
+    group.bench_function("generate_async/15", |b| {
+        b.iter(|| {
+            runtime
+                .block_on(webfont_generator::generate(
+                    base_options(fixture.paths.clone(), vec![FontType::Svg]),
+                    None,
+                ))
+                .unwrap()
+        })
+    });
+    group.finish();
+}
+
+fn criterion_config() -> Criterion {
+    Criterion::default().sample_size(10)
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets =
+        bench_template_rendering,
+        bench_write_paths,
+        bench_input_complexity,
+        bench_geometry_options,
+        bench_ttf_features,
+        bench_error_paths,
+        bench_scaling,
+        bench_async_overhead
+}
+criterion_main!(benches);

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -13,6 +13,7 @@ use webfont_generator::{
 };
 
 const SIZES: [usize; 3] = [100, 300, 600];
+const BENCH_DEST: &str = "/tmp/webfont-generator-bench-out";
 const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
 
 struct FixtureSet {
@@ -190,7 +191,7 @@ fn options_with_types(
 ) -> GenerateWebfontsOptions {
     GenerateWebfontsOptions {
         css: Some(false),
-        dest: temp_dir("out").to_string_lossy().into_owned(),
+        dest: BENCH_DEST.to_owned(),
         files: paths,
         font_name: Some("bench".to_owned()),
         format_options: Some(FormatOptions {

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -1,0 +1,695 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use serde_json::Value;
+use webfont_generator::bench_support::{
+    BenchGlyphCache, BenchSvgSource, prepare_svg_full, prepare_svg_incremental,
+};
+use webfont_generator::{
+    FontType, FormatOptions, GenerateWebfontsOptions, GlyphChange, TtfFormatOptions,
+    Woff2FormatOptions,
+};
+
+const SIZES: [usize; 3] = [100, 300, 600];
+const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
+
+struct FixtureSet {
+    dir: PathBuf,
+    paths: Vec<String>,
+    sources: Vec<BenchSvgSource>,
+}
+
+impl Drop for FixtureSet {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.dir).ok();
+    }
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "webfont-generator-bench-{prefix}-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn path_data(index: usize) -> String {
+    // A deterministic but non-trivial path: enough curve/line segments to make SVG parsing and
+    // path processing visible without depending on external icon packages at bench time.
+    let mut d = String::new();
+    let start_x = 2.0 + (index % 5) as f64 * 0.35;
+    let start_y = 2.0 + (index % 7) as f64 * 0.25;
+    d.push_str(&format!("M{start_x:.2} {start_y:.2}"));
+    for segment in 0..24 {
+        let t = (index + segment) as f64;
+        let x1 = 3.0 + ((t * 1.7) % 18.0);
+        let y1 = 3.0 + ((t * 2.3) % 18.0);
+        let x2 = 3.0 + ((t * 3.1 + 5.0) % 18.0);
+        let y2 = 3.0 + ((t * 1.3 + 7.0) % 18.0);
+        let x = 3.0 + ((t * 2.9 + 11.0) % 18.0);
+        let y = 3.0 + ((t * 3.7 + 13.0) % 18.0);
+        d.push_str(&format!(" C{x1:.2} {y1:.2} {x2:.2} {y2:.2} {x:.2} {y:.2}"));
+    }
+    d.push_str(" Z");
+    d
+}
+
+fn changed_path_data() -> String {
+    let mut d = String::from("M1 1");
+    for segment in 0..24 {
+        let t = segment as f64;
+        let x1 = 2.0 + ((t * 2.1) % 20.0);
+        let y1 = 2.0 + ((t * 1.9) % 20.0);
+        let x2 = 2.0 + ((t * 3.3 + 3.0) % 20.0);
+        let y2 = 2.0 + ((t * 2.7 + 4.0) % 20.0);
+        let x = 2.0 + ((t * 1.5 + 6.0) % 20.0);
+        let y = 2.0 + ((t * 3.5 + 8.0) % 20.0);
+        d.push_str(&format!(" C{x1:.2} {y1:.2} {x2:.2} {y2:.2} {x:.2} {y:.2}"));
+    }
+    d.push_str(" Z");
+    d
+}
+
+fn svg(path_data: &str) -> String {
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{path_data}\"/></svg>"
+    )
+}
+
+fn write_icon(dir: &Path, name: &str, path_data: &str) -> String {
+    let path = dir.join(format!("{name}.svg"));
+    std::fs::write(&path, svg(path_data)).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+fn iconify_json_path(icon_set: &str) -> Option<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let direct = root
+        .join("node_modules")
+        .join("@iconify-json")
+        .join(icon_set)
+        .join("icons.json");
+    if direct.exists() {
+        return Some(direct);
+    }
+
+    let pnpm = root.join("node_modules/.pnpm");
+    let prefix = format!("@iconify-json+{icon_set}@");
+    for entry in std::fs::read_dir(pnpm).ok()? {
+        let entry = entry.ok()?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if !file_name.starts_with(&prefix) {
+            continue;
+        }
+        let path = entry
+            .path()
+            .join("node_modules")
+            .join("@iconify-json")
+            .join(icon_set)
+            .join("icons.json");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn iconify_svgs(size: usize) -> Option<Vec<(String, String)>> {
+    let icon_set = std::env::var("BENCH_ICON_SET").unwrap_or_else(|_| "simple-icons".to_owned());
+    let path = iconify_json_path(&icon_set)?;
+    let json: Value = serde_json::from_slice(&std::fs::read(path).ok()?).ok()?;
+    let default_width = json.get("width").and_then(Value::as_u64).unwrap_or(24);
+    let default_height = json.get("height").and_then(Value::as_u64).unwrap_or(24);
+    let icons = json.get("icons")?.as_object()?;
+    let mut svgs = Vec::with_capacity(size);
+    for (index, (name, icon)) in icons.iter().take(size).enumerate() {
+        let width = icon
+            .get("width")
+            .and_then(Value::as_u64)
+            .unwrap_or(default_width);
+        let height = icon
+            .get("height")
+            .and_then(Value::as_u64)
+            .unwrap_or(default_height);
+        let body = icon.get("body")?.as_str()?;
+        let view_width = width + (index as u64 % 5) * (width / 2).max(1);
+        let view_height = height + ((index as u64 * 3) % 7) * (height / 3).max(1);
+        svgs.push((
+            name.replace(['/', ':'], "-"),
+            format!(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {view_width} {view_height}\">{body}</svg>"
+            ),
+        ));
+    }
+    (svgs.len() == size).then_some(svgs)
+}
+
+fn fixtures(size: usize) -> FixtureSet {
+    let dir = temp_dir(&format!("{size}"));
+    let mut paths = Vec::with_capacity(size);
+    let mut sources = Vec::with_capacity(size);
+    let iconify = iconify_svgs(size);
+    for index in 0..size {
+        let (name, contents) = iconify
+            .as_ref()
+            .and_then(|icons| icons.get(index).cloned())
+            .unwrap_or_else(|| (format!("icon-{index:04}"), svg(&path_data(index))));
+        let path = dir
+            .join(format!("{name}.svg"))
+            .to_string_lossy()
+            .into_owned();
+        std::fs::write(&path, &contents).unwrap();
+        paths.push(path.clone());
+        sources.push(BenchSvgSource {
+            path,
+            glyph_name: name,
+            contents,
+        });
+    }
+    FixtureSet {
+        dir,
+        paths,
+        sources,
+    }
+}
+
+fn options(paths: Vec<String>, incremental: bool) -> GenerateWebfontsOptions {
+    options_with_types(paths, incremental, vec![FontType::Woff2])
+}
+
+fn options_with_types(
+    paths: Vec<String>,
+    incremental: bool,
+    types: Vec<FontType>,
+) -> GenerateWebfontsOptions {
+    GenerateWebfontsOptions {
+        css: Some(false),
+        dest: temp_dir("out").to_string_lossy().into_owned(),
+        files: paths,
+        font_name: Some("bench".to_owned()),
+        format_options: Some(FormatOptions {
+            ttf: Some(TtfFormatOptions {
+                copyright: None,
+                description: None,
+                ts: Some(TEST_TTF_TIMESTAMP),
+                url: None,
+                version: None,
+            }),
+            woff2: Some(Woff2FormatOptions {
+                compression_quality: Some(10),
+            }),
+            ..Default::default()
+        }),
+        html: Some(false),
+        incremental: Some(incremental),
+        ligature: Some(false),
+        types: Some(types),
+        write_files: Some(false),
+        ..Default::default()
+    }
+}
+
+fn css_html_options(paths: Vec<String>, incremental: bool) -> GenerateWebfontsOptions {
+    let mut opts = options(paths, incremental);
+    opts.css = Some(true);
+    opts.html = Some(true);
+    opts
+}
+
+fn urls() -> HashMap<FontType, String> {
+    HashMap::from([
+        (FontType::Svg, "/font.svg".to_owned()),
+        (FontType::Ttf, "/font.ttf".to_owned()),
+        (FontType::Eot, "/font.eot".to_owned()),
+        (FontType::Woff, "/font.woff".to_owned()),
+        (FontType::Woff2, "/font.woff2".to_owned()),
+    ])
+}
+
+fn insert_position(paths: &[String], added: String, position: &str) -> Vec<String> {
+    let mut ordered = paths.to_vec();
+    let index = match position {
+        "start" => 0,
+        "middle" => ordered.len() / 2,
+        "end" => ordered.len(),
+        _ => unreachable!(),
+    };
+    ordered.insert(index, added);
+    ordered
+}
+
+fn remove_position(paths: &[String], position: &str) -> (Vec<String>, String) {
+    let index = match position {
+        "start" => 0,
+        "middle" => paths.len() / 2,
+        "end" => paths.len() - 1,
+        _ => unreachable!(),
+    };
+    let mut ordered = paths.to_vec();
+    let removed = ordered.remove(index);
+    (ordered, removed)
+}
+
+fn bench_svg_prepare(c: &mut Criterion) {
+    let mut group = c.benchmark_group("svg_prepare");
+    group.sample_size(10);
+    for size in SIZES {
+        let fixture = fixtures(size);
+        group.bench_function(format!("full/{size}"), |b| {
+            b.iter(|| {
+                prepare_svg_full(options(fixture.paths.clone(), false), &fixture.sources).unwrap()
+            })
+        });
+
+        let mut cache = BenchGlyphCache::default();
+        prepare_svg_incremental(
+            options(fixture.paths.clone(), true),
+            &fixture.sources,
+            &mut cache,
+        )
+        .unwrap();
+        group.bench_function(format!("incremental_warm/{size}"), |b| {
+            b.iter(|| {
+                prepare_svg_incremental(
+                    options(fixture.paths.clone(), true),
+                    &fixture.sources,
+                    &mut cache,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_regenerate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("regenerate");
+    group.sample_size(10);
+    for size in SIZES {
+        let fixture = fixtures(size);
+        let mut result =
+            webfont_generator::generate_sync(options(fixture.paths.clone(), true), None).unwrap();
+        let changed = fixture.paths[size / 2].clone();
+        group.bench_function(format!("full_unchanged/{size}"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(options(fixture.paths.clone(), false), None)
+                    .unwrap()
+            })
+        });
+        group.bench_function(format!("noop_changed/{size}"), |b| {
+            b.iter(|| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(changed.clone(), GlyphChange::Changed { name: None })],
+                    )
+                    .unwrap()
+            })
+        });
+
+        group.bench_function(format!("full_content_edit/{size}"), |b| {
+            b.iter_batched(
+                || {
+                    let fixture = fixtures(size);
+                    let changed = fixture.paths[size / 2].clone();
+                    std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                    fixture
+                },
+                |fixture| {
+                    webfont_generator::generate_sync(options(fixture.paths.clone(), false), None)
+                        .unwrap()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.bench_function(format!("incremental_content_edit/{size}"), |b| {
+            b.iter_batched(
+                || {
+                    let fixture = fixtures(size);
+                    let result = webfont_generator::generate_sync(
+                        options(fixture.paths.clone(), true),
+                        None,
+                    )
+                    .unwrap();
+                    let changed = fixture.paths[size / 2].clone();
+                    std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                    (fixture, result, changed)
+                },
+                |(fixture, mut result, changed)| {
+                    result
+                        .regenerate(
+                            &fixture.paths,
+                            &[(changed, GlyphChange::Changed { name: None })],
+                        )
+                        .unwrap()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+fn bench_add_remove(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add_remove");
+    group.sample_size(10);
+    for size in SIZES {
+        for position in ["start", "middle", "end"] {
+            group.bench_function(format!("full_add_at_{position}/{size}"), |b| {
+                b.iter_batched(
+                    || {
+                        let mut fixture = fixtures(size);
+                        let added = write_icon(
+                            &fixture.dir,
+                            &format!("added-{position}"),
+                            &changed_path_data(),
+                        );
+                        fixture.paths = insert_position(&fixture.paths, added, position);
+                        fixture
+                    },
+                    |fixture| {
+                        webfont_generator::generate_sync(
+                            options(fixture.paths.clone(), false),
+                            None,
+                        )
+                        .unwrap()
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+
+            group.bench_function(format!("incremental_add_at_{position}/{size}"), |b| {
+                b.iter_batched(
+                    || {
+                        let mut fixture = fixtures(size);
+                        let added = write_icon(
+                            &fixture.dir,
+                            &format!("added-{position}"),
+                            &changed_path_data(),
+                        );
+                        let result = webfont_generator::generate_sync(
+                            options(fixture.paths.clone(), true),
+                            None,
+                        )
+                        .unwrap();
+                        fixture.paths = insert_position(&fixture.paths, added.clone(), position);
+                        (fixture, result, added)
+                    },
+                    |(fixture, mut result, added)| {
+                        result
+                            .regenerate(
+                                &fixture.paths,
+                                &[(added, GlyphChange::Added { name: None })],
+                            )
+                            .unwrap()
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+
+            group.bench_function(format!("full_remove_at_{position}/{size}"), |b| {
+                b.iter_batched(
+                    || {
+                        let mut fixture = fixtures(size);
+                        let (ordered, _) = remove_position(&fixture.paths, position);
+                        fixture.paths = ordered;
+                        fixture
+                    },
+                    |fixture| {
+                        webfont_generator::generate_sync(
+                            options(fixture.paths.clone(), false),
+                            None,
+                        )
+                        .unwrap()
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+
+            group.bench_function(format!("incremental_remove_at_{position}/{size}"), |b| {
+                b.iter_batched(
+                    || {
+                        let mut fixture = fixtures(size);
+                        let result = webfont_generator::generate_sync(
+                            options(fixture.paths.clone(), true),
+                            None,
+                        )
+                        .unwrap();
+                        let (ordered, removed) = remove_position(&fixture.paths, position);
+                        fixture.paths = ordered;
+                        (fixture, result, removed)
+                    },
+                    |(fixture, mut result, removed)| {
+                        result
+                            .regenerate(&fixture.paths, &[(removed, GlyphChange::Removed)])
+                            .unwrap()
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+        }
+    }
+    group.finish();
+}
+
+fn bench_render_cache_after_regenerate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("render_cache_after_regenerate");
+    group.sample_size(10);
+    let size = 300;
+    group.bench_function("content_edit_css_urls_reused/300", |b| {
+        b.iter_batched(
+            || {
+                let fixture = fixtures(size);
+                let result = webfont_generator::generate_sync(
+                    css_html_options(fixture.paths.clone(), true),
+                    None,
+                )
+                .unwrap();
+                result.generate_css_pure(Some(urls())).unwrap();
+                let changed = fixture.paths[size / 2].clone();
+                std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                (fixture, result, changed)
+            },
+            |(fixture, mut result, changed)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(changed, GlyphChange::Changed { name: None })],
+                    )
+                    .unwrap();
+                result.generate_css_pure(Some(urls())).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("rename_css_rerender/300", |b| {
+        b.iter_batched(
+            || {
+                let fixture = fixtures(size);
+                let result = webfont_generator::generate_sync(
+                    css_html_options(fixture.paths.clone(), true),
+                    None,
+                )
+                .unwrap();
+                result.generate_css_pure(Some(urls())).unwrap();
+                let changed = fixture.paths[size / 2].clone();
+                (fixture, result, changed)
+            },
+            |(fixture, mut result, changed)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(
+                            changed,
+                            GlyphChange::Changed {
+                                name: Some("renamed-glyph".to_owned()),
+                            },
+                        )],
+                    )
+                    .unwrap();
+                result.generate_css_pure(Some(urls())).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_incremental_write_content_edit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("write_files_after_regenerate");
+    group.sample_size(10);
+    let size = 100;
+    group.bench_function("content_edit/100", |b| {
+        b.iter_batched(
+            || {
+                let fixture = fixtures(size);
+                let mut opts = css_html_options(fixture.paths.clone(), true);
+                opts.dest = temp_dir("write-content-edit")
+                    .to_string_lossy()
+                    .into_owned();
+                opts.write_files = Some(true);
+                let result = webfont_generator::generate_sync(opts, None).unwrap();
+                let changed = fixture.paths[size / 2].clone();
+                std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                (fixture, result, changed)
+            },
+            |(fixture, mut result, changed)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(changed, GlyphChange::Changed { name: None })],
+                    )
+                    .unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_specialized_incremental_paths(c: &mut Criterion) {
+    let mut group = c.benchmark_group("specialized_incremental_paths");
+    group.sample_size(10);
+    let size = 300;
+    group.bench_function("rename_only/300", |b| {
+        b.iter_batched(
+            || {
+                let fixture = fixtures(size);
+                let result =
+                    webfont_generator::generate_sync(options(fixture.paths.clone(), true), None)
+                        .unwrap();
+                let changed = fixture.paths[size / 2].clone();
+                (fixture, result, changed)
+            },
+            |(fixture, mut result, changed)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(
+                            changed,
+                            GlyphChange::Changed {
+                                name: Some("renamed-glyph".to_owned()),
+                            },
+                        )],
+                    )
+                    .unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("duplicate_content_add/300", |b| {
+        b.iter_batched(
+            || {
+                let mut fixture = fixtures(size);
+                let duplicate = fixture.dir.join("duplicate-added.svg");
+                std::fs::copy(&fixture.paths[0], &duplicate).unwrap();
+                let duplicate = duplicate.to_string_lossy().into_owned();
+                let result =
+                    webfont_generator::generate_sync(options(fixture.paths.clone(), true), None)
+                        .unwrap();
+                fixture.paths.push(duplicate.clone());
+                (fixture, result, duplicate)
+            },
+            |(fixture, mut result, duplicate)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(duplicate, GlyphChange::Added { name: None })],
+                    )
+                    .unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_regenerate_by_format(c: &mut Criterion) {
+    let mut group = c.benchmark_group("regenerate_by_format");
+    group.sample_size(10);
+    let size = 300;
+    for (label, types) in [
+        ("svg", vec![FontType::Svg]),
+        ("ttf", vec![FontType::Ttf]),
+        ("woff2", vec![FontType::Woff2]),
+        (
+            "all_formats",
+            vec![
+                FontType::Svg,
+                FontType::Ttf,
+                FontType::Eot,
+                FontType::Woff,
+                FontType::Woff2,
+            ],
+        ),
+    ] {
+        group.bench_function(format!("full_content_edit/{label}/{size}"), |b| {
+            b.iter_batched(
+                || {
+                    let fixture = fixtures(size);
+                    let changed = fixture.paths[size / 2].clone();
+                    std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                    fixture
+                },
+                |fixture| {
+                    webfont_generator::generate_sync(
+                        options_with_types(fixture.paths.clone(), false, types.clone()),
+                        None,
+                    )
+                    .unwrap()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function(format!("incremental_content_edit/{label}/{size}"), |b| {
+            b.iter_batched(
+                || {
+                    let fixture = fixtures(size);
+                    let result = webfont_generator::generate_sync(
+                        options_with_types(fixture.paths.clone(), true, types.clone()),
+                        None,
+                    )
+                    .unwrap();
+                    let changed = fixture.paths[size / 2].clone();
+                    std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                    (fixture, result, changed)
+                },
+                |(fixture, mut result, changed)| {
+                    result
+                        .regenerate(
+                            &fixture.paths,
+                            &[(changed, GlyphChange::Changed { name: None })],
+                        )
+                        .unwrap()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+fn criterion_config() -> Criterion {
+    Criterion::default().sample_size(10)
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets =
+        bench_svg_prepare,
+        bench_regenerate,
+        bench_add_remove,
+        bench_regenerate_by_format,
+        bench_render_cache_after_regenerate,
+        bench_incremental_write_content_edit,
+        bench_specialized_incremental_paths
+}
+criterion_main!(benches);

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use serde_json::Value;
 use webfont_generator::bench_support::{
-    build_outputs_only, finalize_svg_only, parse_svg_only, BenchSvgSource,
+    BenchSvgSource, build_outputs_only, finalize_svg_only, parse_svg_only,
 };
 use webfont_generator::{
     FontType, FormatOptions, GenerateWebfontsOptions, SvgFormatOptions, TtfFormatOptions,

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use serde_json::Value;
 use webfont_generator::bench_support::{
-    BenchSvgSource, build_outputs_only, finalize_svg_only, parse_svg_only,
+    build_outputs_only, finalize_svg_only, parse_svg_only, BenchSvgSource,
 };
 use webfont_generator::{
     FontType, FormatOptions, GenerateWebfontsOptions, SvgFormatOptions, TtfFormatOptions,
@@ -261,14 +261,18 @@ fn bench_pipeline_stages(c: &mut Criterion) {
         )
         .unwrap();
         group.bench_function(format!("finalize_only/{size}"), |b| {
-            b.iter(|| {
-                finalize_svg_only(
-                    options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
-                    &fixture.sources,
-                    parsed.clone(),
-                )
-                .unwrap()
-            })
+            b.iter_batched(
+                || parsed.clone(),
+                |parsed| {
+                    finalize_svg_only(
+                        options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+                        &fixture.sources,
+                        parsed,
+                    )
+                    .unwrap()
+                },
+                BatchSize::LargeInput,
+            )
         });
 
         let prepared = finalize_svg_only(

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -1,0 +1,368 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use serde_json::Value;
+use webfont_generator::bench_support::{
+    BenchSvgSource, build_outputs_only, finalize_svg_only, parse_svg_only,
+};
+use webfont_generator::{
+    FontType, FormatOptions, GenerateWebfontsOptions, SvgFormatOptions, TtfFormatOptions,
+    Woff2FormatOptions,
+};
+
+const SIZES: [usize; 3] = [100, 300, 600];
+const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
+
+struct FixtureSet {
+    dir: PathBuf,
+    paths: Vec<String>,
+    sources: Vec<BenchSvgSource>,
+}
+
+impl Drop for FixtureSet {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.dir).ok();
+    }
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "webfont-generator-pipeline-bench-{prefix}-{}-{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn path_data(index: usize) -> String {
+    let mut d = String::new();
+    let start_x = 2.0 + (index % 5) as f64 * 0.35;
+    let start_y = 2.0 + (index % 7) as f64 * 0.25;
+    d.push_str(&format!("M{start_x:.2} {start_y:.2}"));
+    for segment in 0..24 {
+        let t = (index + segment) as f64;
+        let x1 = 3.0 + ((t * 1.7) % 18.0);
+        let y1 = 3.0 + ((t * 2.3) % 18.0);
+        let x2 = 3.0 + ((t * 3.1 + 5.0) % 18.0);
+        let y2 = 3.0 + ((t * 1.3 + 7.0) % 18.0);
+        let x = 3.0 + ((t * 2.9 + 11.0) % 18.0);
+        let y = 3.0 + ((t * 3.7 + 13.0) % 18.0);
+        d.push_str(&format!(" C{x1:.2} {y1:.2} {x2:.2} {y2:.2} {x:.2} {y:.2}"));
+    }
+    d.push_str(" Z");
+    d
+}
+
+fn svg(path_data: &str) -> String {
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{path_data}\"/></svg>"
+    )
+}
+
+fn iconify_json_path(icon_set: &str) -> Option<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let direct = root
+        .join("node_modules")
+        .join("@iconify-json")
+        .join(icon_set)
+        .join("icons.json");
+    if direct.exists() {
+        return Some(direct);
+    }
+
+    let pnpm = root.join("node_modules/.pnpm");
+    let prefix = format!("@iconify-json+{icon_set}@");
+    for entry in std::fs::read_dir(pnpm).ok()? {
+        let entry = entry.ok()?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if !file_name.starts_with(&prefix) {
+            continue;
+        }
+        let path = entry
+            .path()
+            .join("node_modules")
+            .join("@iconify-json")
+            .join(icon_set)
+            .join("icons.json");
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn iconify_svgs(size: usize) -> Option<Vec<(String, String)>> {
+    let icon_set = std::env::var("BENCH_ICON_SET").unwrap_or_else(|_| "simple-icons".to_owned());
+    let path = iconify_json_path(&icon_set)?;
+    let json: Value = serde_json::from_slice(&std::fs::read(path).ok()?).ok()?;
+    let default_width = json.get("width").and_then(Value::as_u64).unwrap_or(24);
+    let default_height = json.get("height").and_then(Value::as_u64).unwrap_or(24);
+    let icons = json.get("icons")?.as_object()?;
+    let mut svgs = Vec::with_capacity(size);
+    for (index, (name, icon)) in icons.iter().take(size).enumerate() {
+        let width = icon
+            .get("width")
+            .and_then(Value::as_u64)
+            .unwrap_or(default_width);
+        let height = icon
+            .get("height")
+            .and_then(Value::as_u64)
+            .unwrap_or(default_height);
+        let body = icon.get("body")?.as_str()?;
+        let view_width = width + (index as u64 % 5) * (width / 2).max(1);
+        let view_height = height + ((index as u64 * 3) % 7) * (height / 3).max(1);
+        svgs.push((
+            name.replace(['/', ':'], "-"),
+            format!(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {view_width} {view_height}\">{body}</svg>"
+            ),
+        ));
+    }
+    (svgs.len() == size).then_some(svgs)
+}
+
+fn fixtures(size: usize) -> FixtureSet {
+    let dir = temp_dir(&format!("{size}"));
+    let mut paths = Vec::with_capacity(size);
+    let mut sources = Vec::with_capacity(size);
+    let iconify = iconify_svgs(size);
+    for index in 0..size {
+        let (name, contents) = iconify
+            .as_ref()
+            .and_then(|icons| icons.get(index).cloned())
+            .unwrap_or_else(|| (format!("icon-{index:04}"), svg(&path_data(index))));
+        let path = dir.join(format!("{name}.svg"));
+        std::fs::write(&path, &contents).unwrap();
+        let path = path.to_string_lossy().into_owned();
+        paths.push(path.clone());
+        sources.push(BenchSvgSource {
+            path,
+            glyph_name: name,
+            contents,
+        });
+    }
+    FixtureSet {
+        dir,
+        paths,
+        sources,
+    }
+}
+
+fn format_options(woff2_quality: u8, optimize_output: bool) -> FormatOptions {
+    FormatOptions {
+        svg: Some(SvgFormatOptions {
+            optimize_output: Some(optimize_output),
+            ..Default::default()
+        }),
+        ttf: Some(TtfFormatOptions {
+            copyright: None,
+            description: None,
+            ts: Some(TEST_TTF_TIMESTAMP),
+            url: None,
+            version: None,
+        }),
+        woff2: Some(Woff2FormatOptions {
+            compression_quality: Some(woff2_quality),
+        }),
+        ..Default::default()
+    }
+}
+
+fn options(
+    paths: Vec<String>,
+    types: Vec<FontType>,
+    woff2_quality: u8,
+    optimize_output: bool,
+) -> GenerateWebfontsOptions {
+    GenerateWebfontsOptions {
+        css: Some(false),
+        dest: temp_dir("out").to_string_lossy().into_owned(),
+        files: paths,
+        font_name: Some("bench".to_owned()),
+        format_options: Some(format_options(woff2_quality, optimize_output)),
+        html: Some(false),
+        ligature: Some(false),
+        types: Some(types),
+        write_files: Some(false),
+        ..Default::default()
+    }
+}
+
+fn bench_pipeline_slices(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pipeline");
+    group.sample_size(10);
+    for size in SIZES {
+        let fixture = fixtures(size);
+        group.bench_function(format!("svg/{size}"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(
+                    options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+                    None,
+                )
+                .unwrap()
+            })
+        });
+        group.bench_function(format!("ttf/{size}"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(
+                    options(fixture.paths.clone(), vec![FontType::Ttf], 10, false),
+                    None,
+                )
+                .unwrap()
+            })
+        });
+        group.bench_function(format!("all_formats/{size}"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(
+                    options(
+                        fixture.paths.clone(),
+                        vec![
+                            FontType::Svg,
+                            FontType::Ttf,
+                            FontType::Eot,
+                            FontType::Woff,
+                            FontType::Woff2,
+                        ],
+                        10,
+                        false,
+                    ),
+                    None,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_pipeline_stages(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pipeline_stages");
+    group.sample_size(10);
+    for size in SIZES {
+        let fixture = fixtures(size);
+        group.bench_function(format!("parse_only/{size}"), |b| {
+            b.iter(|| {
+                parse_svg_only(
+                    options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+                    &fixture.sources,
+                )
+                .unwrap()
+            })
+        });
+
+        let parsed = parse_svg_only(
+            options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+            &fixture.sources,
+        )
+        .unwrap();
+        group.bench_function(format!("finalize_only/{size}"), |b| {
+            b.iter(|| {
+                finalize_svg_only(
+                    options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+                    &fixture.sources,
+                    parsed.clone(),
+                )
+                .unwrap()
+            })
+        });
+
+        let prepared = finalize_svg_only(
+            options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+            &fixture.sources,
+            parsed,
+        )
+        .unwrap();
+        group.bench_function(format!("ttf_output_only/{size}"), |b| {
+            b.iter(|| {
+                build_outputs_only(
+                    options(fixture.paths.clone(), vec![FontType::Ttf], 10, false),
+                    &fixture.sources,
+                    &prepared,
+                )
+                .unwrap()
+            })
+        });
+        group.bench_function(format!("woff_output_only/{size}"), |b| {
+            b.iter(|| {
+                build_outputs_only(
+                    options(fixture.paths.clone(), vec![FontType::Woff], 10, false),
+                    &fixture.sources,
+                    &prepared,
+                )
+                .unwrap()
+            })
+        });
+        group.bench_function(format!("woff2_output_only/{size}"), |b| {
+            b.iter(|| {
+                build_outputs_only(
+                    options(fixture.paths.clone(), vec![FontType::Woff2], 10, false),
+                    &fixture.sources,
+                    &prepared,
+                )
+                .unwrap()
+            })
+        });
+        group.bench_function(format!("eot_output_only/{size}"), |b| {
+            b.iter(|| {
+                build_outputs_only(
+                    options(fixture.paths.clone(), vec![FontType::Eot], 10, false),
+                    &fixture.sources,
+                    &prepared,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_woff2_quality(c: &mut Criterion) {
+    let mut group = c.benchmark_group("woff2_quality");
+    group.sample_size(10);
+    let fixture = fixtures(300);
+    for quality in [9, 10, 11] {
+        group.bench_function(format!("quality_{quality}"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(
+                    options(fixture.paths.clone(), vec![FontType::Woff2], quality, false),
+                    None,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_optimize_output(c: &mut Criterion) {
+    let mut group = c.benchmark_group("optimize_output");
+    group.sample_size(10);
+    let fixture = fixtures(300);
+    for optimize in [false, true] {
+        group.bench_function(format!("optimize_{optimize}"), |b| {
+            b.iter(|| {
+                webfont_generator::generate_sync(
+                    options(fixture.paths.clone(), vec![FontType::Svg], 10, optimize),
+                    None,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+fn criterion_config() -> Criterion {
+    Criterion::default().sample_size(10)
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets = bench_pipeline_slices, bench_pipeline_stages, bench_woff2_quality, bench_optimize_output
+}
+criterion_main!(benches);

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -12,6 +12,7 @@ use webfont_generator::{
 };
 
 const SIZES: [usize; 3] = [100, 300, 600];
+const BENCH_DEST: &str = "/tmp/webfont-generator-pipeline-bench-out";
 const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
 
 struct FixtureSet {
@@ -180,7 +181,7 @@ fn options(
 ) -> GenerateWebfontsOptions {
     GenerateWebfontsOptions {
         css: Some(false),
-        dest: temp_dir("out").to_string_lossy().into_owned(),
+        dest: BENCH_DEST.to_owned(),
         files: paths,
         font_name: Some("bench".to_owned()),
         format_options: Some(format_options(woff2_quality, optimize_output)),

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -109,6 +109,124 @@ use types::{
     resolved_font_types,
 };
 
+#[cfg(feature = "bench")]
+pub mod bench_support {
+    use std::io;
+
+    use super::{
+        GenerateWebfontsOptions, GlyphCache, LoadedSvgFile, PreparedSvgFont, build_font_outputs,
+        finalize_generate_webfonts_options, prepare_svg_font, prepare_svg_font_incremental,
+        resolve_generate_webfonts_options, svg_options_from_options,
+    };
+    use crate::svg::types::ParsedGlyph;
+    use crate::svg::{finalize_glyphs, parse_glyphs};
+
+    /// Source fixture used by Rust benchmarks without exposing generator internals.
+    #[derive(Clone)]
+    pub struct BenchSvgSource {
+        pub path: String,
+        pub glyph_name: String,
+        pub contents: String,
+    }
+
+    /// Opaque parsed-glyph cache used by incremental SVG prepare benchmarks.
+    #[derive(Clone, Default)]
+    pub struct BenchGlyphCache(GlyphCache);
+
+    /// Opaque parsed glyph set used to isolate parse and finalize stages.
+    #[derive(Clone)]
+    pub struct BenchParsedGlyphs(Vec<ParsedGlyph>);
+
+    /// Opaque prepared SVG font used to isolate font-output generation stages.
+    #[derive(Clone)]
+    pub struct BenchPreparedSvgFont(PreparedSvgFont);
+
+    fn load_sources(sources: &[BenchSvgSource]) -> Vec<LoadedSvgFile> {
+        sources
+            .iter()
+            .map(|source| LoadedSvgFile {
+                contents: source.contents.clone(),
+                glyph_name: source.glyph_name.clone(),
+                path: source.path.clone(),
+            })
+            .collect()
+    }
+
+    fn resolve(
+        options: GenerateWebfontsOptions,
+        sources: &[LoadedSvgFile],
+    ) -> io::Result<super::ResolvedGenerateWebfontsOptions> {
+        let mut options = resolve_generate_webfonts_options(options)?;
+        finalize_generate_webfonts_options(&mut options, sources)?;
+        Ok(options)
+    }
+
+    /// Run the SVG parse+process preparation path and return the number of prepared glyphs.
+    pub fn prepare_svg_full(
+        options: GenerateWebfontsOptions,
+        sources: &[BenchSvgSource],
+    ) -> io::Result<usize> {
+        let sources = load_sources(sources);
+        let options = resolve(options, &sources)?;
+        let svg_options = svg_options_from_options(&options);
+        let prepared = prepare_svg_font(&svg_options, &sources)?;
+        Ok(prepared.processed_glyphs.len())
+    }
+
+    /// Parse SVG glyph geometry without running set-wide finalization/processing.
+    pub fn parse_svg_only(
+        options: GenerateWebfontsOptions,
+        sources: &[BenchSvgSource],
+    ) -> io::Result<BenchParsedGlyphs> {
+        let sources = load_sources(sources);
+        let options = resolve(options, &sources)?;
+        let svg_options = svg_options_from_options(&options);
+        parse_glyphs(&svg_options, &sources).map(BenchParsedGlyphs)
+    }
+
+    /// Run set-wide SVG finalization/processing from already parsed glyph geometry.
+    pub fn finalize_svg_only(
+        options: GenerateWebfontsOptions,
+        sources: &[BenchSvgSource],
+        parsed: BenchParsedGlyphs,
+    ) -> io::Result<BenchPreparedSvgFont> {
+        let sources = load_sources(sources);
+        let options = resolve(options, &sources)?;
+        let svg_options = svg_options_from_options(&options);
+        finalize_glyphs(&svg_options, parsed.0).map(BenchPreparedSvgFont)
+    }
+
+    /// Build requested font outputs from an already prepared SVG font and return total output bytes.
+    pub fn build_outputs_only(
+        options: GenerateWebfontsOptions,
+        sources: &[BenchSvgSource],
+        prepared: &BenchPreparedSvgFont,
+    ) -> io::Result<usize> {
+        let sources = load_sources(sources);
+        let options = resolve(options, &sources)?;
+        let svg_options = svg_options_from_options(&options);
+        let fonts = build_font_outputs(&options, &svg_options, &prepared.0)?;
+        Ok(fonts.svg_font.as_ref().map_or(0, |v| v.len())
+            + fonts.ttf_font.as_ref().map_or(0, |v| v.len())
+            + fonts.woff_font.as_ref().map_or(0, |v| v.len())
+            + fonts.woff2_font.as_ref().map_or(0, |v| v.len())
+            + fonts.eot_font.as_ref().map_or(0, |v| v.len()))
+    }
+
+    /// Run the incremental SVG preparation path and return the number of prepared glyphs.
+    pub fn prepare_svg_incremental(
+        options: GenerateWebfontsOptions,
+        sources: &[BenchSvgSource],
+        cache: &mut BenchGlyphCache,
+    ) -> io::Result<usize> {
+        let sources = load_sources(sources);
+        let options = resolve(options, &sources)?;
+        let svg_options = svg_options_from_options(&options);
+        let prepared = prepare_svg_font_incremental(&svg_options, &sources, &mut cache.0)?;
+        Ok(prepared.processed_glyphs.len())
+    }
+}
+
 #[cfg(all(test, feature = "napi"))]
 #[unsafe(no_mangle)]
 extern "C" fn napi_call_threadsafe_function(

--- a/packages/webfont-generator/src/svg/types.rs
+++ b/packages/webfont-generator/src/svg/types.rs
@@ -24,6 +24,7 @@ pub(crate) struct SvgOptions<'a> {
     pub round: Option<f64>,
 }
 
+#[derive(Clone)]
 pub(crate) struct ParsedGlyph {
     pub codepoint: u32,
     pub height: f64,
@@ -40,6 +41,7 @@ pub(crate) struct GlyphWorkItem<'a> {
     pub source_file: &'a LoadedSvgFile,
 }
 
+#[derive(Clone)]
 pub(crate) struct ProcessedGlyph {
     pub codepoint: u32,
     pub height: f64,
@@ -50,6 +52,7 @@ pub(crate) struct ProcessedGlyph {
     pub width: f64,
 }
 
+#[derive(Clone)]
 pub(crate) struct PreparedSvgFont {
     pub ascent: f64,
     pub descent: f64,

--- a/packages/webfont-generator/vite.config.ts
+++ b/packages/webfont-generator/vite.config.ts
@@ -14,6 +14,9 @@ export default defineProject({
             build: {
                 command: 'napi build --platform --esm --js binding.js --dts binding.d.ts -- --features napi',
             },
+            bench: {
+                command: 'cargo bench --features bench',
+            },
             'build:release': {
                 command: 'napi build --platform --esm --js binding.js --dts binding.d.ts --release -- --features napi',
                 dependsOn: ['test'],


### PR DESCRIPTION
## Summary

- add Criterion benchmark targets for incremental regeneration, pipeline stages, and feature-specific paths
- expose benchmark-only helpers behind the `bench` feature to measure internal SVG and output-generation stages
- add a Vite+ bench task: `vp run @atlowchemi/webfont-generator#bench`
- add VS Code Rust analyzer bench feature support for local benchmark development

## Validation

- `cargo fmt --check`
- `cargo bench --features bench --no-run`
- `cargo clippy --all-targets --features bench -- -D warnings`
- `vp run @atlowchemi/webfont-generator#bench --no-run`
- smoke-ran selected incremental benchmark filters