### PR TITLE
feat(vite-svg-2-webfont): batch watch regenerates

### DIFF
--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -711,7 +711,7 @@ describe('serve - regenerates css when a new svg is added', () => {
 
     it('reloads the virtual css module after a new svg appears', async () => {
         await writeFile(watcherSvgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h1024v1024H0z"/></svg>');
-        await watcherHandler({ path: pathJoin(webfontFolder, filename), kind: 'added' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, filename), kind: 'added' }]);
         await waitForCssReload;
         expect(reloadedIds.some(id => id.includes('vite-svg-2-webfont.css'))).toBe(true);
     });
@@ -750,7 +750,7 @@ describe('serve - swallows reloadModule rejection from the watcher', () => {
 
     it('does not crash the watcher when reloadModule rejects', async () => {
         await writeFile(watcherSvgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h512v512H0z"/></svg>');
-        await watcherHandler({ path: pathJoin(webfontFolder, filename), kind: 'added' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, filename), kind: 'added' }]);
         await waitForReloadCalled;
         expect(rejectingReload).toHaveBeenCalledOnce();
     });
@@ -802,7 +802,7 @@ describe('serve - incrementally regenerates on a content edit', () => {
     });
 
     it('reuses cached glyphs via regenerate and reloads the css module', async () => {
-        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' }]);
         await waitForCssReload;
         expect(regenerateCalls).toHaveLength(1);
         const [files, changes] = regenerateCalls[0]!;
@@ -812,9 +812,23 @@ describe('serve - incrementally regenerates on a content edit', () => {
     });
 
     it('passes removed watcher events through regenerate', async () => {
-        await watcherHandler({ path: pathJoin(webfontFolder, '__already-removed__.svg'), kind: 'removed' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, '__already-removed__.svg'), kind: 'removed' }]);
 
         expect(regenerateCalls.at(-1)?.[1]).toEqual([{ path: pathJoin(webfontFolder, '__already-removed__.svg'), changeType: 'removed' }]);
+    });
+
+    it('passes batched watcher events through a single regenerate call', async () => {
+        const callsBefore = regenerateCalls.length;
+        await watcherHandler([
+            { path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' },
+            { path: pathJoin(webfontFolder, '__already-removed__.svg'), kind: 'removed' },
+        ]);
+
+        expect(regenerateCalls).toHaveLength(callsBefore + 1);
+        expect(regenerateCalls.at(-1)?.[1]).toEqual([
+            { path: pathJoin(webfontFolder, 'add.svg'), changeType: 'changed' },
+            { path: pathJoin(webfontFolder, '__already-removed__.svg'), changeType: 'removed' },
+        ]);
     });
 });
 
@@ -841,7 +855,7 @@ describe('serve - skips unchanged dev css/html writes', () => {
 
     it('does not rewrite dev companion files when rendered output is unchanged', async () => {
         const writesBefore = ensureDirExistsAndWriteFileMock.mock.calls.length;
-        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' }]);
 
         expect(ensureDirExistsAndWriteFileMock).toHaveBeenCalledTimes(writesBefore);
     });
@@ -880,7 +894,7 @@ describe('serve - falls back to full regenerate when incremental is unavailable'
 
     it('full-regenerates and reloads when cssContext disables incremental', async () => {
         const callsBefore = generateWebfontsMock.mock.calls.length;
-        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' }]);
         await waitForCssReload;
 
         expect(generateWebfontsMock).toHaveBeenCalledTimes(callsBefore + 1);
@@ -930,7 +944,7 @@ describe('serve - falls back when regenerate throws', () => {
 
     it('full-regenerates and skips the normal incremental reload path', async () => {
         const callsBefore = generateWebfontsMock.mock.calls.length;
-        await watcherHandler({ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' }]);
         await waitForCssReload;
 
         expect(generateWebfontsMock).toHaveBeenCalledTimes(callsBefore + 1);
@@ -968,7 +982,7 @@ describe('serve - writes refreshed fonts to disk when generateFiles includes fon
         // The initial build wrote the font to disk; capture it, then add an icon via the watcher.
         const before = await readFile(woff2Path);
         await writeFile(svgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path d="M0 0h1024v1024H0z"/></svg>');
-        await watcherHandler({ path: pathJoin(webfontFolder, svgName), kind: 'added' });
+        await watcherHandler([{ path: pathJoin(webfontFolder, svgName), kind: 'added' }]);
         const after = await readFile(woff2Path);
         expect(after).not.toEqual(before);
     });

--- a/packages/vite-svg-2-webfont/src/index.ts
+++ b/packages/vite-svg-2-webfont/src/index.ts
@@ -3,7 +3,7 @@ import type { ModuleGraph, ModuleNode, Plugin } from 'vite';
 import { setupWatcher, MIME_TYPES, ensureDirExistsAndWriteFile, getTmpDir, getBufferHash, rmDir } from './utils';
 import { parseOptions, parseFiles, parsePreloadFormatsOption } from './optionParser';
 import * as templatesImport from '@atlowchemi/webfont-generator/templates';
-import type { WatchedChange } from './utils';
+import type { WatchedChangeBatch } from './utils';
 import type { FontType, GenerateWebfontsResult, GlyphChangeEntry } from '@atlowchemi/webfont-generator';
 import type { IconPluginOptions } from './optionParser';
 import type { GeneratedWebfont } from './types/generatedWebfont';
@@ -22,7 +22,7 @@ function getResolvedVirtualModuleId<T extends string>(virtualModuleId: T): `\0${
     return `\0${virtualModuleId}`;
 }
 
-const toGlyphChange = (change: WatchedChange): GlyphChangeEntry =>
+const toGlyphChange = (change: WatchedChangeBatch[number]): GlyphChangeEntry =>
     change.kind === 'removed' ? { path: change.path, changeType: 'removed' } : { path: change.path, changeType: change.kind };
 
 /** Ensure vp doesn't crash locally and in CI if the native binding doesn't exist yet.  */
@@ -136,8 +136,11 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         }
     };
 
-    /** Rebuild on a watch event, incrementally reusing cached glyphs, else a full rebuild. */
-    const regenerateFromWatch = async (change: WatchedChange) => {
+    /** Rebuild on watch events, incrementally reusing cached glyphs, else a full rebuild. */
+    const regenerateFromWatch = async (changes: WatchedChangeBatch) => {
+        if (changes.length === 0) {
+            return;
+        }
         // Reuse cached glyphs, handing the engine the fresh glob order so additions land in their
         // correct position (byte-identical to a fresh build). When `writeFiles` is set, `regenerate`
         // refreshes the on-disk fonts itself; otherwise `writeDevFiles` handles the CSS/HTML below.
@@ -148,7 +151,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         try {
             const orderedFiles = parseFiles(options);
             processedOptions.files = orderedFiles;
-            generatedFonts.regenerate(orderedFiles, [toGlyphChange(change)]);
+            generatedFonts.regenerate(orderedFiles, changes.map(toGlyphChange));
         } catch {
             await generate(true);
             return;
@@ -234,7 +237,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         },
         async buildStart() {
             if (!isBuild) {
-                setupWatcher(options.context, ac.signal, change => regenerateFromWatch(change)).catch(() => null);
+                setupWatcher(options.context, ac.signal, changes => regenerateFromWatch(changes)).catch(() => null);
             }
             await generate();
             if (isBuild && !options.inline) {

--- a/packages/vite-svg-2-webfont/src/utils.test.ts
+++ b/packages/vite-svg-2-webfont/src/utils.test.ts
@@ -1,4 +1,6 @@
 import * as fs from 'node:fs/promises';
+import { join as pathJoin } from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import * as utils from './utils';
 
@@ -73,6 +75,7 @@ describe('utils', () => {
 
         beforeEach(() => {
             ac = new AbortController();
+            handler.mockClear();
         });
 
         it('throws error if no such folder', async () => {
@@ -86,7 +89,7 @@ describe('utils', () => {
             expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
         });
 
-        it('triggers the handler for adds and removes alike', async () => {
+        it('batches and coalesces adds and removes', async () => {
             const { watch, access } = fs;
             const event = { eventType: 'rename', filename: 'ex.svg' };
             async function* mock() {
@@ -103,7 +106,61 @@ describe('utils', () => {
             }
 
             expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
-            expect(handler).toBeCalledTimes(3);
+            expect(handler).toHaveBeenCalledExactlyOnceWith([{ path: pathJoin(folderPath, 'ex.svg'), kind: 'changed' }]);
+        });
+
+        it('batches changes for multiple svg files', async () => {
+            const { watch } = fs;
+            const events = [
+                { eventType: 'change' as const, filename: 'a.svg' },
+                { eventType: 'change' as const, filename: 'b.svg' },
+            ];
+            async function* mock() {
+                yield* events;
+            }
+            if (vi.isMockFunction(watch)) {
+                watch.mockReturnValue(mock());
+            }
+
+            expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
+            expect(handler).toHaveBeenCalledExactlyOnceWith([
+                { path: pathJoin(folderPath, 'a.svg'), kind: 'changed' },
+                { path: pathJoin(folderPath, 'b.svg'), kind: 'changed' },
+            ]);
+        });
+
+        it('serializes async batch handlers', async () => {
+            const { watch } = fs;
+            const firstHandler = Promise.withResolvers<void>();
+            const calls: utils.WatchedChangeBatch[] = [];
+            const events = [
+                { eventType: 'change' as const, filename: 'a.svg' },
+                { eventType: 'change' as const, filename: 'b.svg' },
+            ];
+            async function* mock() {
+                yield events[0]!;
+                await setTimeout(40);
+                yield events[1]!;
+            }
+            if (vi.isMockFunction(watch)) {
+                watch.mockReturnValue(mock());
+            }
+            handler.mockImplementationOnce(async (changes: utils.WatchedChangeBatch) => {
+                calls.push(changes);
+                await firstHandler.promise;
+            });
+            handler.mockImplementationOnce((changes: utils.WatchedChangeBatch) => {
+                calls.push(changes);
+            });
+
+            const watcher = utils.setupWatcher(folderPath, ac.signal, handler);
+            await setTimeout(100);
+            expect(calls).toEqual([[{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }]]);
+
+            firstHandler.resolve();
+            await watcher;
+
+            expect(calls).toEqual([[{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }], [{ path: pathJoin(folderPath, 'b.svg'), kind: 'changed' }]]);
         });
     });
 

--- a/packages/vite-svg-2-webfont/src/utils.ts
+++ b/packages/vite-svg-2-webfont/src/utils.ts
@@ -27,6 +27,7 @@ export async function doesFileExist(folderPath: string, fileName: string): Promi
 
 /** A normalized SVG change surfaced by the watcher. `path` matches the `parseFiles` output. */
 export type WatchedChange = { path: string; kind: 'added' | 'changed' | 'removed' };
+export type WatchedChangeBatch = WatchedChange[];
 
 export async function handleWatchEvent(
     folderPath: string,
@@ -49,14 +50,73 @@ export async function handleWatchEvent(
     await onChange({ path, kind: exists ? 'added' : 'removed' });
 }
 
-export async function setupWatcher(folderPath: string, signal: AbortSignal, onChange: (change: WatchedChange) => void | Promise<void>): Promise<void> {
+const WATCH_BATCH_DELAY_MS = 25;
+
+function coalesceChange(previous: WatchedChange | undefined, next: WatchedChange): WatchedChange {
+    if (!previous) {
+        return next;
+    }
+    if (next.kind === 'removed') {
+        return next;
+    }
+    if (previous.kind === 'added') {
+        return { ...next, kind: 'added' };
+    }
+    if (previous.kind === 'removed' && next.kind === 'added') {
+        return { ...next, kind: 'changed' };
+    }
+    return next;
+}
+
+export async function setupWatcher(folderPath: string, signal: AbortSignal, onChange: (changes: WatchedChangeBatch) => void | Promise<void>): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let flushChain = Promise.resolve();
+    const pending = new Map<string, WatchedChange>();
+
+    const flush = async () => {
+        if (timer) {
+            clearTimeout(timer);
+            timer = undefined;
+        }
+        if (pending.size === 0) {
+            return;
+        }
+        const changes = [...pending.values()];
+        pending.clear();
+        await onChange(changes);
+    };
+
+    const scheduleFlush = () => {
+        flushChain = flushChain
+            .catch(() => undefined)
+            .then(flush)
+            .catch(() => undefined);
+    };
+
+    const drain = async () => {
+        await flushChain.catch(() => undefined);
+        await flush().catch(() => undefined);
+    };
+
+    const queueChange = (change: WatchedChange) => {
+        pending.set(change.path, coalesceChange(pending.get(change.path), change));
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = setTimeout(() => {
+            scheduleFlush();
+        }, WATCH_BATCH_DELAY_MS);
+    };
+
     try {
         watcher = watch(folderPath, { signal });
         for await (const event of watcher) {
-            // A single failed rebuild (e.g. an unreadable file) must not tear down the watcher.
-            await handleWatchEvent(folderPath, event, onChange).catch(() => undefined);
+            // A single failed event classification (e.g. an unreadable file) must not tear down the watcher.
+            await handleWatchEvent(folderPath, event, queueChange).catch(() => undefined);
         }
+        await drain();
     } catch (err: unknown) {
+        await drain();
         if (err && typeof err === 'object' && 'name' in err && err.name === 'AbortError') {
             return;
         }

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -358,6 +358,86 @@ fn bench_regenerate(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_regenerate_batches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("regenerate_batches");
+    group.sample_size(10);
+    let all_formats = vec![
+        FontType::Svg,
+        FontType::Ttf,
+        FontType::Eot,
+        FontType::Woff,
+        FontType::Woff2,
+    ];
+
+    for size in SIZES {
+        for change_count in [2, 10] {
+            group.bench_function(format!("separate_{change_count}/{size}"), |b| {
+                b.iter_batched(
+                    || {
+                        let fixture = fixtures(size);
+                        let result = webfont_generator::generate_sync(
+                            options_with_types(fixture.paths.clone(), true, all_formats.clone()),
+                            None,
+                        )
+                        .unwrap();
+                        let changes = fixture
+                            .paths
+                            .iter()
+                            .take(change_count)
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        (fixture, result, changes)
+                    },
+                    |(fixture, mut result, changes)| {
+                        for changed in changes {
+                            std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                            result
+                                .regenerate(
+                                    &fixture.paths,
+                                    &[(changed, GlyphChange::Changed { name: None })],
+                                )
+                                .unwrap();
+                        }
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+
+            group.bench_function(format!("batched_{change_count}/{size}"), |b| {
+                b.iter_batched(
+                    || {
+                        let fixture = fixtures(size);
+                        let result = webfont_generator::generate_sync(
+                            options_with_types(fixture.paths.clone(), true, all_formats.clone()),
+                            None,
+                        )
+                        .unwrap();
+                        let changes = fixture
+                            .paths
+                            .iter()
+                            .take(change_count)
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        (fixture, result, changes)
+                    },
+                    |(fixture, mut result, changes)| {
+                        for changed in &changes {
+                            std::fs::write(changed, svg(&changed_path_data())).unwrap();
+                        }
+                        let changes = changes
+                            .into_iter()
+                            .map(|path| (path, GlyphChange::Changed { name: None }))
+                            .collect::<Vec<_>>();
+                        result.regenerate(&fixture.paths, &changes).unwrap();
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
+        }
+    }
+    group.finish();
+}
+
 fn bench_add_remove(c: &mut Criterion) {
     let mut group = c.benchmark_group("add_remove");
     group.sample_size(10);
@@ -687,6 +767,7 @@ criterion_group! {
     targets =
         bench_svg_prepare,
         bench_regenerate,
+        bench_regenerate_batches,
         bench_add_remove,
         bench_regenerate_by_format,
         bench_render_cache_after_regenerate,

--- a/tests/webfonts-generator.bench.ts
+++ b/tests/webfonts-generator.bench.ts
@@ -309,11 +309,13 @@ describe.each([5, 300])('generateCss / generateHtml — %i glyphs', numGlyphs =>
 const DEV_FORMAT = { formatOptions: { woff2: { compressionQuality: 10 } } };
 const EDIT_SVG_A = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>';
 const EDIT_SVG_B = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20L12 22z"/></svg>';
+const EDIT_SVG_C = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h30L12 22z"/></svg>';
 
-async function makeEditableFiles(numGlyphs: number, label: string): Promise<string[]> {
-    const editFile = join(bulkFixtureDir, `${label}-${numGlyphs}-edit.svg`);
-    await writeFile(editFile, EDIT_SVG_A);
-    return [editFile, ...bulkFiles.slice(1, numGlyphs)];
+async function makeNEditableFiles(n: number, numGlyphs: number, label: string): Promise<string[]> {
+    const filePathGenerator = (index: number) => join(bulkFixtureDir, `${label}-${numGlyphs}-edit-${String.fromCharCode(97 + index)}.svg`);
+    const files = Array.from({ length: n }, (_, i) => filePathGenerator(i));
+    await Promise.all(files.map(file => writeFile(file, EDIT_SVG_A)));
+    return [...files, ...bulkFiles.slice(n, numGlyphs)];
 }
 
 const incrementalResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
@@ -340,7 +342,7 @@ const contentEditFiles = new Map<number, string[]>();
 const contentEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
 await Promise.all(
     [100, 300, 600].map(async numGlyphs => {
-        const files = await makeEditableFiles(numGlyphs, 'regen-content');
+        const files = await makeNEditableFiles(1, numGlyphs, 'regen-content');
         const result = await generateWebfonts(baseOpts(files, { incremental: true, ...DEV_FORMAT }));
         contentEditFiles.set(numGlyphs, files);
         contentEditResults.set(numGlyphs, result);
@@ -363,6 +365,76 @@ describe.each([100, 300, 600])('rebuild after a 1-file content edit — %i glyph
             toggle = !toggle;
             writeFileSync(files[0]!, toggle ? EDIT_SVG_B : EDIT_SVG_A);
             expect(result.regenerate(files, change)).toBeUndefined();
+        },
+        benchOpts,
+    );
+});
+
+const separateTwoEditFiles = new Map<number, string[]>();
+const separateTenEditFiles = new Map<number, string[]>();
+const batchedEditFiles = new Map<number, string[]>();
+const separateTwoEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+const separateTenEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+const batchedEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [100, 300, 600].map(async numGlyphs => {
+        const separateTwoFiles = await makeNEditableFiles(2, numGlyphs, 'regen-separate-two-content');
+        const separateTenFiles = await makeNEditableFiles(10, numGlyphs, 'regen-separate-ten-content');
+        const batchedFiles = await makeNEditableFiles(10, numGlyphs, 'regen-batch-content');
+        const [separateTwo, separateTen, batched] = await Promise.all([
+            generateWebfonts(baseOpts(separateTwoFiles, { incremental: true, ...DEV_FORMAT })),
+            generateWebfonts(baseOpts(separateTenFiles, { incremental: true, ...DEV_FORMAT })),
+            generateWebfonts(baseOpts(batchedFiles, { incremental: true, ...DEV_FORMAT })),
+        ]);
+        separateTwoEditFiles.set(numGlyphs, separateTwoFiles);
+        separateTenEditFiles.set(numGlyphs, separateTenFiles);
+        batchedEditFiles.set(numGlyphs, batchedFiles);
+        separateTwoEditResults.set(numGlyphs, separateTwo);
+        separateTenEditResults.set(numGlyphs, separateTen);
+        batchedEditResults.set(numGlyphs, batched);
+    }),
+);
+
+describe.each([100, 300, 600])('batched vs separate content edits — %i glyphs', numGlyphs => {
+    const separateTwoFiles = separateTwoEditFiles.get(numGlyphs)!;
+    const separateTenFiles = separateTenEditFiles.get(numGlyphs)!;
+    const batchedFiles = batchedEditFiles.get(numGlyphs)!;
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+    const separateTwo = separateTwoEditResults.get(numGlyphs)!;
+    const separateTen = separateTenEditResults.get(numGlyphs)!;
+    const batched = batchedEditResults.get(numGlyphs)!;
+    const separateTwoChanges = separateTwoFiles.slice(0, 2).map(path => ({ path, changeType: 'changed' as const }));
+    const separateTenChanges = separateTenFiles.slice(0, 10).map(path => ({ path, changeType: 'changed' as const }));
+    const batchedChanges = batchedFiles.slice(0, 10).map(path => ({ path, changeType: 'changed' as const }));
+
+    let twoToggle = false;
+    let tenToggle = false;
+    let batchedToggle = false;
+
+    bench(
+        'new core — two separate incremental regenerates',
+        () => {
+            twoToggle = !twoToggle;
+            separateTwoChanges.forEach(change => writeFileSync(change.path, twoToggle ? EDIT_SVG_B : EDIT_SVG_C));
+            expect(separateTwoChanges.map(change => separateTwo.regenerate(separateTwoFiles, [change]))).toEqual(Array.from({ length: separateTwoChanges.length }));
+        },
+        benchOpts,
+    );
+    bench(
+        'new core — ten separate incremental regenerates',
+        () => {
+            tenToggle = !tenToggle;
+            separateTenChanges.forEach(change => writeFileSync(change.path, tenToggle ? EDIT_SVG_B : EDIT_SVG_C));
+            expect(separateTenChanges.map(change => separateTen.regenerate(separateTenFiles, [change]))).toEqual(Array.from({ length: separateTenChanges.length }));
+        },
+        benchOpts,
+    );
+    bench(
+        'new core — one batched incremental regenerate',
+        () => {
+            batchedToggle = !batchedToggle;
+            batchedChanges.forEach(change => writeFileSync(change.path, batchedToggle ? EDIT_SVG_B : EDIT_SVG_C));
+            expect(batched.regenerate(batchedFiles, batchedChanges)).toBeUndefined();
         },
         benchOpts,
     );
@@ -413,7 +485,7 @@ const contentEditCssFiles = new Map<number, string[]>();
 const contentEditCssResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
 await Promise.all(
     [100, 300, 600].map(async numGlyphs => {
-        const files = await makeEditableFiles(numGlyphs, 'regen-content-css');
+        const files = await makeNEditableFiles(1, numGlyphs, 'regen-content-css');
         const result = await generateWebfonts(baseOpts(files, { incremental: true, ...DEV_FORMAT }));
         contentEditCssFiles.set(numGlyphs, files);
         contentEditCssResults.set(numGlyphs, result);
@@ -469,7 +541,7 @@ const contentEditWriteFiles = new Map<number, string[]>();
 const contentEditWriteResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
 await Promise.all(
     [100, 300, 600].map(async numGlyphs => {
-        const files = await makeEditableFiles(numGlyphs, 'regen-content-write');
+        const files = await makeNEditableFiles(1, numGlyphs, 'regen-content-write');
         const dest = join(bulkFixtureDir, `regen-content-write-${numGlyphs}`);
         const result = await generateWebfonts(baseOpts(files, { incremental: true, writeFiles: true, dest, ...DEV_FORMAT }));
         contentEditWriteFiles.set(numGlyphs, files);


### PR DESCRIPTION
## Summary
- debounce SVG watcher events into a coalesced batch before regenerating
- pass batched changes through the Vite plugin to a single `result.regenerate(...)` call
- add JS and Rust benchmark coverage for batched vs separate regenerates
- update `examples/recalc-ceiling.mjs` to report actual regenerate timings

## Validation
- `vp run test packages/vite-svg-2-webfont/src/utils.test.ts packages/vite-svg-2-webfont/src/index.test.ts`
- `vp fmt tests/webfonts-generator.bench.ts --check`
- `vp lint tests/webfonts-generator.bench.ts`
- `cargo fmt --check` in `packages/webfont-generator`
- `vp run @atlowchemi/webfont-generator#bench --no-run`
- `vp run @atlowchemi/webfont-generator#bench --bench incremental regenerate_batches`
- `vp run test bench tests/webfonts-generator.bench.ts -t 'batched vs separate content edits'` partially completed 100/300 before timeout; reran 600 separately with `-t 'batched vs separate content edits — 600 glyphs'`

Note: full `vp check` was previously blocked by unrelated pre-existing formatting issues in untracked/unstaged `examples/font-compare/*.mjs` files.