### PR TITLE
fix(vite-svg-2-webfont): release generated fonts on shutdown

### DIFF
--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -14,9 +14,10 @@ import type { IconPluginOptions } from './optionParser';
 const { generateWebfontsMock } = vi.hoisted(() => ({
     generateWebfontsMock: vi.fn<typeof import('@atlowchemi/webfont-generator').generateWebfonts>(),
 }));
-const { ensureDirExistsAndWriteFileMock, setupWatcherMock } = vi.hoisted(() => ({
+const { ensureDirExistsAndWriteFileMock, rmDirMock, setupWatcherMock } = vi.hoisted(() => ({
     setupWatcherMock: vi.fn<typeof import('./utils').setupWatcher>(),
     ensureDirExistsAndWriteFileMock: vi.fn<typeof import('./utils').ensureDirExistsAndWriteFile>(),
+    rmDirMock: vi.fn<typeof import('./utils').rmDir>(),
 }));
 
 vi.mock('@atlowchemi/webfont-generator', async importOriginal => {
@@ -32,7 +33,8 @@ vi.mock('./utils', async importOriginal => {
     const actual = await importOriginal<typeof import('./utils')>();
     setupWatcherMock.mockImplementation(actual.setupWatcher);
     ensureDirExistsAndWriteFileMock.mockImplementation(actual.ensureDirExistsAndWriteFile);
-    return { ...actual, setupWatcher: setupWatcherMock, ensureDirExistsAndWriteFile: ensureDirExistsAndWriteFileMock };
+    rmDirMock.mockImplementation(actual.rmDir);
+    return { ...actual, setupWatcher: setupWatcherMock, ensureDirExistsAndWriteFile: ensureDirExistsAndWriteFileMock, rmDir: rmDirMock };
 });
 
 type ViteBuildResult = Awaited<ReturnType<typeof build>>;
@@ -1006,6 +1008,30 @@ describe('build - throws when generator omits a requested font type', () => {
                 plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2', 'ttf'] })],
             }),
         ).rejects.toThrow(/Failed to generate font of type woff2/);
+    });
+});
+
+describe('serve - releases retained watch state on close', () => {
+    it('aborts the watcher signal and removes the temp directory', async () => {
+        let watchSignal: AbortSignal | undefined;
+        const rmDirCallsBefore = rmDirMock.mock.calls.length;
+        setupWatcherMock.mockImplementationOnce(async (_path, signal) => {
+            watchSignal = signal;
+        });
+
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+        const server = await created.listen();
+
+        expect(watchSignal?.aborted).toBe(false);
+        await server.close();
+
+        expect(watchSignal?.aborted).toBe(true);
+        expect(rmDirMock.mock.calls.length).toBe(rmDirCallsBefore + 1);
     });
 });
 

--- a/packages/vite-svg-2-webfont/src/index.ts
+++ b/packages/vite-svg-2-webfont/src/index.ts
@@ -44,7 +44,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
     const preloadFormats = parsePreloadFormatsOption<T>(options).filter((type): type is T => processedOptions.types.includes(type));
     let isBuild: boolean;
     let fileRefs: { [Ref in T]: string } | undefined;
-    let _moduleGraph: ModuleGraph;
+    let _moduleGraph: ModuleGraph | undefined;
     let _reloadModule: undefined | ((module: ModuleNode) => Promise<void>);
     let generatedFonts: GenerateWebfontsResult<T> | undefined;
     const generatedWebfonts: GeneratedWebfont[] = [];
@@ -289,6 +289,10 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         buildEnd() {
             ac.abort();
             rmDir(tmpDir);
+            generatedFonts = undefined;
+            fileRefs = undefined;
+            _moduleGraph = undefined;
+            _reloadModule = undefined;
         },
     };
 }

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -192,6 +192,33 @@ fn regenerate_without_incremental_errors() {
 }
 
 #[test]
+fn non_incremental_results_do_not_retain_glyph_cache() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let result = generate(vec![a], false);
+
+    assert!(
+        result.glyph_cache.is_none(),
+        "one-shot builds must not retain parsed glyph geometry"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn incremental_results_seed_glyph_cache_for_active_files() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let result = generate(vec![a, b], true);
+    let cache = result.glyph_cache.as_ref().unwrap();
+
+    assert_eq!(cache.entries.len(), 2);
+    assert_eq!(cache.content_hashes.len(), 2);
+    assert_eq!(cache.by_content_hash.len(), 2);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn regenerate_noop_changed_event_returns_before_parsing() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);
@@ -241,6 +268,68 @@ fn regenerate_added_duplicate_reuses_content_addressed_cache() {
         "added files with SVG bytes already in the cache should not be parsed again"
     );
     assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_remove_prunes_inactive_cache_entries() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+    let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
+
+    result
+        .regenerate(&[a.clone(), c.clone()], &[(b, GlyphChange::Removed)])
+        .unwrap();
+
+    let cache = result.glyph_cache.as_ref().unwrap();
+    assert_eq!(cache.entries.len(), 2);
+    assert_eq!(cache.content_hashes.len(), 2);
+    assert_eq!(cache.by_content_hash.len(), 2);
+    assert!(cache.entries.contains_key(&a));
+    assert!(cache.entries.contains_key(&c));
+    assert_same(&result, &generate(vec![a, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_add_remove_cycles_do_not_grow_cache() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let mut result = generate(vec![a.clone(), b.clone()], true);
+
+    for index in 0..5 {
+        let name = format!("extra-{index}");
+        let path_data = format!("M{index} {index} L24 0 L24 24 Z");
+        let extra = write_icon(&dir, &name, &path_data);
+        let with_extra = vec![a.clone(), b.clone(), extra.clone()];
+        result
+            .regenerate(
+                &with_extra,
+                &[(extra.clone(), GlyphChange::Added { name: None })],
+            )
+            .unwrap();
+
+        let cache = result.glyph_cache.as_ref().unwrap();
+        assert_eq!(cache.entries.len(), 3);
+        assert_eq!(cache.content_hashes.len(), 3);
+        assert_eq!(cache.by_content_hash.len(), 3);
+
+        result
+            .regenerate(&[a.clone(), b.clone()], &[(extra, GlyphChange::Removed)])
+            .unwrap();
+
+        let cache = result.glyph_cache.as_ref().unwrap();
+        assert_eq!(cache.entries.len(), 2);
+        assert_eq!(cache.content_hashes.len(), 2);
+        assert_eq!(cache.by_content_hash.len(), 2);
+        assert!(cache.entries.contains_key(&a));
+        assert!(cache.entries.contains_key(&b));
+    }
+
+    assert_same(&result, &generate(vec![a, b], false));
     std::fs::remove_dir_all(&dir).ok();
 }
 


### PR DESCRIPTION
## Summary
- add Rust tests validating incremental glyph-cache retention and pruning behavior
- release retained generated font state during Vite plugin shutdown
- add plugin lifecycle coverage for watcher abort and temp directory cleanup

## Validation
- `cargo fmt --check` in `packages/webfont-generator`
- `vp fmt packages/vite-svg-2-webfont/src/index.ts packages/vite-svg-2-webfont/src/index.test.ts --check`
- `vp lint packages/vite-svg-2-webfont/src/index.ts packages/vite-svg-2-webfont/src/index.test.ts`
- `cargo test incremental::tests` in `packages/webfont-generator`
- `vp run test packages/vite-svg-2-webfont/src/index.test.ts`

Note: full `vp check` is still blocked by unrelated untracked `examples/font-compare/*.mjs` formatting issues in the local workspace.