### PR TITLE
feat(webfont-generator): support regenerate rediff

### DIFF
--- a/packages/docs/webfont-generator/node.md
+++ b/packages/docs/webfont-generator/node.md
@@ -178,7 +178,7 @@ const cssCustom = result.generateCss({ woff2: '/fonts/icons.woff2' });
 
 - Type: `boolean`
 - Default: `false`
-- Description: Retain parsed glyph data on the result so [`regenerate()`](#regenerate-changes) can rebuild after file changes without re-parsing the glyphs that didn't change. Enable for watch/dev; leave it off for one-shot builds so the parsed geometry isn't held in memory.
+- Description: Retain parsed glyph data on the result so [`regenerate()`](#regeneratefiles-changes) can rebuild after file changes without re-parsing the glyphs that didn't change. Enable for watch/dev; leave it off for one-shot builds so the parsed geometry isn't held in memory.
 
 ### `fixedWidth`
 
@@ -318,17 +318,19 @@ Each font format is available as a property on the result. Formats that were not
 - Type: `(urls?: Partial<Record<FontType, string>>) => string`
 - Description: Returns the rendered HTML preview string. Pass `urls` to override font URLs in the embedded stylesheet.
 
-### `regenerate(files, changes)`
+### `regenerate(files, changes?)`
 
-- Type: `(files: string[], changes: GlyphChangeEntry[]) => void`
+- Type: `(files: string[], changes?: GlyphChangeEntry[] | null) => void`
 - Requires: the result was produced with [`incremental: true`](#incremental) (throws otherwise).
-- Description: Rebuilds every requested font format after a batch of file changes, reusing cached geometry for the glyphs that didn't change (and reusing the rendered CSS/HTML when the glyph names and codepoints are unchanged). `files` is the complete file set after the change, in the order a fresh build would use (e.g. your glob result); the rebuilt glyphs are ordered to match it, so the result is byte-identical to a fresh `generateWebfonts()` of that set — additions included. Any file omitted from `files` is dropped; added/changed files named in `changes` are read from disk and re-parsed. Outputs are refreshed in memory, and — when the result was created with [`writeFiles: true`](#writefiles) — refreshed fonts are written to disk too, while unchanged CSS/HTML companion files are skipped. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run by the synchronous method. Intended for dev/watch rebuilds.
+- Description: Rebuilds every requested font format after file changes, reusing cached geometry for the glyphs that didn't change (and reusing the rendered CSS/HTML when the glyph names and codepoints are unchanged). `files` is the complete file set after the change, in the order a fresh build would use (e.g. your glob result); the rebuilt glyphs are ordered to match it, so the result is byte-identical to a fresh `generateWebfonts()` of that set — additions included. Any file omitted from `files` is dropped; added/changed files named in `changes` are read from disk and re-parsed. Omit `changes` or pass `null` to re-read/hash every current file and infer added/changed/removed paths automatically. Outputs are refreshed in memory, and — when the result was created with [`writeFiles: true`](#writefiles) — refreshed fonts are written to disk too, while unchanged CSS/HTML companion files are skipped. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run by the synchronous method. Intended for dev/watch rebuilds.
 
 ```ts
 let files = ['/icons/add.svg', '/icons/search.svg'];
 const result = await generateWebfonts({ files, dest, incremental: true });
 // ...on a watch event:
 result.regenerate(files, [{ path: '/icons/add.svg', changeType: 'changed' }]);
+// ...or when watcher hints are unavailable/untrusted:
+result.regenerate(files);
 result.woff2; // refreshed bytes
 ```
 

--- a/packages/docs/webfont-generator/rust.md
+++ b/packages/docs/webfont-generator/rust.md
@@ -187,9 +187,10 @@ Both methods accept `Option<HashMap<FontType, String>>` for the `urls` parameter
 
 ### Incremental rebuild
 
-| Method                               | Return type      | Description                                          |
-| ------------------------------------ | ---------------- | ---------------------------------------------------- |
-| `regenerate(ordered_paths, changes)` | `io::Result<()>` | Rebuild after file changes, reusing unchanged glyphs |
+| Method                               | Return type      | Description                                                          |
+| ------------------------------------ | ---------------- | -------------------------------------------------------------------- |
+| `regenerate(ordered_paths, changes)` | `io::Result<()>` | Rebuild after known file changes, reusing unchanged glyphs           |
+| `regenerate_all(ordered_paths)`      | `io::Result<()>` | Re-read/hash the full file set and infer added/changed/removed paths |
 
 Requires the result to have been generated with `incremental: Some(true)` (errors otherwise).
 `ordered_paths: &[String]` is the complete file set after the changes, in the order a fresh build
@@ -199,14 +200,16 @@ existing glyphs. Any path absent from `ordered_paths` is dropped. `changes: &[(S
 names the affected files: added/changed files are re-read from disk. Every format is refreshed in
 memory, and — when the result was built with `write_files` — refreshed fonts are written to disk
 too, while unchanged CSS/HTML companion files are skipped. Rendered
-CSS/HTML is reused when glyph names and codepoints are unchanged.
+CSS/HTML is reused when glyph names and codepoints are unchanged. Use `regenerate_all` when you have
+the fresh ordered file set but no reliable watcher change batch; existing glyph names are preserved,
+and added paths derive their glyph name from the file stem.
 
 For Node.js results, `regenerate()` errors if the initial build used `cssContext` or `htmlContext`
 callbacks because the synchronous method cannot re-run JavaScript callbacks during the rebuild.
 
 ```rust
 pub enum GlyphChange {
-    Added { name: String },           // new file; `name` is the resolved glyph name
+    Added { name: Option<String> },   // new file; `name` overrides the file-stem glyph name
     Changed { name: Option<String> }, // content changed; `name` overrides the glyph name
     Removed,                          // file deleted
 }
@@ -214,6 +217,8 @@ pub enum GlyphChange {
 // result built with `incremental: Some(true)`
 let files = vec!["icons/add.svg".to_owned(), "icons/remove.svg".to_owned()];
 result.regenerate(&files, &[("icons/add.svg".to_owned(), GlyphChange::Changed { name: None })])?;
+// Or re-diff the full set when watcher hints are unavailable/untrusted:
+result.regenerate_all(&files)?;
 ```
 
 ## Full API reference

--- a/packages/webfont-generator/README.md
+++ b/packages/webfont-generator/README.md
@@ -21,7 +21,7 @@ The API is largely compatible with `@vusion/webfonts-generator`, with a few diff
 - `formatOptions` is now strictly typed as `{ svg?: SvgFormatOptions; ttf?: TtfFormatOptions; woff?: WoffFormatOptions; woff2?: Woff2FormatOptions }`. The original accepted arbitrary `{ [format]: unknown }`; the `eot` key is no longer accepted (EOT is derived from the TTF output).
 - A new `optimizeOutput` option runs an SVG path optimizer over each glyph before assembling the font. Defaults to `false`; opt in for smaller output bytes at a small build-time cost. Also available as `formatOptions.svg.optimizeOutput`.
 - `formatOptions.woff2.compressionQuality` sets the Brotli compression quality (0–11) for WOFF2 output. Defaults to `11` (smallest output); lower it (e.g. to `10`) for faster encoding at a marginal size cost.
-- A new `incremental` option (default `false`) retains parsed glyph data on the result so `result.regenerate(files, changes)` can rebuild after file changes without re-parsing the glyphs that didn't change — for dev/watch rebuilds. It refreshes the outputs in memory and, when the result was generated with `writeFiles`, writes refreshed fonts to disk too while skipping unchanged CSS/HTML companion files. You pass the full file set (in the order a fresh build would use) plus what changed; the result is byte-identical to a fresh `generateWebfonts()` of that set, additions included.
+- A new `incremental` option (default `false`) retains parsed glyph data on the result so `result.regenerate(files, changes?)` can rebuild after file changes without re-parsing the glyphs that didn't change — for dev/watch rebuilds. It refreshes the outputs in memory and, when the result was generated with `writeFiles`, writes refreshed fonts to disk too while skipping unchanged CSS/HTML companion files. You pass the full file set (in the order a fresh build would use) plus what changed, or omit `changes` to re-read/hash the full set and infer changes; the result is byte-identical to a fresh `generateWebfonts()` of that set, additions included.
 - Generated font binaries (TTF, WOFF, etc.) may differ at the byte level because a different encoder is used, but the fonts are equally valid.
 - CSS, HTML, and template output is identical.
 
@@ -36,10 +36,12 @@ const result = await generateWebfonts({ files, dest, fontName: 'my-icons', incre
 // On a watch event, rebuild reusing cached geometry for unchanged glyphs. Pass the full file set
 // (in fresh-build order) so additions land in the right position, plus what changed:
 result.regenerate(files, [{ path: './icons/home.svg', changeType: 'changed' }]);
+// Or omit changes when watcher hints are unavailable/untrusted:
+result.regenerate(files);
 result.woff2; // refreshed bytes
 ```
 
-The first argument is the complete file set after the change, in the order a fresh build would use (e.g. your glob result) — any file omitted from it is dropped. Each change is `{ path, changeType: 'added' | 'changed' | 'removed', name? }`, where `name` is the resolved glyph name if you apply a custom rename; otherwise added files derive their name from the file stem, changed files keep their current name, and removed files ignore it. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run by the synchronous method.
+The first argument is the complete file set after the change, in the order a fresh build would use (e.g. your glob result) — any file omitted from it is dropped. Each change is `{ path, changeType: 'added' | 'changed' | 'removed', name? }`, where `name` is the resolved glyph name if you apply a custom rename; otherwise added files derive their name from the file stem, changed files keep their current name, and removed files ignore it. When `changes` is omitted or `null`, every current file is re-read and hashed to detect added/changed/removed paths automatically. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run by the synchronous method.
 
 ## Node.js (npm)
 

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -313,6 +313,11 @@ fn bench_regenerate(c: &mut Criterion) {
                     .unwrap()
             })
         });
+        let mut rediff_noop_result =
+            webfont_generator::generate_sync(options(fixture.paths.clone(), true), None).unwrap();
+        group.bench_function(format!("rediff_noop/{size}"), |b| {
+            b.iter(|| rediff_noop_result.regenerate_all(&fixture.paths).unwrap())
+        });
 
         group.bench_function(format!("full_content_edit/{size}"), |b| {
             b.iter_batched(
@@ -351,6 +356,24 @@ fn bench_regenerate(c: &mut Criterion) {
                         )
                         .unwrap()
                 },
+                BatchSize::SmallInput,
+            )
+        });
+
+        group.bench_function(format!("rediff_content_edit/{size}"), |b| {
+            b.iter_batched(
+                || {
+                    let fixture = fixtures(size);
+                    let result = webfont_generator::generate_sync(
+                        options(fixture.paths.clone(), true),
+                        None,
+                    )
+                    .unwrap();
+                    let changed = fixture.paths[size / 2].clone();
+                    std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                    (fixture, result)
+                },
+                |(fixture, mut result)| result.regenerate_all(&fixture.paths).unwrap(),
                 BatchSize::SmallInput,
             )
         });

--- a/packages/webfont-generator/binding.d.ts
+++ b/packages/webfont-generator/binding.d.ts
@@ -36,12 +36,13 @@ export declare class GenerateWebfontsResult {
    * fresh build would use (e.g. the glob result) — the rebuilt glyphs are ordered to match it,
    * so the output bytes are identical to a fresh `generateWebfonts` of that set. `changes`
    * describes the affected files: added/changed files are re-read from disk; any file absent
-   * from `files` is dropped. Every requested format is refreshed in memory, and — like
-   * `generateWebfonts` — when the result was built with `writeFiles` enabled the refreshed
-   * fonts are written to disk too, while CSS/HTML companion files are skipped if their rendered
-   * bytes are unchanged since the last write.
+   * from `files` is dropped. Omit `changes` to re-read/hash every current file and infer
+   * added/changed/removed paths from `files`. Every requested format is refreshed in memory,
+   * and — like `generateWebfonts` — when the result was built with `writeFiles` enabled the
+   * refreshed fonts are written to disk too, while CSS/HTML companion files are skipped if their
+   * rendered bytes are unchanged since the last write.
    */
-  regenerate(files: Array<string>, changes: Array<GlyphChangeEntry>): void
+  regenerate(files: Array<string>, changes?: Array<GlyphChangeEntry> | undefined | null): void
 }
 
 /**

--- a/packages/webfont-generator/src/incremental/mod.rs
+++ b/packages/webfont-generator/src/incremental/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests;
 
+use std::collections::HashSet;
 use std::io::ErrorKind;
 use std::path::Path;
 
@@ -198,6 +199,45 @@ impl GenerateWebfontsResult {
             write_generate_webfonts_result_sync(self)?;
         }
         Ok(())
+    }
+
+    /// Rebuild after re-diffing the complete ordered file set against the retained incremental
+    /// cache. This is useful when the caller has a fresh file list but not a reliable watcher
+    /// change batch: every current path is re-read and hashed, missing prior paths are treated as
+    /// removed, new paths as added, and paths whose content hash changed as changed. Existing glyph
+    /// names are preserved; added paths derive their glyph name from the file stem.
+    pub fn regenerate_all(&mut self, ordered_paths: &[String]) -> std::io::Result<()> {
+        let cache = self.glyph_cache.as_ref().ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "regenerate requires the font to be generated with `incremental` enabled.",
+            )
+        })?;
+        let ordered_set: HashSet<&str> = ordered_paths.iter().map(String::as_str).collect();
+        let mut previous_paths = HashSet::with_capacity(self.source_files.len());
+        let mut changes = Vec::new();
+
+        for source_file in &self.source_files {
+            previous_paths.insert(source_file.path.as_str());
+            if !ordered_set.contains(source_file.path.as_str()) {
+                changes.push((source_file.path.clone(), GlyphChange::Removed));
+            }
+        }
+
+        for path in ordered_paths {
+            if !previous_paths.contains(path.as_str()) {
+                changes.push((path.clone(), GlyphChange::Added { name: None }));
+                continue;
+            }
+
+            let contents = std::fs::read_to_string(path)?;
+            let hash = source_content_hash(&contents);
+            if cache.content_hashes.get(path) != Some(&hash) {
+                changes.push((path.clone(), GlyphChange::Changed { name: None }));
+            }
+        }
+
+        self.regenerate(ordered_paths, &changes)
     }
 }
 

--- a/packages/webfont-generator/src/incremental/mod.rs
+++ b/packages/webfont-generator/src/incremental/mod.rs
@@ -171,6 +171,7 @@ impl GenerateWebfontsResult {
         }
         source_files = reordered;
         validate_glyph_names(&source_files)?;
+        options.files = ordered_paths.to_vec();
 
         // Re-resolve codepoints for the (possibly changed) set from the stable explicit base, so
         // auto-assigned codepoints match what a fresh build of the new set would produce.

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -179,6 +179,62 @@ fn regenerate_after_remove_matches_fresh() {
 }
 
 #[test]
+fn regenerate_all_after_content_change_matches_fresh() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+
+    let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate_all(&[a.clone(), b.clone(), c.clone()])
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_all_after_add_and_remove_matches_fresh() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+
+    let mut result = generate(vec![a.clone(), b], true);
+    result.regenerate_all(&[a.clone(), c.clone()]).unwrap();
+
+    assert_same(&result, &generate(vec![a, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_all_noop_returns_before_parsing() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let mut result = generate(vec![a.clone(), b.clone()], true);
+    let before = result.glyph_cache.as_ref().unwrap().parse_count;
+
+    result.regenerate_all(&[a, b]).unwrap();
+
+    assert_eq!(result.glyph_cache.as_ref().unwrap().parse_count, before);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_all_without_incremental_errors() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let mut result = generate(vec![a.clone()], false);
+    let error = result.regenerate_all(&[a]).unwrap_err();
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn regenerate_without_incremental_errors() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -721,16 +721,22 @@ impl GenerateWebfontsResult {
     /// fresh build would use (e.g. the glob result) — the rebuilt glyphs are ordered to match it,
     /// so the output bytes are identical to a fresh `generateWebfonts` of that set. `changes`
     /// describes the affected files: added/changed files are re-read from disk; any file absent
-    /// from `files` is dropped. Every requested format is refreshed in memory, and — like
-    /// `generateWebfonts` — when the result was built with `writeFiles` enabled the refreshed
-    /// fonts are written to disk too, while CSS/HTML companion files are skipped if their rendered
-    /// bytes are unchanged since the last write.
+    /// from `files` is dropped. Omit `changes` to re-read/hash every current file and infer
+    /// added/changed/removed paths from `files`. Every requested format is refreshed in memory,
+    /// and — like `generateWebfonts` — when the result was built with `writeFiles` enabled the
+    /// refreshed fonts are written to disk too, while CSS/HTML companion files are skipped if their
+    /// rendered bytes are unchanged since the last write.
     #[napi(js_name = "regenerate")]
     pub fn regenerate_from_js(
         &mut self,
         files: Vec<String>,
-        changes: Vec<GlyphChangeEntry>,
+        changes: Option<Vec<GlyphChangeEntry>>,
     ) -> napi::Result<()> {
+        let Some(changes) = changes else {
+            return self
+                .regenerate_all(&files)
+                .map_err(crate::util::to_napi_err);
+        };
         let changes = changes
             .into_iter()
             .map(|entry| {

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -553,6 +553,10 @@ function assertSameFonts(actual: Awaited<ReturnType<typeof generateWebfonts>>, e
     expect(actual.woff2).toEqual(expected.woff2);
 }
 
+function assertSameDefaultCss(actual: Awaited<ReturnType<typeof generateWebfonts>>, expected: Awaited<ReturnType<typeof generateWebfonts>>) {
+    expect(actual.generateCss()).toBe(expected.generateCss());
+}
+
 describe('regenerate (incremental)', () => {
     it('matches a fresh build after a content change', async () => {
         const dir = await createTempDir('regen-change-');
@@ -573,7 +577,9 @@ describe('regenerate (incremental)', () => {
         const c = await writeRegenIcon(dir, 'c', 'c');
         result.regenerate([a, b, c], [{ path: c, changeType: 'added' }]);
 
-        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, b, c])));
+        const fresh = await generateWebfonts(regenBaseOpts(dir, [a, b, c]));
+        assertSameFonts(result, fresh);
+        assertSameDefaultCss(result, fresh);
     });
 
     it('matches a fresh build after adding a file that sorts before existing glyphs', async () => {
@@ -595,7 +601,9 @@ describe('regenerate (incremental)', () => {
 
         result.regenerate([a, c], [{ path: b, changeType: 'removed' }]);
 
-        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, c])));
+        const fresh = await generateWebfonts(regenBaseOpts(dir, [a, c]));
+        assertSameFonts(result, fresh);
+        assertSameDefaultCss(result, fresh);
     });
 
     it('matches a fresh build after re-diffing omitted changes', async () => {
@@ -607,7 +615,9 @@ describe('regenerate (incremental)', () => {
         const c = await writeRegenIcon(dir, 'c', 'c');
         result.regenerate([a, b, c]);
 
-        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, b, c])));
+        const fresh = await generateWebfonts(regenBaseOpts(dir, [a, b, c]));
+        assertSameFonts(result, fresh);
+        assertSameDefaultCss(result, fresh);
     });
 
     it('matches a fresh build after re-diffing null changes', async () => {
@@ -618,7 +628,9 @@ describe('regenerate (incremental)', () => {
         await writeFile(c, regenIcon(REGEN_PATHS.changed));
         result.regenerate([a, c], null);
 
-        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, c])));
+        const fresh = await generateWebfonts(regenBaseOpts(dir, [a, c]));
+        assertSameFonts(result, fresh);
+        assertSameDefaultCss(result, fresh);
     });
 
     it('reuses the CSS render on a content edit and re-renders on rename', async () => {

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -598,6 +598,29 @@ describe('regenerate (incremental)', () => {
         assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, c])));
     });
 
+    it('matches a fresh build after re-diffing omitted changes', async () => {
+        const dir = await createTempDir('regen-rediff-');
+        const [a, b] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b')]);
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a, b]), incremental: true });
+
+        await writeFile(b, regenIcon(REGEN_PATHS.changed));
+        const c = await writeRegenIcon(dir, 'c', 'c');
+        result.regenerate([a, b, c]);
+
+        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, b, c])));
+    });
+
+    it('matches a fresh build after re-diffing null changes', async () => {
+        const dir = await createTempDir('regen-rediff-null-');
+        const [a, b, c] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b'), writeRegenIcon(dir, 'c', 'c')]);
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a, b, c]), incremental: true });
+
+        await writeFile(c, regenIcon(REGEN_PATHS.changed));
+        result.regenerate([a, c], null);
+
+        assertSameFonts(result, await generateWebfonts(regenBaseOpts(dir, [a, c])));
+    });
+
     it('reuses the CSS render on a content edit and re-renders on rename', async () => {
         const dir = await createTempDir('regen-css-');
         const [a, b] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b')]);

--- a/tests/webfonts-generator.bench.ts
+++ b/tests/webfonts-generator.bench.ts
@@ -340,12 +340,18 @@ describe.each([100, 300, 600])('changed event with unchanged contents — %i gly
 
 const contentEditFiles = new Map<number, string[]>();
 const contentEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+const rediffContentEditFiles = new Map<number, string[]>();
+const rediffContentEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
 await Promise.all(
     [100, 300, 600].map(async numGlyphs => {
         const files = await makeNEditableFiles(1, numGlyphs, 'regen-content');
         const result = await generateWebfonts(baseOpts(files, { incremental: true, ...DEV_FORMAT }));
+        const rediffFiles = await makeNEditableFiles(1, numGlyphs, 'regen-content-rediff');
+        const rediffResult = await generateWebfonts(baseOpts(rediffFiles, { incremental: true, ...DEV_FORMAT }));
         contentEditFiles.set(numGlyphs, files);
         contentEditResults.set(numGlyphs, result);
+        rediffContentEditFiles.set(numGlyphs, rediffFiles);
+        rediffContentEditResults.set(numGlyphs, rediffResult);
     }),
 );
 
@@ -354,8 +360,11 @@ describe.each([100, 300, 600])('rebuild after a 1-file content edit — %i glyph
     const opts = baseOpts(files, DEV_FORMAT);
     const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
     const result = contentEditResults.get(numGlyphs)!;
+    const rediffFiles = rediffContentEditFiles.get(numGlyphs)!;
+    const rediffResult = rediffContentEditResults.get(numGlyphs)!;
     const change = [{ path: files[0]!, changeType: 'changed' as const }];
     let toggle = false;
+    let rediffToggle = false;
 
     bench('upstream — full regen', () => expect(upstreamDirect(opts)).resolves.toBeDefined(), benchOpts);
     bench('new core — full regen (legacy)', () => expect(generateWebfonts(opts)).resolves.toBeDefined(), benchOpts);
@@ -365,6 +374,15 @@ describe.each([100, 300, 600])('rebuild after a 1-file content edit — %i glyph
             toggle = !toggle;
             writeFileSync(files[0]!, toggle ? EDIT_SVG_B : EDIT_SVG_A);
             expect(result.regenerate(files, change)).toBeUndefined();
+        },
+        benchOpts,
+    );
+    bench(
+        'new core — incremental regenerate rediff',
+        () => {
+            rediffToggle = !rediffToggle;
+            writeFileSync(rediffFiles[0]!, rediffToggle ? EDIT_SVG_B : EDIT_SVG_A);
+            expect(rediffResult.regenerate(rediffFiles)).toBeUndefined();
         },
         benchOpts,
     );


### PR DESCRIPTION
## Summary
- add Rust `GenerateWebfontsResult::regenerate_all(ordered_paths)` to infer added/changed/removed paths from a fresh ordered file set
- allow Node `result.regenerate(files)` / `result.regenerate(files, null)` to trigger full re-diff
- add Rust and JS tests for omitted/null changes, add/remove/content-change parity, and non-incremental errors
- add Rust and JS benchmark coverage for re-diff overhead
- update README, Node docs, Rust docs, and generated binding declarations

## Validation
- `cargo fmt --check`
- `vp fmt packages/webfont-generator/README.md packages/docs/webfont-generator/node.md packages/docs/webfont-generator/rust.md tests/webfonts-generator.bench.ts --check`
- `vp run @atlowchemi/webfont-generator#build`
- `cargo test incremental::tests`
- `vp run test packages/webfont-generator/tests/generator.test.ts`
- `vp lint tests/webfonts-generator.bench.ts`
- `vp run @atlowchemi/webfont-generator#bench --no-run`
- `vp run @atlowchemi/webfont-generator#bench --bench incremental rediff`
- `vp run test bench tests/webfonts-generator.bench.ts -t 'rebuild after a 1-file content edit'`
- `vp run @atlowchemi/vite-svg-webfont-docs#build`

Note: full `vp check` is still blocked in this local workspace by unrelated untracked `examples/font-compare/*.mjs` formatting issues.