### PR TITLE
test(vite-svg-2-webfont): cover watcher edge cases

### DIFF
--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -861,6 +861,16 @@ describe('serve - skips unchanged dev css/html writes', () => {
 
         expect(ensureDirExistsAndWriteFileMock).toHaveBeenCalledTimes(writesBefore);
     });
+
+    it('ignores empty watcher batches', async () => {
+        const generateCallsBefore = generateWebfontsMock.mock.calls.length;
+        const writesBefore = ensureDirExistsAndWriteFileMock.mock.calls.length;
+
+        await watcherHandler([]);
+
+        expect(generateWebfontsMock).toHaveBeenCalledTimes(generateCallsBefore);
+        expect(ensureDirExistsAndWriteFileMock).toHaveBeenCalledTimes(writesBefore);
+    });
 });
 
 describe('serve - falls back to full regenerate when incremental is unavailable', () => {
@@ -1032,6 +1042,21 @@ describe('serve - releases retained watch state on close', () => {
 
         expect(watchSignal?.aborted).toBe(true);
         expect(rmDirMock.mock.calls.length).toBe(rmDirCallsBefore + 1);
+    });
+
+    it('does not fail server startup when watcher setup rejects', async () => {
+        setupWatcherMock.mockRejectedValueOnce(new Error('intentional watcher setup failure'));
+
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+        const server = await created.listen();
+        await server.close();
+
+        expect(setupWatcherMock).toHaveBeenCalled();
     });
 });
 

--- a/packages/vite-svg-2-webfont/src/utils.test.ts
+++ b/packages/vite-svg-2-webfont/src/utils.test.ts
@@ -129,6 +129,40 @@ describe('utils', () => {
             ]);
         });
 
+        it('keeps a newly added svg as added when it changes in the same batch', async () => {
+            const { watch } = fs;
+            const events = [
+                { eventType: 'rename' as const, filename: 'a.svg' },
+                { eventType: 'change' as const, filename: 'a.svg' },
+            ];
+            async function* mock() {
+                yield* events;
+            }
+            if (vi.isMockFunction(watch)) {
+                watch.mockReturnValue(mock());
+            }
+
+            expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
+            expect(handler).toHaveBeenCalledExactlyOnceWith([{ path: pathJoin(folderPath, 'a.svg'), kind: 'added' }]);
+        });
+
+        it('keeps the latest change when no special coalescing applies', async () => {
+            const { watch } = fs;
+            const events = [
+                { eventType: 'change' as const, filename: 'a.svg' },
+                { eventType: 'change' as const, filename: 'a.svg' },
+            ];
+            async function* mock() {
+                yield* events;
+            }
+            if (vi.isMockFunction(watch)) {
+                watch.mockReturnValue(mock());
+            }
+
+            expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
+            expect(handler).toHaveBeenCalledExactlyOnceWith([{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }]);
+        });
+
         it('serializes async batch handlers', async () => {
             const { watch } = fs;
             const firstHandler = Promise.withResolvers<void>();
@@ -161,6 +195,63 @@ describe('utils', () => {
             await watcher;
 
             expect(calls).toEqual([[{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }], [{ path: pathJoin(folderPath, 'b.svg'), kind: 'changed' }]]);
+        });
+
+        it('continues flushing later batches after a scheduled handler rejection', async () => {
+            const { watch } = fs;
+            const calls: utils.WatchedChangeBatch[] = [];
+            const events = [
+                { eventType: 'change' as const, filename: 'a.svg' },
+                { eventType: 'change' as const, filename: 'b.svg' },
+            ];
+            async function* mock() {
+                yield events[0]!;
+                await setTimeout(40);
+                yield events[1]!;
+            }
+            if (vi.isMockFunction(watch)) {
+                watch.mockReturnValue(mock());
+            }
+            handler.mockImplementationOnce((changes: utils.WatchedChangeBatch) => {
+                calls.push(changes);
+                throw new Error('intentional batch failure');
+            });
+            handler.mockImplementationOnce((changes: utils.WatchedChangeBatch) => {
+                calls.push(changes);
+            });
+
+            expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
+            expect(calls).toEqual([[{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }], [{ path: pathJoin(folderPath, 'b.svg'), kind: 'changed' }]]);
+        });
+
+        it('swallows a final drain rejection after the watcher closes', async () => {
+            const { watch } = fs;
+            const event = { eventType: 'change' as const, filename: 'a.svg' };
+            async function* mock() {
+                yield event;
+            }
+            if (vi.isMockFunction(watch)) {
+                watch.mockReturnValue(mock());
+            }
+            handler.mockRejectedValueOnce(new Error('intentional drain failure'));
+
+            expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
+            expect(handler).toHaveBeenCalledExactlyOnceWith([{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }]);
+        });
+
+        it('does not propagate watch event classification errors', async () => {
+            const { watch } = fs;
+            const validEvent = { eventType: 'change' as const, filename: 'a.svg' };
+            async function* mock() {
+                yield { eventType: 'change' as const, filename: { endsWith: true } } as never;
+                yield validEvent;
+            }
+            if (vi.isMockFunction(watch)) {
+                watch.mockReturnValue(mock());
+            }
+
+            expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
+            expect(handler).toHaveBeenCalledExactlyOnceWith([{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }]);
         });
     });
 

--- a/packages/vite-svg-2-webfont/src/utils.ts
+++ b/packages/vite-svg-2-webfont/src/utils.ts
@@ -87,14 +87,11 @@ export async function setupWatcher(folderPath: string, signal: AbortSignal, onCh
     };
 
     const scheduleFlush = () => {
-        flushChain = flushChain
-            .catch(() => undefined)
-            .then(flush)
-            .catch(() => undefined);
+        flushChain = flushChain.then(flush).catch(() => undefined);
     };
 
     const drain = async () => {
-        await flushChain.catch(() => undefined);
+        await flushChain;
         await flush().catch(() => undefined);
     };
 
@@ -144,7 +141,7 @@ export function getTmpDir(): string {
 }
 
 export function rmDir(path: string): void {
-    fsRm(path, { force: true, recursive: true }, () => {});
+    fsRm(path, { force: true, recursive: true }, /* v8 ignore next -- best-effort temp cleanup callback has no observable behavior */ () => {});
 }
 
 export function base64ToArrayBuffer(base64: string): ArrayBuffer {

--- a/packages/webfont-generator/index.js
+++ b/packages/webfont-generator/index.js
@@ -5,7 +5,7 @@ const UPSTREAM_TTF_COMPAT_TS = 1_484_141_760_000;
 
 function coerceCodepoints(codepoints) {
     if (!codepoints) return undefined;
-    return Object.fromEntries(Object.entries(codepoints).map(([name, value]) => [name, String.fromCharCode(value).codePointAt(0) ?? 0]));
+    return Object.fromEntries(Object.entries(codepoints).map(([name, value]) => [name, String.fromCharCode(value).codePointAt(0)]));
 }
 
 async function generateWebfonts(options) {


### PR DESCRIPTION
## Summary
- add regression coverage for watcher batch edge cases, classification failures, and setup failures
- simplify watcher flush error handling while preserving swallowed failures
- remove the unreachable codepoint coercion fallback in the webfont-generator JS wrapper

## Verification
- `vp run coverage`
- `vp check`