### PR TITLE
perf(webfont-generator): reuse renders by template dependencies

### DIFF
--- a/packages/webfont-generator/benches/features.rs
+++ b/packages/webfont-generator/benches/features.rs
@@ -348,6 +348,7 @@ fn bench_template_rendering(c: &mut Criterion) {
     let mut custom_opts = opts.clone();
     custom_opts.css_template = Some(css_template);
     custom_opts.html_template = Some(html_template);
+    let custom_result = webfont_generator::generate_sync(custom_opts.clone(), None).unwrap();
     group.bench_function("css_first/custom/300", |b| {
         b.iter_batched(
             || webfont_generator::generate_sync(custom_opts.clone(), None).unwrap(),
@@ -355,12 +356,20 @@ fn bench_template_rendering(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
+    custom_result.generate_css_pure(None).unwrap();
+    group.bench_function("css_cached/custom/300", |b| {
+        b.iter(|| custom_result.generate_css_pure(None).unwrap())
+    });
     group.bench_function("html_first/custom/300", |b| {
         b.iter_batched(
             || webfont_generator::generate_sync(custom_opts.clone(), None).unwrap(),
             |result| result.generate_html_pure(None).unwrap(),
             BatchSize::SmallInput,
         )
+    });
+    custom_result.generate_html_pure(None).unwrap();
+    group.bench_function("html_cached/custom/300", |b| {
+        b.iter(|| custom_result.generate_html_pure(None).unwrap())
     });
     group.finish();
 }

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -623,6 +623,58 @@ fn bench_render_cache_after_regenerate(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
+    group.bench_function("add_custom_html_ignored_deps_reused/300", |b| {
+        b.iter_batched(
+            || {
+                let mut fixture = fixtures(size);
+                let template = fixture.dir.join("html-font-name-only.hbs");
+                std::fs::write(&template, "<h1>{{fontName}}</h1>\n").unwrap();
+                let mut opts = css_html_options(fixture.paths.clone(), true);
+                opts.html_template = Some(template.to_string_lossy().into_owned());
+                let result = webfont_generator::generate_sync(opts, None).unwrap();
+                result.generate_html_pure(None).unwrap();
+                let added = write_icon(&fixture.dir, "added-html-reuse", &changed_path_data());
+                fixture.paths.push(added.clone());
+                (fixture, result, added)
+            },
+            |(fixture, mut result, added)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(added, GlyphChange::Added { name: None })],
+                    )
+                    .unwrap();
+                result.generate_html_pure(None).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("add_default_html_rerender/300", |b| {
+        b.iter_batched(
+            || {
+                let mut fixture = fixtures(size);
+                let result = webfont_generator::generate_sync(
+                    css_html_options(fixture.paths.clone(), true),
+                    None,
+                )
+                .unwrap();
+                result.generate_html_pure(None).unwrap();
+                let added = write_icon(&fixture.dir, "added-html-rerender", &changed_path_data());
+                fixture.paths.push(added.clone());
+                (fixture, result, added)
+            },
+            |(fixture, mut result, added)| {
+                result
+                    .regenerate(
+                        &fixture.paths,
+                        &[(added, GlyphChange::Added { name: None })],
+                    )
+                    .unwrap();
+                result.generate_html_pure(None).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
     group.finish();
 }
 

--- a/packages/webfont-generator/src/incremental/mod.rs
+++ b/packages/webfont-generator/src/incremental/mod.rs
@@ -188,12 +188,12 @@ impl GenerateWebfontsResult {
             .iter()
             .map(|file| file.glyph_name.as_str())
             .eq(prev_names.iter().map(String::as_str));
-        let reuse_renders = names_unchanged && options.codepoints == prev_codepoints;
+        let codepoints_unchanged = options.codepoints == prev_codepoints;
         self.source_files = source_files;
         self.options = options;
         self.fonts = fonts;
         self.glyph_cache = Some(cache);
-        self.reset_render_cache(reuse_renders);
+        self.reset_render_cache(names_unchanged, codepoints_unchanged);
 
         // Match `generate`'s write behavior: refresh font files, and skip unchanged CSS/HTML.
         if self.options.write_files {

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -719,6 +719,40 @@ fn regenerate_drops_html_for_template_that_reads_names() {
 }
 
 #[test]
+fn regenerate_drops_html_for_template_that_reads_root_styles() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let html_template =
+        write_temp_template("html-root-styles", "<style>{{{@root.styles}}}</style>\n");
+
+    let mut result = generate_with_templates(
+        vec![a.clone(), b.clone()],
+        true,
+        None,
+        Some(html_template.clone()),
+    );
+    let before = result.generate_html_pure(None).unwrap();
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+    let after = result.generate_html_pure(None).unwrap();
+
+    assert_ne!(before, after, "HTML styles changed with the font hash");
+    assert!(
+        !result.has_carried_html_no_urls_for_test(),
+        "HTML that reads @root.styles must be re-rendered when styles change"
+    );
+    let fresh = generate_with_templates(vec![a, b], false, None, Some(html_template));
+    assert_eq!(after, fresh.generate_html_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn regenerate_drops_dynamic_css_template_cache_conservatively() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -880,6 +880,39 @@ fn regenerate_drops_html_for_block_param_template() {
 }
 
 #[test]
+fn regenerate_drops_html_for_whole_context_template() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let html_template = write_temp_template("html-whole-context", "{{this}}\n");
+
+    let mut result = generate_with_templates(
+        vec![a.clone(), b.clone()],
+        true,
+        None,
+        Some(html_template.clone()),
+    );
+    result.generate_html_pure(None).unwrap();
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(c.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        !result.has_carried_html_no_urls_for_test(),
+        "HTML with whole-context reads must not carry render cache"
+    );
+    let after = result.generate_html_pure(None).unwrap();
+    assert!(after.contains("c"));
+    let fresh = generate_with_templates(vec![a, b, c], false, None, Some(html_template));
+    assert_eq!(after, fresh.generate_html_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn regenerate_drops_dynamic_css_template_cache_conservatively() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -844,6 +844,42 @@ fn regenerate_drops_html_for_lookup_subexpression_template() {
 }
 
 #[test]
+fn regenerate_drops_html_for_block_param_template() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let html_template = write_temp_template(
+        "html-block-param-names",
+        "{{#with this as |ctx|}}{{#each ctx.names}}{{this}};{{/each}}{{/with}}\n",
+    );
+
+    let mut result = generate_with_templates(
+        vec![a.clone(), b.clone()],
+        true,
+        None,
+        Some(html_template.clone()),
+    );
+    result.generate_html_pure(None).unwrap();
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(c.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        !result.has_carried_html_no_urls_for_test(),
+        "HTML with block-param aliases must not carry render cache"
+    );
+    let after = result.generate_html_pure(None).unwrap();
+    assert!(after.contains("c;"));
+    let fresh = generate_with_templates(vec![a, b, c], false, None, Some(html_template));
+    assert_eq!(after, fresh.generate_html_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn regenerate_drops_dynamic_css_template_cache_conservatively() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::test_helpers::write_temp_template;
 use crate::types::{FontType, GenerateWebfontsResult, GlyphChange, LoadedSvgFile};
 use crate::{FormatOptions, GenerateWebfontsOptions, TtfFormatOptions};
 use crate::{
@@ -497,6 +498,33 @@ fn generate_with_css(paths: Vec<String>, incremental: bool) -> GenerateWebfontsR
     generate_webfonts_sync(resolved, source_files).unwrap()
 }
 
+fn generate_with_templates(
+    paths: Vec<String>,
+    incremental: bool,
+    css_template: Option<String>,
+    html_template: Option<String>,
+) -> GenerateWebfontsResult {
+    let mut resolved = resolve_generate_webfonts_options(GenerateWebfontsOptions {
+        css: Some(css_template.is_some()),
+        css_template,
+        dest: "artifacts".to_owned(),
+        files: paths,
+        html: Some(html_template.is_some()),
+        html_template,
+        font_name: Some("rc".to_owned()),
+        format_options: Some(stable_format_options()),
+        ligature: Some(false),
+        incremental: Some(incremental),
+        write_files: Some(false),
+        types: Some(vec![FontType::Woff2]),
+        ..Default::default()
+    })
+    .unwrap();
+    let source_files = load(&resolved.files);
+    finalize_generate_webfonts_options(&mut resolved, &source_files).unwrap();
+    generate_webfonts_sync(resolved, source_files).unwrap()
+}
+
 #[test]
 fn regenerate_reuses_provided_url_css_on_content_edit() {
     let dir = temp_dir();
@@ -579,6 +607,138 @@ fn regenerate_rerenders_css_on_rename() {
     assert!(
         after.contains("renamed"),
         "new glyph name should appear in the CSS"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_carries_css_for_template_that_ignores_changed_glyph_data() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let css_template = write_temp_template("css-font-name-only", "{{fontName}}\n");
+
+    let mut result =
+        generate_with_templates(vec![a.clone(), b.clone()], true, Some(css_template), None);
+    let before = result.generate_css_pure(None).unwrap();
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(c.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        result.has_carried_css_no_urls_for_test(),
+        "CSS that only reads stable fields should be carried across glyph set changes"
+    );
+    assert_eq!(before, result.generate_css_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_drops_css_for_template_that_reads_codepoints() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let css_template = write_temp_template(
+        "css-codepoints",
+        "{{#each codepoints}}{{@key}}={{this}};{{/each}}\n",
+    );
+
+    let mut result =
+        generate_with_templates(vec![a.clone(), b.clone()], true, Some(css_template), None);
+    result.generate_css_pure(None).unwrap();
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(c.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        !result.has_carried_css_no_urls_for_test(),
+        "CSS that reads codepoints must be re-rendered when codepoints change"
+    );
+    assert!(result.generate_css_pure(None).unwrap().contains("c="));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_carries_html_for_template_that_ignores_names_and_styles() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let html_template = write_temp_template("html-font-name-only", "<h1>{{fontName}}</h1>\n");
+
+    let mut result =
+        generate_with_templates(vec![a.clone(), b.clone()], true, None, Some(html_template));
+    let before = result.generate_html_pure(None).unwrap();
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(c.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        result.has_carried_html_no_urls_for_test(),
+        "HTML that only reads stable fields should be carried across glyph set changes"
+    );
+    assert_eq!(before, result.generate_html_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_drops_html_for_template_that_reads_names() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let html_template = write_temp_template("html-names", "{{#each names}}{{this}};{{/each}}\n");
+
+    let mut result =
+        generate_with_templates(vec![a.clone(), b.clone()], true, None, Some(html_template));
+    result.generate_html_pure(None).unwrap();
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(c.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        !result.has_carried_html_no_urls_for_test(),
+        "HTML that reads names must be re-rendered when names change"
+    );
+    assert!(result.generate_html_pure(None).unwrap().contains("c;"));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_drops_dynamic_css_template_cache_conservatively() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let css_template = write_temp_template("css-dynamic", "{{lookup codepoints \"a\"}}\n");
+
+    let mut result =
+        generate_with_templates(vec![a.clone(), b.clone()], true, Some(css_template), None);
+    result.generate_css_pure(None).unwrap();
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        !result.has_carried_css_no_urls_for_test(),
+        "dynamic template access should not be carried across regenerates"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -753,6 +753,39 @@ fn regenerate_drops_html_for_template_that_reads_root_styles() {
 }
 
 #[test]
+fn regenerate_drops_html_for_template_that_reads_trimmed_styles() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let html_template = write_temp_template("html-trimmed-styles", "<style>{{~styles~}}</style>\n");
+
+    let mut result = generate_with_templates(
+        vec![a.clone(), b.clone()],
+        true,
+        None,
+        Some(html_template.clone()),
+    );
+    let before = result.generate_html_pure(None).unwrap();
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+    let after = result.generate_html_pure(None).unwrap();
+
+    assert_ne!(before, after, "HTML styles changed with the font hash");
+    assert!(
+        !result.has_carried_html_no_urls_for_test(),
+        "HTML that reads {{~styles~}} must be re-rendered when styles change"
+    );
+    let fresh = generate_with_templates(vec![a, b], false, None, Some(html_template));
+    assert_eq!(after, fresh.generate_html_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn regenerate_drops_dynamic_css_template_cache_conservatively() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use serde_json::{Map, Value};
+
 use crate::test_helpers::write_temp_template;
 use crate::types::{FontType, GenerateWebfontsResult, GlyphChange, LoadedSvgFile};
 use crate::{FormatOptions, GenerateWebfontsOptions, TtfFormatOptions};
@@ -504,6 +506,16 @@ fn generate_with_templates(
     css_template: Option<String>,
     html_template: Option<String>,
 ) -> GenerateWebfontsResult {
+    generate_with_templates_and_options(paths, incremental, css_template, html_template, None)
+}
+
+fn generate_with_templates_and_options(
+    paths: Vec<String>,
+    incremental: bool,
+    css_template: Option<String>,
+    html_template: Option<String>,
+    template_options: Option<Map<String, Value>>,
+) -> GenerateWebfontsResult {
     let mut resolved = resolve_generate_webfonts_options(GenerateWebfontsOptions {
         css: Some(css_template.is_some()),
         css_template,
@@ -515,6 +527,7 @@ fn generate_with_templates(
         format_options: Some(stable_format_options()),
         ligature: Some(false),
         incremental: Some(incremental),
+        template_options,
         write_files: Some(false),
         types: Some(vec![FontType::Woff2]),
         ..Default::default()
@@ -781,6 +794,51 @@ fn regenerate_drops_html_for_template_that_reads_trimmed_styles() {
         "HTML that reads {{~styles~}} must be re-rendered when styles change"
     );
     let fresh = generate_with_templates(vec![a, b], false, None, Some(html_template));
+    assert_eq!(after, fresh.generate_html_pure(None).unwrap());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_drops_html_for_lookup_subexpression_template() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let html_template = write_temp_template(
+        "html-lookup-names",
+        "{{#each (lookup this field)}}{{this}};{{/each}}\n",
+    );
+    let template_options =
+        Map::from_iter([("field".to_owned(), Value::String("names".to_owned()))]);
+
+    let mut result = generate_with_templates_and_options(
+        vec![a.clone(), b.clone()],
+        true,
+        None,
+        Some(html_template.clone()),
+        Some(template_options.clone()),
+    );
+    result.generate_html_pure(None).unwrap();
+    let c = write_icon(&dir, "c", D3);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(c.clone(), GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+
+    assert!(
+        !result.has_carried_html_no_urls_for_test(),
+        "HTML with lookup subexpressions must not carry render cache"
+    );
+    let after = result.generate_html_pure(None).unwrap();
+    assert!(after.contains("c;"));
+    let fresh = generate_with_templates_and_options(
+        vec![a, b, c],
+        false,
+        None,
+        Some(html_template),
+        Some(template_options),
+    );
     assert_eq!(after, fresh.generate_html_pure(None).unwrap());
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -93,7 +93,7 @@ use svg::{
 #[cfg(feature = "napi")]
 use templates::{
     SharedTemplateData, apply_context_function, build_css_context, build_html_context,
-    build_html_registry, html_template_dependencies,
+    build_html_registry_and_dependencies,
 };
 #[cfg(feature = "napi")]
 use util::to_napi_err;
@@ -318,9 +318,8 @@ pub async fn generate_webfonts(
         }
 
         // Seed the OnceLock -- avoids re-creating SharedTemplateData in get_cached()
-        let html_registry = build_html_registry(&result.options).map_err(to_napi_err)?;
-        let html_template_dependencies =
-            html_template_dependencies(&result.options).map_err(to_napi_err)?;
+        let (html_registry, html_template_dependencies) =
+            build_html_registry_and_dependencies(&result.options).map_err(to_napi_err)?;
         let css_hbs_context = handlebars::Context::wraps(&css_ctx).map_err(to_napi_err)?;
         let html_hbs_context = handlebars::Context::wraps(&html_ctx).map_err(to_napi_err)?;
         let _ = result.cached.set(Ok(types::CachedTemplateData {

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -93,7 +93,7 @@ use svg::{
 #[cfg(feature = "napi")]
 use templates::{
     SharedTemplateData, apply_context_function, build_css_context, build_html_context,
-    build_html_registry,
+    build_html_registry, html_template_dependencies,
 };
 #[cfg(feature = "napi")]
 use util::to_napi_err;
@@ -319,6 +319,8 @@ pub async fn generate_webfonts(
 
         // Seed the OnceLock -- avoids re-creating SharedTemplateData in get_cached()
         let html_registry = build_html_registry(&result.options).map_err(to_napi_err)?;
+        let html_template_dependencies =
+            html_template_dependencies(&result.options).map_err(to_napi_err)?;
         let css_hbs_context = handlebars::Context::wraps(&css_ctx).map_err(to_napi_err)?;
         let html_hbs_context = handlebars::Context::wraps(&html_ctx).map_err(to_napi_err)?;
         let _ = result.cached.set(Ok(types::CachedTemplateData {
@@ -327,6 +329,7 @@ pub async fn generate_webfonts(
             css_hbs_context: Mutex::new(css_hbs_context),
             html_context: html_ctx,
             html_hbs_context: Mutex::new(html_hbs_context),
+            html_template_dependencies,
             html_registry,
             render_cache: Mutex::new(Default::default()),
         }));

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -411,6 +411,7 @@ fn is_lookup_token(token: &str) -> bool {
 fn collect_path_dependency(path: &str, deps: &mut TemplateDependencies) {
     let mut path = path
         .trim_matches(|c| matches!(c, '(' | ')' | ',' | '"' | '\'' | '~'))
+        .trim_start_matches('&')
         .trim_start_matches("../")
         .trim_start_matches("./");
     path = path
@@ -1540,6 +1541,15 @@ mod tests {
         let deps = template_dependencies("{{#each ./names}}{{@index}}{{/each}}");
 
         assert!(deps.names);
+        assert!(!deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_normalizes_unescaped_ampersand_paths() {
+        let deps = template_dependencies("{{&styles}}{{&src}}");
+
+        assert!(deps.styles);
+        assert!(deps.src);
         assert!(!deps.dynamic);
     }
 

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -284,7 +284,7 @@ impl TemplateDependencies {
         }
     }
 
-    pub(crate) const fn depends_on_src(self) -> bool {
+    pub(crate) const fn may_depend_on_src(self) -> bool {
         self.src || self.dynamic
     }
 
@@ -478,14 +478,13 @@ impl SharedTemplateData {
             Some(path) => Some(fs::read_to_string(path)?),
             None => None,
         };
-        // Default template always uses src. Custom templates: scan for any
-        // Handlebars expression referencing `src` (handles whitespace variants
-        // like `{{ src }}`, `{{{ src }}}`, etc.).
+        // Default template always uses src. Dynamic custom templates stay URL-sensitive because
+        // helpers, partials, or whole-context reads may observe `src` indirectly.
         let css_template_dependencies = match &css_template_source {
             None => TemplateDependencies::css_default(),
             Some(source) => template_dependencies(source),
         };
-        let css_template_uses_src = css_template_dependencies.depends_on_src();
+        let css_template_uses_src = css_template_dependencies.may_depend_on_src();
         let (codepoints_hex, codepoints_num) = make_codepoints(options);
         Ok(Self {
             codepoints_hex,

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -361,6 +361,10 @@ fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependen
         deps.dynamic = true;
         return;
     }
+    if expression.contains('|') {
+        deps.dynamic = true;
+        return;
+    }
     let tokens = expression.split_whitespace().collect::<Vec<_>>();
     let Some(first) = tokens.first().copied() else {
         return;
@@ -1505,6 +1509,15 @@ mod tests {
     #[test]
     fn template_dependencies_marks_lookup_subexpression_dynamic() {
         let deps = template_dependencies("{{#each (lookup this field)}}{{this}}{{/each}}");
+
+        assert!(deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_marks_block_params_dynamic() {
+        let deps = template_dependencies(
+            "{{#with this as |ctx|}}{{#each ctx.names}}{{this}}{{/each}}{{/with}}",
+        );
 
         assert!(deps.dynamic);
     }

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -1548,6 +1548,8 @@ mod tests {
         assert!(template_dependencies("{{this}}").dynamic);
         assert!(template_dependencies("{{.}}").dynamic);
         assert!(template_dependencies("{{@root}}").dynamic);
+        assert!(template_dependencies("{{#each this}}{{@key}}={{this}}{{/each}}").dynamic);
+        assert!(template_dependencies("{{#each .}}{{@key}}={{this}}{{/each}}").dynamic);
     }
 
     #[test]

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -254,28 +254,169 @@ fn render_default_css_inner(ctx: &Map<String, Value>, font_name: &str, src: &str
     result
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TemplateDependencies {
+    pub names: bool,
+    pub codepoints: bool,
+    pub src: bool,
+    pub styles: bool,
+    pub dynamic: bool,
+}
+
+impl TemplateDependencies {
+    pub(crate) const fn css_default() -> Self {
+        Self {
+            names: false,
+            codepoints: true,
+            src: true,
+            styles: false,
+            dynamic: false,
+        }
+    }
+
+    pub(crate) const fn html_default() -> Self {
+        Self {
+            names: true,
+            codepoints: false,
+            src: false,
+            styles: true,
+            dynamic: false,
+        }
+    }
+
+    pub(crate) const fn depends_on_src(self) -> bool {
+        self.src || self.dynamic
+    }
+
+    pub(crate) const fn can_reuse_css_no_urls(
+        self,
+        names_unchanged: bool,
+        codepoints_unchanged: bool,
+    ) -> bool {
+        !self.dynamic
+            && !self.src
+            && (!self.names || names_unchanged)
+            && (!self.codepoints || codepoints_unchanged)
+    }
+
+    pub(crate) const fn can_reuse_css_with_urls(
+        self,
+        names_unchanged: bool,
+        codepoints_unchanged: bool,
+    ) -> bool {
+        !self.dynamic
+            && (!self.names || names_unchanged)
+            && (!self.codepoints || codepoints_unchanged)
+    }
+
+    pub(crate) const fn can_reuse_html(
+        self,
+        names_unchanged: bool,
+        codepoints_unchanged: bool,
+        styles_unchanged: bool,
+    ) -> bool {
+        !self.dynamic
+            && (!self.names || names_unchanged)
+            && (!self.codepoints || codepoints_unchanged)
+            && (!self.styles || styles_unchanged)
+    }
+}
+
+pub(crate) fn template_dependencies(source: &str) -> TemplateDependencies {
+    let mut deps = TemplateDependencies::default();
+    for expression in mustache_expressions(source) {
+        collect_expression_dependencies(expression, &mut deps);
+        if deps.dynamic {
+            break;
+        }
+    }
+    deps
+}
+
+fn mustache_expressions(mut source: &str) -> Vec<&str> {
+    let mut expressions = Vec::new();
+    loop {
+        let Some(open) = source.find("{{") else {
+            return expressions;
+        };
+        source = &source[open + 2..];
+        let (inner_start, close_pat) = match source.strip_prefix('{') {
+            Some(rest) => (rest, "}}}"),
+            None => (source, "}}"),
+        };
+        let Some(close) = inner_start.find(close_pat) else {
+            return expressions;
+        };
+        expressions.push(inner_start[..close].trim());
+        source = &inner_start[close + close_pat.len()..];
+    }
+}
+
+fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependencies) {
+    let expression = expression.trim();
+    if expression.is_empty() || expression.starts_with('!') || expression.starts_with('/') {
+        return;
+    }
+    if expression.contains('[') || expression.contains(']') {
+        deps.dynamic = true;
+        return;
+    }
+    let tokens = expression.split_whitespace().collect::<Vec<_>>();
+    let Some(first) = tokens.first().copied() else {
+        return;
+    };
+    let first = first.trim_start_matches(['#', '^']);
+    if first == "lookup" {
+        deps.dynamic = true;
+        return;
+    }
+    if matches!(first, "each" | "if" | "unless" | "with") {
+        for token in tokens.iter().skip(1) {
+            collect_path_dependency(token, deps);
+        }
+        return;
+    }
+    if tokens.len() == 1 {
+        collect_path_dependency(first, deps);
+        return;
+    }
+    if first == "removePeriods" {
+        for token in tokens.iter().skip(1) {
+            collect_path_dependency(token, deps);
+        }
+        return;
+    }
+    deps.dynamic = true;
+}
+
+fn collect_path_dependency(path: &str, deps: &mut TemplateDependencies) {
+    let path = path
+        .trim_matches(|c| matches!(c, '(' | ')' | ',' | '"' | '\''))
+        .trim_start_matches("../");
+    if path.is_empty() || path == "this" || path.starts_with('@') {
+        return;
+    }
+    let root = path.split(['.', '/']).next().unwrap_or(path);
+    match root {
+        "names" => deps.names = true,
+        "codepoints" => deps.codepoints = true,
+        "src" => deps.src = true,
+        "styles" => deps.styles = true,
+        _ => {}
+    }
+}
+
 /// Check whether a Handlebars template source contains `{{name}}` or `{{{name}}}` as an
 /// exact variable reference (with optional whitespace). Does not match block helpers,
 /// conditionals, or sub-expressions — only bare mustache names.
+#[cfg(test)]
 fn template_contains_exact_mustache_name(source: &str, name: &str) -> bool {
-    let mut s = source;
-    loop {
-        let Some(open) = s.find("{{") else {
-            return false;
-        };
-        s = &s[open + 2..];
-        let (inner_start, close_pat) = match s.strip_prefix('{') {
-            Some(rest) => (rest, "}}}"),
-            None => (s, "}}"),
-        };
-        let Some(close) = inner_start.find(close_pat) else {
-            return false;
-        };
-        if inner_start[..close].trim() == name {
+    for expression in mustache_expressions(source) {
+        if expression == name {
             return true;
         }
-        s = &inner_start[close + close_pat.len()..];
     }
+    false
 }
 
 /// Pre-computed values shared between CSS and HTML context building.
@@ -288,6 +429,7 @@ pub(crate) struct SharedTemplateData {
     pub codepoints_num: Map<String, Value>,
     css_template_source: Option<String>,
     css_registry_cache: std::sync::OnceLock<Result<Handlebars<'static>, String>>,
+    pub css_template_dependencies: TemplateDependencies,
     /// Whether the CSS template references `{src}` — if false, URL overrides are a no-op.
     pub css_template_uses_src: bool,
     pub hash: String,
@@ -306,16 +448,18 @@ impl SharedTemplateData {
         // Default template always uses src. Custom templates: scan for any
         // Handlebars expression referencing `src` (handles whitespace variants
         // like `{{ src }}`, `{{{ src }}}`, etc.).
-        let css_template_uses_src = match &css_template_source {
-            None => true,
-            Some(source) => template_contains_exact_mustache_name(source, "src"),
+        let css_template_dependencies = match &css_template_source {
+            None => TemplateDependencies::css_default(),
+            Some(source) => template_dependencies(source),
         };
+        let css_template_uses_src = css_template_dependencies.depends_on_src();
         let (codepoints_hex, codepoints_num) = make_codepoints(options);
         Ok(Self {
             codepoints_hex,
             codepoints_num,
             css_template_source,
             css_registry_cache: std::sync::OnceLock::new(),
+            css_template_dependencies,
             css_template_uses_src,
             hash: calc_hash(options, source_files),
             template_options: resolved_template_options(options),
@@ -579,7 +723,7 @@ impl<'a> From<&'a crate::types::WoffFormatOptions> for HashableWoffFormatOptions
 mod tests {
     use super::{
         SharedTemplateData, build_css_context, calc_hash, make_ctx, make_src, make_urls,
-        render_css_with_context, template_contains_exact_mustache_name,
+        render_css_with_context, template_contains_exact_mustache_name, template_dependencies,
     };
     use crate::{
         FontType, FormatOptions, GenerateWebfontsOptions, LoadedSvgFile,
@@ -1282,6 +1426,41 @@ mod tests {
             shared.is_ok(),
             "init should succeed even with invalid template content"
         );
+    }
+
+    // --- template_dependencies ---
+
+    #[test]
+    fn template_dependencies_detect_each_codepoints_and_parent_paths() {
+        let deps = template_dependencies(
+            "{{#each codepoints}}.{{../classPrefix}}{{@key}} { content: {{this}} }{{/each}}",
+        );
+
+        assert!(deps.codepoints);
+        assert!(!deps.names);
+        assert!(!deps.src);
+        assert!(!deps.styles);
+        assert!(!deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_detect_html_names_styles_and_known_helper_arg() {
+        let deps = template_dependencies(
+            "{{{styles}}} {{#each names}}{{removePeriods ../baseSelector}} {{this}}{{/each}}",
+        );
+
+        assert!(deps.names);
+        assert!(deps.styles);
+        assert!(!deps.codepoints);
+        assert!(!deps.src);
+        assert!(!deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_marks_lookup_dynamic() {
+        let deps = template_dependencies("{{lookup codepoints \"a\"}}");
+
+        assert!(deps.dynamic);
     }
 
     // --- template_contains_exact_mustache_name ---

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -357,6 +357,10 @@ fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependen
     if expression.is_empty() || expression.starts_with('!') || expression.starts_with('/') {
         return;
     }
+    if matches!(expression, "." | "this" | "@root") || expression.starts_with('>') {
+        deps.dynamic = true;
+        return;
+    }
     if expression.contains('[') || expression.contains(']') {
         deps.dynamic = true;
         return;
@@ -370,6 +374,10 @@ fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependen
         return;
     };
     let first = first.trim_start_matches(['#', '^']);
+    if first.starts_with('>') {
+        deps.dynamic = true;
+        return;
+    }
     if tokens.iter().any(|token| is_lookup_token(token)) {
         deps.dynamic = true;
         return;
@@ -403,7 +411,8 @@ fn is_lookup_token(token: &str) -> bool {
 fn collect_path_dependency(path: &str, deps: &mut TemplateDependencies) {
     let mut path = path
         .trim_matches(|c| matches!(c, '(' | ')' | ',' | '"' | '\'' | '~'))
-        .trim_start_matches("../");
+        .trim_start_matches("../")
+        .trim_start_matches("./");
     path = path
         .strip_prefix("@root.")
         .or_else(|| path.strip_prefix("@root/"))
@@ -412,7 +421,11 @@ fn collect_path_dependency(path: &str, deps: &mut TemplateDependencies) {
         .strip_prefix("this.")
         .or_else(|| path.strip_prefix("this/"))
         .unwrap_or(path);
-    if path.is_empty() || path == "this" || path.starts_with('@') {
+    if matches!(path, "" | "." | "this" | "@root") {
+        deps.dynamic = true;
+        return;
+    }
+    if path.starts_with('@') {
         return;
     }
     let root = path.split(['.', '/']).next().unwrap_or(path);
@@ -1452,7 +1465,7 @@ mod tests {
     #[test]
     fn template_dependencies_detect_each_codepoints_and_parent_paths() {
         let deps = template_dependencies(
-            "{{#each codepoints}}.{{../classPrefix}}{{@key}} { content: {{this}} }{{/each}}",
+            "{{#each codepoints}}.{{../classPrefix}}{{@key}} { content: x }{{/each}}",
         );
 
         assert!(deps.codepoints);
@@ -1465,7 +1478,7 @@ mod tests {
     #[test]
     fn template_dependencies_detect_html_names_styles_and_known_helper_arg() {
         let deps = template_dependencies(
-            "{{{styles}}} {{#each names}}{{removePeriods ../baseSelector}} {{this}}{{/each}}",
+            "{{{styles}}} {{#each names}}{{removePeriods ../baseSelector}} {{@index}}{{/each}}",
         );
 
         assert!(deps.names);
@@ -1489,7 +1502,7 @@ mod tests {
     #[test]
     fn template_dependencies_normalizes_whitespace_control_markers() {
         let deps = template_dependencies(
-            "{{~styles}} {{#each names~}}{{this}}{{/each}} {{~@root/codepoints.a~}}",
+            "{{~styles}} {{#each names~}}{{@index}}{{/each}} {{~@root/codepoints.a~}}",
         );
 
         assert!(deps.names);
@@ -1520,6 +1533,28 @@ mod tests {
         );
 
         assert!(deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_normalizes_current_context_paths() {
+        let deps = template_dependencies("{{#each ./names}}{{@index}}{{/each}}");
+
+        assert!(deps.names);
+        assert!(!deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_marks_whole_context_reads_dynamic() {
+        assert!(template_dependencies("{{this}}").dynamic);
+        assert!(template_dependencies("{{.}}").dynamic);
+        assert!(template_dependencies("{{@root}}").dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_marks_partials_dynamic() {
+        assert!(template_dependencies("{{> iconPreview}}").dynamic);
+        assert!(template_dependencies("{{>iconPreview}}").dynamic);
+        assert!(template_dependencies("{{#> iconPreview}}{{/iconPreview}}").dynamic);
     }
 
     // --- template_contains_exact_mustache_name ---

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -366,7 +366,7 @@ fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependen
         return;
     };
     let first = first.trim_start_matches(['#', '^']);
-    if first == "lookup" {
+    if tokens.iter().any(|token| is_lookup_token(token)) {
         deps.dynamic = true;
         return;
     }
@@ -387,6 +387,13 @@ fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependen
         return;
     }
     deps.dynamic = true;
+}
+
+fn is_lookup_token(token: &str) -> bool {
+    token
+        .trim_matches(|c| matches!(c, '(' | ')' | ',' | '"' | '\'' | '~'))
+        .trim_start_matches(['#', '^'])
+        == "lookup"
 }
 
 fn collect_path_dependency(path: &str, deps: &mut TemplateDependencies) {
@@ -1491,6 +1498,13 @@ mod tests {
     #[test]
     fn template_dependencies_marks_lookup_dynamic() {
         let deps = template_dependencies("{{lookup codepoints \"a\"}}");
+
+        assert!(deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_marks_lookup_subexpression_dynamic() {
+        let deps = template_dependencies("{{#each (lookup this field)}}{{this}}{{/each}}");
 
         assert!(deps.dynamic);
     }

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -390,9 +390,17 @@ fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependen
 }
 
 fn collect_path_dependency(path: &str, deps: &mut TemplateDependencies) {
-    let path = path
+    let mut path = path
         .trim_matches(|c| matches!(c, '(' | ')' | ',' | '"' | '\''))
         .trim_start_matches("../");
+    path = path
+        .strip_prefix("@root.")
+        .or_else(|| path.strip_prefix("@root/"))
+        .unwrap_or(path);
+    path = path
+        .strip_prefix("this.")
+        .or_else(|| path.strip_prefix("this/"))
+        .unwrap_or(path);
     if path.is_empty() || path == "this" || path.starts_with('@') {
         return;
     }
@@ -1452,6 +1460,17 @@ mod tests {
         assert!(deps.names);
         assert!(deps.styles);
         assert!(!deps.codepoints);
+        assert!(!deps.src);
+        assert!(!deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_normalizes_root_qualified_paths() {
+        let deps = template_dependencies("{{@root.styles}} {{this.names}} {{@root/codepoints.a}}");
+
+        assert!(deps.names);
+        assert!(deps.styles);
+        assert!(deps.codepoints);
         assert!(!deps.src);
         assert!(!deps.dynamic);
     }

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -353,7 +353,7 @@ fn mustache_expressions(mut source: &str) -> Vec<&str> {
 }
 
 fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependencies) {
-    let expression = expression.trim();
+    let expression = expression.trim().trim_matches('~').trim();
     if expression.is_empty() || expression.starts_with('!') || expression.starts_with('/') {
         return;
     }
@@ -391,7 +391,7 @@ fn collect_expression_dependencies(expression: &str, deps: &mut TemplateDependen
 
 fn collect_path_dependency(path: &str, deps: &mut TemplateDependencies) {
     let mut path = path
-        .trim_matches(|c| matches!(c, '(' | ')' | ',' | '"' | '\''))
+        .trim_matches(|c| matches!(c, '(' | ')' | ',' | '"' | '\'' | '~'))
         .trim_start_matches("../");
     path = path
         .strip_prefix("@root.")
@@ -1467,6 +1467,19 @@ mod tests {
     #[test]
     fn template_dependencies_normalizes_root_qualified_paths() {
         let deps = template_dependencies("{{@root.styles}} {{this.names}} {{@root/codepoints.a}}");
+
+        assert!(deps.names);
+        assert!(deps.styles);
+        assert!(deps.codepoints);
+        assert!(!deps.src);
+        assert!(!deps.dynamic);
+    }
+
+    #[test]
+    fn template_dependencies_normalizes_whitespace_control_markers() {
+        let deps = template_dependencies(
+            "{{~styles}} {{#each names~}}{{this}}{{/each}} {{~@root/codepoints.a~}}",
+        );
 
         assert!(deps.names);
         assert!(deps.styles);

--- a/packages/webfont-generator/src/templates/html.rs
+++ b/packages/webfont-generator/src/templates/html.rs
@@ -67,30 +67,28 @@ fn render_html_with_context(
 /// Pre-compile the HTML Handlebars template with the removePeriods helper.
 /// Returns Ok(None) when no custom template is configured.
 /// Returns Err when the template exists but fails to compile.
+#[cfg(test)]
 pub(crate) fn build_html_registry(
     options: &ResolvedGenerateWebfontsOptions,
 ) -> Result<Option<Handlebars<'static>>, Error> {
+    Ok(build_html_registry_and_dependencies(options)?.0)
+}
+
+pub(crate) fn build_html_registry_and_dependencies(
+    options: &ResolvedGenerateWebfontsOptions,
+) -> Result<(Option<Handlebars<'static>>, TemplateDependencies), Error> {
     let path = match &options.html_template {
         Some(path) => path,
-        None => return Ok(None),
+        None => return Ok((None, TemplateDependencies::html_default())),
     };
     let source = fs::read_to_string(path)?;
+    let dependencies = template_dependencies(&source);
     let mut registry = Handlebars::new();
     registry.register_helper("removePeriods", Box::new(RemovePeriodsHelper));
     registry
         .register_template_string("html", &source)
         .map_err(|error| to_io_err(format!("Failed to compile HTML template: {error}")))?;
-    Ok(Some(registry))
-}
-
-pub(crate) fn html_template_dependencies(
-    options: &ResolvedGenerateWebfontsOptions,
-) -> Result<TemplateDependencies, Error> {
-    let Some(path) = &options.html_template else {
-        return Ok(TemplateDependencies::html_default());
-    };
-    let source = fs::read_to_string(path)?;
-    Ok(template_dependencies(&source))
+    Ok((Some(registry), dependencies))
 }
 
 #[inline]

--- a/packages/webfont-generator/src/templates/html.rs
+++ b/packages/webfont-generator/src/templates/html.rs
@@ -4,7 +4,8 @@ use std::io::Error;
 use std::path::Path;
 
 use crate::templates::css::{
-    SharedTemplateData, build_css_context_with_fonts_url, render_css_with_context,
+    SharedTemplateData, TemplateDependencies, build_css_context_with_fonts_url,
+    render_css_with_context, template_dependencies,
 };
 use crate::types::{LoadedSvgFile, ResolvedGenerateWebfontsOptions};
 use crate::util::to_io_err;
@@ -80,6 +81,16 @@ pub(crate) fn build_html_registry(
         .register_template_string("html", &source)
         .map_err(|error| to_io_err(format!("Failed to compile HTML template: {error}")))?;
     Ok(Some(registry))
+}
+
+pub(crate) fn html_template_dependencies(
+    options: &ResolvedGenerateWebfontsOptions,
+) -> Result<TemplateDependencies, Error> {
+    let Some(path) = &options.html_template else {
+        return Ok(TemplateDependencies::html_default());
+    };
+    let source = fs::read_to_string(path)?;
+    Ok(template_dependencies(&source))
 }
 
 #[inline]

--- a/packages/webfont-generator/src/templates/mod.rs
+++ b/packages/webfont-generator/src/templates/mod.rs
@@ -16,6 +16,6 @@ pub(crate) use css::{
     render_css_with_hbs_context, render_css_with_src_mutate,
 };
 pub(crate) use html::{
-    build_html_context, build_html_registry, html_template_dependencies,
-    render_default_html_with_styles, render_html_with_hbs_context,
+    build_html_context, build_html_registry_and_dependencies, render_default_html_with_styles,
+    render_html_with_hbs_context,
 };

--- a/packages/webfont-generator/src/templates/mod.rs
+++ b/packages/webfont-generator/src/templates/mod.rs
@@ -12,10 +12,10 @@ pub(super) fn ctx_str<'a>(ctx: &'a Map<String, Value>, key: &str, default: &'a s
 #[cfg(feature = "napi")]
 pub(crate) use css::apply_context_function;
 pub(crate) use css::{
-    SharedTemplateData, build_css_context, make_src, render_css_with_hbs_context,
-    render_css_with_src_mutate,
+    SharedTemplateData, TemplateDependencies, build_css_context, make_src,
+    render_css_with_hbs_context, render_css_with_src_mutate,
 };
 pub(crate) use html::{
-    build_html_context, build_html_registry, render_default_html_with_styles,
-    render_html_with_hbs_context,
+    build_html_context, build_html_registry, html_template_dependencies,
+    render_default_html_with_styles, render_html_with_hbs_context,
 };

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -11,7 +11,7 @@ use serde_json::{Map, Value};
 use crate::svg::types::GlyphCache;
 use crate::templates::{
     SharedTemplateData, TemplateDependencies, build_css_context, build_html_context,
-    build_html_registry, html_template_dependencies, make_src, render_css_with_hbs_context,
+    build_html_registry_and_dependencies, make_src, render_css_with_hbs_context,
     render_css_with_src_mutate, render_default_html_with_styles, render_html_with_hbs_context,
 };
 use crate::util::to_io_err;
@@ -488,10 +488,9 @@ impl GenerateWebfontsResult {
                     None => build_html_context(&self.options, &shared, &self.source_files, None)
                         .map_err(|e| e.to_string())?,
                 };
-                let html_registry =
-                    build_html_registry(&self.options).map_err(|e| e.to_string())?;
-                let html_template_dependencies =
-                    html_template_dependencies(&self.options).map_err(|e| e.to_string())?;
+                let (html_registry, html_template_dependencies) =
+                    build_html_registry_and_dependencies(&self.options)
+                        .map_err(|e| e.to_string())?;
                 let css_hbs_context =
                     handlebars::Context::wraps(&css_context).map_err(|e| e.to_string())?;
                 let html_hbs_context =

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -10,9 +10,9 @@ use serde_json::{Map, Value};
 
 use crate::svg::types::GlyphCache;
 use crate::templates::{
-    SharedTemplateData, build_css_context, build_html_context, build_html_registry, make_src,
-    render_css_with_hbs_context, render_css_with_src_mutate, render_default_html_with_styles,
-    render_html_with_hbs_context,
+    SharedTemplateData, TemplateDependencies, build_css_context, build_html_context,
+    build_html_registry, html_template_dependencies, make_src, render_css_with_hbs_context,
+    render_css_with_src_mutate, render_default_html_with_styles, render_html_with_hbs_context,
 };
 use crate::util::to_io_err;
 
@@ -389,6 +389,7 @@ pub(crate) struct CachedTemplateData {
     pub css_hbs_context: Mutex<handlebars::Context>,
     pub html_context: Map<String, Value>,
     pub html_hbs_context: Mutex<handlebars::Context>,
+    pub html_template_dependencies: TemplateDependencies,
     pub html_registry: Option<handlebars::Handlebars<'static>>,
     pub(crate) render_cache: Mutex<RenderCache>,
 }
@@ -431,6 +432,20 @@ pub struct GenerateWebfontsResult {
 
 // Pure Rust getters (always available)
 impl GenerateWebfontsResult {
+    #[cfg(test)]
+    pub(crate) fn has_carried_css_no_urls_for_test(&self) -> bool {
+        self.carried_render
+            .as_ref()
+            .is_some_and(|cache| cache.css_no_urls.is_some())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_carried_html_no_urls_for_test(&self) -> bool {
+        self.carried_render
+            .as_ref()
+            .is_some_and(|cache| cache.html_no_urls.is_some())
+    }
+
     /// Returns the EOT font bytes, if generated.
     pub fn eot_bytes(&self) -> Option<&[u8]> {
         self.fonts.eot_font.as_ref().map(|v| v.as_ref().as_slice())
@@ -475,6 +490,8 @@ impl GenerateWebfontsResult {
                 };
                 let html_registry =
                     build_html_registry(&self.options).map_err(|e| e.to_string())?;
+                let html_template_dependencies =
+                    html_template_dependencies(&self.options).map_err(|e| e.to_string())?;
                 let css_hbs_context =
                     handlebars::Context::wraps(&css_context).map_err(|e| e.to_string())?;
                 let html_hbs_context =
@@ -485,6 +502,7 @@ impl GenerateWebfontsResult {
                     css_hbs_context: Mutex::new(css_hbs_context),
                     html_context,
                     html_hbs_context: Mutex::new(html_hbs_context),
+                    html_template_dependencies,
                     html_registry,
                     // Seed with any entries carried across a regenerate (see reset_render_cache);
                     // these are renders that don't depend on what changed, so reusing them is safe.
@@ -495,27 +513,51 @@ impl GenerateWebfontsResult {
             .map_err(to_io_err)
     }
 
-    /// Reset the lazily-built template/render cache after an incremental `regenerate`. The
-    /// template data (font hash, `src`, contexts) is always rebuilt fresh so default/no-URL
-    /// renders pick up the new font. When `reuse_renders` is true (the glyph names and codepoints
-    /// the templates read are unchanged), the still-valid rendered strings are carried forward to
-    /// seed the rebuilt cache: provided-URL renders always (they don't embed the font hash), and
-    /// no-URL renders only when the CSS template doesn't reference `src` (so it can't embed the
-    /// hash either). Everything else is dropped and re-rendered on next use.
-    pub(crate) fn reset_render_cache(&mut self, reuse_renders: bool) {
-        let carried = reuse_renders
-            .then(|| self.cached.get().and_then(|cached| cached.as_ref().ok()))
-            .flatten()
+    /// Reset the lazily-built template/render cache after an incremental `regenerate`. Template
+    /// data (font hash, `src`, contexts) is rebuilt fresh, but rendered strings that provably do
+    /// not depend on changed template inputs are carried forward into the next cache.
+    pub(crate) fn reset_render_cache(&mut self, names_unchanged: bool, codepoints_unchanged: bool) {
+        let carried = self
+            .cached
+            .get()
+            .and_then(|cached| cached.as_ref().ok())
             .map(|cached| {
+                let css_deps = cached.shared.css_template_dependencies;
+                let css_no_urls_unchanged =
+                    css_deps.can_reuse_css_no_urls(names_unchanged, codepoints_unchanged);
+                let css_with_urls_unchanged =
+                    css_deps.can_reuse_css_with_urls(names_unchanged, codepoints_unchanged);
+                let html_no_urls_unchanged = cached.html_template_dependencies.can_reuse_html(
+                    names_unchanged,
+                    codepoints_unchanged,
+                    css_no_urls_unchanged,
+                );
+                let html_with_urls_unchanged = cached.html_template_dependencies.can_reuse_html(
+                    names_unchanged,
+                    codepoints_unchanged,
+                    css_with_urls_unchanged,
+                );
+
                 let rc = cached.render_cache.lock().unwrap();
-                let keep_no_urls = !cached.shared.css_template_uses_src;
                 RenderCache {
-                    css_no_urls: keep_no_urls.then(|| rc.css_no_urls.clone()).flatten(),
-                    html_no_urls: keep_no_urls.then(|| rc.html_no_urls.clone()).flatten(),
-                    css_last_urls: rc.css_last_urls.clone(),
-                    css_last_result: rc.css_last_result.clone(),
-                    html_last_urls: rc.html_last_urls.clone(),
-                    html_last_result: rc.html_last_result.clone(),
+                    css_no_urls: css_no_urls_unchanged
+                        .then(|| rc.css_no_urls.clone())
+                        .flatten(),
+                    html_no_urls: html_no_urls_unchanged
+                        .then(|| rc.html_no_urls.clone())
+                        .flatten(),
+                    css_last_urls: css_with_urls_unchanged
+                        .then(|| rc.css_last_urls.clone())
+                        .flatten(),
+                    css_last_result: css_with_urls_unchanged
+                        .then(|| rc.css_last_result.clone())
+                        .flatten(),
+                    html_last_urls: html_with_urls_unchanged
+                        .then(|| rc.html_last_urls.clone())
+                        .flatten(),
+                    html_last_result: html_with_urls_unchanged
+                        .then(|| rc.html_last_result.clone())
+                        .flatten(),
                 }
             });
         self.cached = OnceLock::new();

--- a/tests/webfonts-generator.bench.ts
+++ b/tests/webfonts-generator.bench.ts
@@ -208,6 +208,10 @@ describe.each([15, 100, 300, 600])('%i glyphs', numGlyphs => {
 
 const customCssTemplate = join(fileURLToPath(new URL('./fixtures/templates/', import.meta.url)), 'customTemplate.hbs');
 const customHtmlTemplate = join(fileURLToPath(new URL('./fixtures/templates/', import.meta.url)), 'customTemplate.hbs');
+const dependencyAwareCssTemplate = join(bulkFixtureDir, 'dependency-aware-css.hbs');
+const dependencyAwareHtmlTemplate = join(bulkFixtureDir, 'dependency-aware-html.hbs');
+writeFileSync(dependencyAwareCssTemplate, '{{fontName}}\n');
+writeFileSync(dependencyAwareHtmlTemplate, '<h1>{{fontName}}</h1>\n');
 const contextMutator = (ctx: Record<string, unknown>) => {
     ctx.custom = 'bench-value';
 };
@@ -307,6 +311,7 @@ describe.each([5, 300])('generateCss / generateHtml — %i glyphs', numGlyphs =>
 
 // Incremental rebuild: full regen vs reusing unchanged glyphs.
 const DEV_FORMAT = { formatOptions: { woff2: { compressionQuality: 10 } } };
+const RENDER_REUSE_FORMAT = { optimizeOutput: false, types: ['svg'] as const };
 const EDIT_SVG_A = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>';
 const EDIT_SVG_B = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20L12 22z"/></svg>';
 const EDIT_SVG_C = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h30L12 22z"/></svg>';
@@ -659,6 +664,80 @@ describe.each([100, 300, 600])('ordered add/remove regenerate — %i glyphs', nu
                 }
                 hasExtra = !hasExtra;
                 expect(result.svg).toBeDefined();
+            },
+            benchOpts,
+        );
+    });
+});
+
+const dependencyAwareResults = new Map<string, Awaited<ReturnType<typeof generateWebfonts>>>();
+await Promise.all(
+    [15, 100, 300, 600].flatMap(numGlyphs => {
+        const files = bulkFiles.slice(0, numGlyphs);
+        return [
+            generateWebfonts(baseOpts(files, { css: true, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
+                result.generateCss();
+                dependencyAwareResults.set(`${numGlyphs}-default-css`, result);
+            }),
+            generateWebfonts(baseOpts(files, { css: true, cssTemplate: dependencyAwareCssTemplate, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
+                result.generateCss();
+                dependencyAwareResults.set(`${numGlyphs}-custom-css`, result);
+            }),
+            generateWebfonts(baseOpts(files, { html: true, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
+                result.generateHtml();
+                dependencyAwareResults.set(`${numGlyphs}-default-html`, result);
+            }),
+            generateWebfonts(baseOpts(files, { html: true, htmlTemplate: dependencyAwareHtmlTemplate, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
+                result.generateHtml();
+                dependencyAwareResults.set(`${numGlyphs}-custom-html`, result);
+            }),
+        ];
+    }),
+);
+
+describe.each([15, 100, 300, 600])('dependency-aware render reuse after add/remove — %i glyphs', numGlyphs => {
+    const files = bulkFiles.slice(0, numGlyphs);
+    const extra = extraSvgs.get('end')!;
+    const filesWithExtra = [...files, extra];
+    const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
+
+    const cases = [
+        {
+            key: `${numGlyphs}-default-css`,
+            label: 'default CSS — rerender',
+            render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateCss(),
+        },
+        {
+            key: `${numGlyphs}-custom-css`,
+            label: 'custom CSS ignored deps — reused',
+            render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateCss(),
+        },
+        {
+            key: `${numGlyphs}-default-html`,
+            label: 'default HTML — rerender',
+            render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateHtml(),
+        },
+        {
+            key: `${numGlyphs}-custom-html`,
+            label: 'custom HTML ignored deps — reused',
+            render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateHtml(),
+        },
+    ];
+
+    cases.forEach(({ key, label, render }) => {
+        const result = dependencyAwareResults.get(key)!;
+        let hasExtra = false;
+
+        bench(
+            `new core — ${label}`,
+            () => {
+                if (hasExtra) {
+                    result.regenerate(files, [{ path: extra, changeType: 'removed' }]);
+                } else {
+                    result.regenerate(filesWithExtra, [{ path: extra, changeType: 'added', name: 'icon-extra-end' }]);
+                }
+                hasExtra = !hasExtra;
+                expect(render(result)).toBeDefined();
             },
             benchOpts,
         );

--- a/tests/webfonts-generator.bench.ts
+++ b/tests/webfonts-generator.bench.ts
@@ -691,7 +691,7 @@ await Promise.all(
     }),
 );
 
-describe.each([15, 100, 300, 600])('dependency-aware render reuse after add/remove — %i glyphs', numGlyphs => {
+describe.each([15, 100, 300, 600])('dependency-aware render reuse add/remove toggle — %i glyphs', numGlyphs => {
     const files = bulkFiles.slice(0, numGlyphs);
     const extra = extraSvgs.get('end')!;
     const filesWithExtra = [...files, extra];
@@ -700,22 +700,22 @@ describe.each([15, 100, 300, 600])('dependency-aware render reuse after add/remo
     const cases = [
         {
             key: `${numGlyphs}-default-css`,
-            label: 'default CSS — rerender',
+            label: 'default CSS rerender',
             render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateCss(),
         },
         {
             key: `${numGlyphs}-custom-css`,
-            label: 'custom CSS ignored deps — reused',
+            label: 'custom CSS ignored deps reused',
             render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateCss(),
         },
         {
             key: `${numGlyphs}-default-html`,
-            label: 'default HTML — rerender',
+            label: 'default HTML rerender',
             render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateHtml(),
         },
         {
             key: `${numGlyphs}-custom-html`,
-            label: 'custom HTML ignored deps — reused',
+            label: 'custom HTML ignored deps reused',
             render: (result: Awaited<ReturnType<typeof generateWebfonts>>) => result.generateHtml(),
         },
     ];
@@ -725,7 +725,7 @@ describe.each([15, 100, 300, 600])('dependency-aware render reuse after add/remo
         let hasExtra = false;
 
         bench(
-            `new core — ${label}`,
+            `new core — ${label} toggle`,
             () => {
                 if (hasExtra) {
                     result.regenerate(files, [{ path: extra, changeType: 'removed' }]);

--- a/tests/webfonts-generator.bench.ts
+++ b/tests/webfonts-generator.bench.ts
@@ -311,7 +311,7 @@ describe.each([5, 300])('generateCss / generateHtml — %i glyphs', numGlyphs =>
 
 // Incremental rebuild: full regen vs reusing unchanged glyphs.
 const DEV_FORMAT = { formatOptions: { woff2: { compressionQuality: 10 } } };
-const RENDER_REUSE_FORMAT = { optimizeOutput: false, types: ['svg'] as const };
+const RENDER_REUSE_FORMAT = { optimizeOutput: false, types: ['svg'] } satisfies Partial<GenerateWebfontsInputOptions>;
 const EDIT_SVG_A = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>';
 const EDIT_SVG_B = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h20L12 22z"/></svg>';
 const EDIT_SVG_C = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 2h30L12 22z"/></svg>';
@@ -675,22 +675,18 @@ await Promise.all(
     [15, 100, 300, 600].flatMap(numGlyphs => {
         const files = bulkFiles.slice(0, numGlyphs);
         return [
-            generateWebfonts(baseOpts(files, { css: true, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
-                result.generateCss();
-                dependencyAwareResults.set(`${numGlyphs}-default-css`, result);
-            }),
-            generateWebfonts(baseOpts(files, { css: true, cssTemplate: dependencyAwareCssTemplate, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
-                result.generateCss();
-                dependencyAwareResults.set(`${numGlyphs}-custom-css`, result);
-            }),
-            generateWebfonts(baseOpts(files, { html: true, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
-                result.generateHtml();
-                dependencyAwareResults.set(`${numGlyphs}-default-html`, result);
-            }),
-            generateWebfonts(baseOpts(files, { html: true, htmlTemplate: dependencyAwareHtmlTemplate, incremental: true, ...RENDER_REUSE_FORMAT })).then(result => {
-                result.generateHtml();
-                dependencyAwareResults.set(`${numGlyphs}-custom-html`, result);
-            }),
+            generateWebfonts(baseOpts(files, { css: true, incremental: true, ...RENDER_REUSE_FORMAT })).then(
+                result => (result.generateCss(), dependencyAwareResults.set(`${numGlyphs}-default-css`, result)),
+            ),
+            generateWebfonts(baseOpts(files, { css: true, cssTemplate: dependencyAwareCssTemplate, incremental: true, ...RENDER_REUSE_FORMAT })).then(
+                result => (result.generateCss(), dependencyAwareResults.set(`${numGlyphs}-custom-css`, result)),
+            ),
+            generateWebfonts(baseOpts(files, { html: true, incremental: true, ...RENDER_REUSE_FORMAT })).then(
+                result => (result.generateHtml(), dependencyAwareResults.set(`${numGlyphs}-default-html`, result)),
+            ),
+            generateWebfonts(baseOpts(files, { html: true, htmlTemplate: dependencyAwareHtmlTemplate, incremental: true, ...RENDER_REUSE_FORMAT })).then(
+                result => (result.generateHtml(), dependencyAwareResults.set(`${numGlyphs}-custom-html`, result)),
+            ),
         ];
     }),
 );


### PR DESCRIPTION
## Summary
- add static Handlebars template dependency extraction for render-cache carryover
- reuse CSS/HTML render cache entries only when the fields a template reads are unchanged
- derive custom HTML registry and dependency metadata from the same template source read
- add Rust tests plus Criterion and JS benchmark coverage for dependency-aware render reuse