### PR TITLE
test(webfont-generator): add recalc benchmarks

### DIFF
--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -58,14 +58,34 @@ fn path_data(index: usize) -> String {
 }
 
 fn svg(path_data: &str) -> String {
+    svg_with_viewbox(24.0, 24.0, path_data)
+}
+
+fn svg_with_viewbox(width: f64, height: f64, path_data: &str) -> String {
     format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{path_data}\"/></svg>"
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {width:.2} {height:.2}\"><path d=\"{path_data}\"/></svg>"
     )
 }
 
-fn tall_svg() -> String {
-    "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 96\"><path d=\"M2 2 C8 24 16 48 22 94\"/></svg>"
-        .to_owned()
+fn replacement_path(width: f64, height: f64) -> String {
+    let max_x = (width - 2.0).max(2.0);
+    let max_y = (height - 2.0).max(2.0);
+    format!(
+        "M2 2 C{:.2} {:.2} {:.2} {:.2} {max_x:.2} {max_y:.2}",
+        width * 0.33,
+        height * 0.25,
+        width * 0.67,
+        height * 0.5
+    )
+}
+
+fn viewbox_size(svg: &str) -> Option<(f64, f64)> {
+    let (_, after_attr) = svg.split_once("viewBox=\"")?;
+    let (viewbox, _) = after_attr.split_once('"')?;
+    let mut values = viewbox.split_ascii_whitespace();
+    values.next()?;
+    values.next()?;
+    Some((values.next()?.parse().ok()?, values.next()?.parse().ok()?))
 }
 
 fn sources_with_first_changed(fixture: &FixtureSet, contents: String) -> Vec<BenchSvgSource> {
@@ -74,6 +94,36 @@ fn sources_with_first_changed(fixture: &FixtureSet, contents: String) -> Vec<Ben
         source.contents = contents;
     }
     sources
+}
+
+fn stable_metric_sources(fixture: &FixtureSet) -> Vec<BenchSvgSource> {
+    let (width, height) = fixture
+        .sources
+        .first()
+        .and_then(|source| viewbox_size(&source.contents))
+        .unwrap_or((24.0, 24.0));
+    sources_with_first_changed(
+        fixture,
+        svg_with_viewbox(width, height, &replacement_path(width, height)),
+    )
+}
+
+fn metric_shift_sources(fixture: &FixtureSet) -> Vec<BenchSvgSource> {
+    let (first_width, first_height) = fixture
+        .sources
+        .first()
+        .and_then(|source| viewbox_size(&source.contents))
+        .unwrap_or((24.0, 24.0));
+    let max_height = fixture
+        .sources
+        .iter()
+        .filter_map(|source| viewbox_size(&source.contents).map(|(_, height)| height))
+        .fold(first_height, f64::max);
+    let height = max_height + first_height.max(24.0);
+    sources_with_first_changed(
+        fixture,
+        svg_with_viewbox(first_width, height, &replacement_path(first_width, height)),
+    )
 }
 
 fn iconify_json_path(icon_set: &str) -> Option<PathBuf> {
@@ -379,8 +429,8 @@ fn bench_recalc_finalize_inputs(c: &mut Criterion) {
     group.sample_size(10);
     for size in SIZES {
         let fixture = fixtures(size);
-        let stable_sources = sources_with_first_changed(&fixture, svg(&path_data(size + 1)));
-        let metric_shift_sources = sources_with_first_changed(&fixture, tall_svg());
+        let stable_sources = stable_metric_sources(&fixture);
+        let metric_shift_sources = metric_shift_sources(&fixture);
 
         for optimize in [false, true] {
             let stable_options = options(fixture.paths.clone(), vec![FontType::Svg], 10, optimize);

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -63,6 +63,19 @@ fn svg(path_data: &str) -> String {
     )
 }
 
+fn tall_svg() -> String {
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 96\"><path d=\"M2 2 C8 24 16 48 22 94\"/></svg>"
+        .to_owned()
+}
+
+fn sources_with_first_changed(fixture: &FixtureSet, contents: String) -> Vec<BenchSvgSource> {
+    let mut sources = fixture.sources.clone();
+    if let Some(source) = sources.first_mut() {
+        source.contents = contents;
+    }
+    sources
+}
+
 fn iconify_json_path(icon_set: &str) -> Option<PathBuf> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let direct = root
@@ -361,6 +374,97 @@ fn bench_optimize_output(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_recalc_finalize_inputs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recalc_finalize_inputs");
+    group.sample_size(10);
+    for size in SIZES {
+        let fixture = fixtures(size);
+        let stable_sources = sources_with_first_changed(&fixture, svg(&path_data(size + 1)));
+        let metric_shift_sources = sources_with_first_changed(&fixture, tall_svg());
+
+        for optimize in [false, true] {
+            let stable_options = options(fixture.paths.clone(), vec![FontType::Svg], 10, optimize);
+            let stable_parsed = parse_svg_only(stable_options.clone(), &stable_sources).unwrap();
+            group.bench_function(
+                format!("stable_metrics_finalize/optimize_{optimize}/{size}"),
+                |b| {
+                    b.iter_batched(
+                        || stable_parsed.clone(),
+                        |parsed| {
+                            finalize_svg_only(stable_options.clone(), &stable_sources, parsed)
+                                .unwrap()
+                        },
+                        BatchSize::LargeInput,
+                    )
+                },
+            );
+
+            let shifted_options = options(fixture.paths.clone(), vec![FontType::Svg], 10, optimize);
+            let shifted_parsed =
+                parse_svg_only(shifted_options.clone(), &metric_shift_sources).unwrap();
+            group.bench_function(
+                format!("metric_shift_finalize/optimize_{optimize}/{size}"),
+                |b| {
+                    b.iter_batched(
+                        || shifted_parsed.clone(),
+                        |parsed| {
+                            finalize_svg_only(
+                                shifted_options.clone(),
+                                &metric_shift_sources,
+                                parsed,
+                            )
+                            .unwrap()
+                        },
+                        BatchSize::LargeInput,
+                    )
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_recalc_output_ceiling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recalc_output_ceiling");
+    group.sample_size(10);
+    for size in SIZES {
+        let fixture = fixtures(size);
+        let parsed = parse_svg_only(
+            options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+            &fixture.sources,
+        )
+        .unwrap();
+        let prepared = finalize_svg_only(
+            options(fixture.paths.clone(), vec![FontType::Svg], 10, false),
+            &fixture.sources,
+            parsed,
+        )
+        .unwrap();
+
+        group.bench_function(format!("ttf_from_prepared/{size}"), |b| {
+            b.iter(|| {
+                build_outputs_only(
+                    options(fixture.paths.clone(), vec![FontType::Ttf], 10, false),
+                    &fixture.sources,
+                    &prepared,
+                )
+                .unwrap()
+            })
+        });
+        group.bench_function(format!("woff2_from_prepared/{size}"), |b| {
+            b.iter(|| {
+                build_outputs_only(
+                    options(fixture.paths.clone(), vec![FontType::Woff2], 10, false),
+                    &fixture.sources,
+                    &prepared,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
 fn criterion_config() -> Criterion {
     Criterion::default().sample_size(10)
 }
@@ -368,6 +472,6 @@ fn criterion_config() -> Criterion {
 criterion_group! {
     name = benches;
     config = criterion_config();
-    targets = bench_pipeline_slices, bench_pipeline_stages, bench_woff2_quality, bench_optimize_output
+    targets = bench_pipeline_slices, bench_pipeline_stages, bench_woff2_quality, bench_optimize_output, bench_recalc_finalize_inputs, bench_recalc_output_ceiling
 }
 criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add durable Criterion benchmarks for recalc finalization inputs
- add output-ceiling benches for TTF and WOFF2 generation from prepared data
- cover stable-metric vs metric-shift edits and optimizeOutput sensitivity

## Validation
- cargo fmt --manifest-path "packages/webfont-generator/Cargo.toml" --
- vp run @atlowchemi/webfont-generator#bench --no-run
- cargo bench --manifest-path "packages/webfont-generator/Cargo.toml" --features bench --bench pipeline phase2
- cargo test --manifest-path "packages/webfont-generator/Cargo.toml"
- vp run test
- git diff --check