### PR TITLE
test(webfont-generator): stabilize benchmark sampling

### DIFF
--- a/.github/workflows/benchmark-baselines.yml
+++ b/.github/workflows/benchmark-baselines.yml
@@ -20,6 +20,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
+    VITEST_BENCH_BASELINE: benchmark-baselines/webfont-generator/vitest/webfonts-generator.json
     VITEST_BENCH_OUTPUT: benchmark-results/vitest/webfonts-generator.json
 
 jobs:
@@ -82,7 +83,12 @@ jobs:
               run: |
                   set -euo pipefail
                   mkdir -p "$(dirname "$VITEST_BENCH_OUTPUT")"
-                  vp test bench --run --outputJson "$VITEST_BENCH_OUTPUT"
+                  if [ -f "$VITEST_BENCH_BASELINE" ]; then
+                    vp test bench --run --compare "$VITEST_BENCH_BASELINE" --outputJson "$VITEST_BENCH_OUTPUT"
+                  else
+                    echo "::warning::No previous Vitest benchmark JSON found on benchmark-baselines."
+                    vp test bench --run --outputJson "$VITEST_BENCH_OUTPUT"
+                  fi
 
             - name: Store benchmark outputs
               run: |

--- a/packages/webfont-generator/benches/features.rs
+++ b/packages/webfont-generator/benches/features.rs
@@ -301,7 +301,7 @@ fn urls() -> HashMap<FontType, String> {
 
 fn bench_template_rendering(c: &mut Criterion) {
     let mut group = c.benchmark_group("template_rendering");
-    group.sample_size(10);
+    group.sample_size(50);
     let fixture = fixtures(300, "heavy");
     let mut opts = base_options(fixture.paths.clone(), vec![FontType::Woff2]);
     opts.css = Some(true);
@@ -376,7 +376,7 @@ fn bench_template_rendering(c: &mut Criterion) {
 
 fn bench_write_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("write_paths");
-    group.sample_size(10);
+    group.sample_size(50);
     let fixture = fixtures(100, "heavy");
     group.bench_function("initial_write/100", |b| {
         b.iter_batched(
@@ -448,7 +448,7 @@ fn bench_input_complexity(c: &mut Criterion) {
 
 fn bench_geometry_options(c: &mut Criterion) {
     let mut group = c.benchmark_group("geometry_options");
-    group.sample_size(10);
+    group.sample_size(30);
     let fixture = fixtures(300, "heavy");
     for name in [
         "normalize_false",

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -259,7 +259,7 @@ fn remove_position(paths: &[String], position: &str) -> (Vec<String>, String) {
 
 fn bench_svg_prepare(c: &mut Criterion) {
     let mut group = c.benchmark_group("svg_prepare");
-    group.sample_size(10);
+    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         group.bench_function(format!("full/{size}"), |b| {

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -258,7 +258,7 @@ fn options(
 
 fn bench_pipeline_slices(c: &mut Criterion) {
     let mut group = c.benchmark_group("pipeline");
-    group.sample_size(10);
+    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         group.bench_function(format!("svg/{size}"), |b| {
@@ -305,7 +305,7 @@ fn bench_pipeline_slices(c: &mut Criterion) {
 
 fn bench_pipeline_stages(c: &mut Criterion) {
     let mut group = c.benchmark_group("pipeline_stages");
-    group.sample_size(10);
+    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         group.bench_function(format!("parse_only/{size}"), |b| {


### PR DESCRIPTION
## Summary
- run Vitest benchmarks with --compare when a prior benchmark JSON exists
- increase sample sizes for Criterion groups that showed wide intervals in the first baseline job
- target noisy groups: template rendering, write paths, geometry options, svg prepare, and pipeline slices/stages

## Notes
- kept Criterion baseline restore/comparison in place so unstable Rust benches remain visible in logs
- template_rendering is raised to 50 samples so cached nanosecond probes also get a higher-sample validation pass

## Validation
- cargo fmt --manifest-path "packages/webfont-generator/Cargo.toml" --
- vp run @atlowchemi/webfont-generator#bench --no-run
- git diff --check