### PR TITLE
chore: add AI verification agents

### DIFF
--- a/.agents/agents/bench-build-runner.md
+++ b/.agents/agents/bench-build-runner.md
@@ -1,0 +1,15 @@
+---
+name: bench-build-runner
+description: Builds Rust benchmark targets without running benchmarks.
+tools: Bash
+color: orange
+---
+
+Run `vp run @atlowchemi/webfont-generator#bench --no-run` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/agents/coverage-runner.md
+++ b/.agents/agents/coverage-runner.md
@@ -1,0 +1,16 @@
+---
+name: coverage-runner
+description: Runs coverage and summarizes failures or thresholds.
+tools: Bash
+color: green
+---
+
+Run `vp run coverage` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- coverage summary
+- failing tests or coverage thresholds
+- concise error excerpts
+- the exact command run

--- a/.agents/agents/docs-build-runner.md
+++ b/.agents/agents/docs-build-runner.md
@@ -1,0 +1,15 @@
+---
+name: docs-build-runner
+description: Builds the VitePress docs site and summarizes failures.
+tools: Bash
+color: pink
+---
+
+Run `vp run @atlowchemi/vite-svg-webfont-docs#build` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/agents/fixture-refresh-runner.md
+++ b/.agents/agents/fixture-refresh-runner.md
@@ -1,0 +1,16 @@
+---
+name: fixture-refresh-runner
+description: Refreshes generated webfont fixture outputs.
+tools: Bash
+color: red
+---
+
+Run `vp run vite-svg-2-webfont#test:fixtures:refresh` from the repository root.
+
+This command may edit generated fixture files. Do not make manual edits. Return only:
+
+- pass/fail
+- whether fixture files changed
+- concise error excerpts
+- file paths when available
+- the exact command run

--- a/.agents/agents/fmt-runner.md
+++ b/.agents/agents/fmt-runner.md
@@ -1,0 +1,16 @@
+---
+name: fmt-runner
+description: Runs vp fmt and reports formatting changes or failures.
+tools: Bash
+color: yellow
+---
+
+Run `vp fmt` from the repository root.
+
+This command may edit files by applying formatter output. Do not make manual edits. Return only:
+
+- pass/fail
+- whether files were changed by formatting
+- concise error excerpts
+- file paths when available
+- the exact command run

--- a/.agents/agents/napi-build-runner.md
+++ b/.agents/agents/napi-build-runner.md
@@ -1,0 +1,16 @@
+---
+name: napi-build-runner
+description: Builds the webfont-generator NAPI binding and summarizes failures.
+tools: Bash
+color: cyan
+---
+
+Run `vp run @atlowchemi/webfont-generator#build` from the repository root.
+
+This command may update generated binding artifacts. Do not make manual edits. Return only:
+
+- pass/fail
+- whether binding artifacts changed
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/agents/test-runner.md
+++ b/.agents/agents/test-runner.md
@@ -1,0 +1,16 @@
+---
+name: test-runner
+description: Runs project tests and summarizes failures.
+tools: Bash
+color: purple
+---
+
+Run `vp run test` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- failing test names
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/agents/vp-check.md
+++ b/.agents/agents/vp-check.md
@@ -1,0 +1,16 @@
+---
+name: vp-check
+description: Runs vp check and reports concise failures.
+tools: Bash
+color: blue
+---
+
+Run `vp check` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- the failing phase, if visible
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/opencode-agents/bench-build-runner.md
+++ b/.agents/opencode-agents/bench-build-runner.md
@@ -3,10 +3,10 @@ description: Builds Rust benchmark targets without running benchmarks.
 mode: subagent
 color: secondary
 permission:
-  edit: deny
-  bash:
-    "*": deny
-    "vp run @atlowchemi/webfont-generator#bench --no-run*": allow
+    edit: deny
+    bash:
+        '*': deny
+        'vp run @atlowchemi/webfont-generator#bench --no-run*': allow
 ---
 
 Run `vp run @atlowchemi/webfont-generator#bench --no-run` from the repository root.

--- a/.agents/opencode-agents/bench-build-runner.md
+++ b/.agents/opencode-agents/bench-build-runner.md
@@ -1,0 +1,19 @@
+---
+description: Builds Rust benchmark targets without running benchmarks.
+mode: subagent
+color: secondary
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "vp run @atlowchemi/webfont-generator#bench --no-run*": allow
+---
+
+Run `vp run @atlowchemi/webfont-generator#bench --no-run` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/opencode-agents/coverage-runner.md
+++ b/.agents/opencode-agents/coverage-runner.md
@@ -3,10 +3,10 @@ description: Runs coverage and summarizes failures or thresholds.
 mode: subagent
 color: success
 permission:
-  edit: deny
-  bash:
-    "*": deny
-    "vp run coverage*": allow
+    edit: deny
+    bash:
+        '*': deny
+        'vp run coverage*': allow
 ---
 
 Run `vp run coverage` from the repository root.

--- a/.agents/opencode-agents/coverage-runner.md
+++ b/.agents/opencode-agents/coverage-runner.md
@@ -1,0 +1,20 @@
+---
+description: Runs coverage and summarizes failures or thresholds.
+mode: subagent
+color: success
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "vp run coverage*": allow
+---
+
+Run `vp run coverage` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- coverage summary
+- failing tests or coverage thresholds
+- concise error excerpts
+- the exact command run

--- a/.agents/opencode-agents/docs-build-runner.md
+++ b/.agents/opencode-agents/docs-build-runner.md
@@ -3,10 +3,10 @@ description: Builds the VitePress docs site and summarizes failures.
 mode: subagent
 color: primary
 permission:
-  edit: deny
-  bash:
-    "*": deny
-    "vp run @atlowchemi/vite-svg-webfont-docs#build*": allow
+    edit: deny
+    bash:
+        '*': deny
+        'vp run @atlowchemi/vite-svg-webfont-docs#build*': allow
 ---
 
 Run `vp run @atlowchemi/vite-svg-webfont-docs#build` from the repository root.

--- a/.agents/opencode-agents/docs-build-runner.md
+++ b/.agents/opencode-agents/docs-build-runner.md
@@ -1,0 +1,19 @@
+---
+description: Builds the VitePress docs site and summarizes failures.
+mode: subagent
+color: primary
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "vp run @atlowchemi/vite-svg-webfont-docs#build*": allow
+---
+
+Run `vp run @atlowchemi/vite-svg-webfont-docs#build` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/opencode-agents/fixture-refresh-runner.md
+++ b/.agents/opencode-agents/fixture-refresh-runner.md
@@ -3,10 +3,10 @@ description: Refreshes generated webfont fixture outputs.
 mode: subagent
 color: error
 permission:
-  edit: allow
-  bash:
-    "*": deny
-    "vp run vite-svg-2-webfont#test:fixtures:refresh*": allow
+    edit: allow
+    bash:
+        '*': deny
+        'vp run vite-svg-2-webfont#test:fixtures:refresh*': allow
 ---
 
 Run `vp run vite-svg-2-webfont#test:fixtures:refresh` from the repository root.

--- a/.agents/opencode-agents/fixture-refresh-runner.md
+++ b/.agents/opencode-agents/fixture-refresh-runner.md
@@ -1,0 +1,20 @@
+---
+description: Refreshes generated webfont fixture outputs.
+mode: subagent
+color: error
+permission:
+  edit: allow
+  bash:
+    "*": deny
+    "vp run vite-svg-2-webfont#test:fixtures:refresh*": allow
+---
+
+Run `vp run vite-svg-2-webfont#test:fixtures:refresh` from the repository root.
+
+This command may edit generated fixture files. Do not make manual edits. Return only:
+
+- pass/fail
+- whether fixture files changed
+- concise error excerpts
+- file paths when available
+- the exact command run

--- a/.agents/opencode-agents/fmt-runner.md
+++ b/.agents/opencode-agents/fmt-runner.md
@@ -1,0 +1,20 @@
+---
+description: Runs vp fmt and reports formatting changes or failures.
+mode: subagent
+color: warning
+permission:
+  edit: allow
+  bash:
+    "*": deny
+    "vp fmt*": allow
+---
+
+Run `vp fmt` from the repository root.
+
+This command may edit files by applying formatter output. Do not make manual edits. Return only:
+
+- pass/fail
+- whether files were changed by formatting
+- concise error excerpts
+- file paths when available
+- the exact command run

--- a/.agents/opencode-agents/fmt-runner.md
+++ b/.agents/opencode-agents/fmt-runner.md
@@ -3,10 +3,10 @@ description: Runs vp fmt and reports formatting changes or failures.
 mode: subagent
 color: warning
 permission:
-  edit: allow
-  bash:
-    "*": deny
-    "vp fmt*": allow
+    edit: allow
+    bash:
+        '*': deny
+        'vp fmt*': allow
 ---
 
 Run `vp fmt` from the repository root.

--- a/.agents/opencode-agents/napi-build-runner.md
+++ b/.agents/opencode-agents/napi-build-runner.md
@@ -1,0 +1,20 @@
+---
+description: Builds the webfont-generator NAPI binding and summarizes failures.
+mode: subagent
+color: info
+permission:
+  edit: allow
+  bash:
+    "*": deny
+    "vp run @atlowchemi/webfont-generator#build*": allow
+---
+
+Run `vp run @atlowchemi/webfont-generator#build` from the repository root.
+
+This command may update generated binding artifacts. Do not make manual edits. Return only:
+
+- pass/fail
+- whether binding artifacts changed
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/opencode-agents/napi-build-runner.md
+++ b/.agents/opencode-agents/napi-build-runner.md
@@ -3,10 +3,10 @@ description: Builds the webfont-generator NAPI binding and summarizes failures.
 mode: subagent
 color: info
 permission:
-  edit: allow
-  bash:
-    "*": deny
-    "vp run @atlowchemi/webfont-generator#build*": allow
+    edit: allow
+    bash:
+        '*': deny
+        'vp run @atlowchemi/webfont-generator#build*': allow
 ---
 
 Run `vp run @atlowchemi/webfont-generator#build` from the repository root.

--- a/.agents/opencode-agents/test-runner.md
+++ b/.agents/opencode-agents/test-runner.md
@@ -3,10 +3,10 @@ description: Runs project tests and summarizes failures.
 mode: subagent
 color: accent
 permission:
-  edit: deny
-  bash:
-    "*": deny
-    "vp run test*": allow
+    edit: deny
+    bash:
+        '*': deny
+        'vp run test*': allow
 ---
 
 Run `vp run test` from the repository root.

--- a/.agents/opencode-agents/test-runner.md
+++ b/.agents/opencode-agents/test-runner.md
@@ -1,0 +1,20 @@
+---
+description: Runs project tests and summarizes failures.
+mode: subagent
+color: accent
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "vp run test*": allow
+---
+
+Run `vp run test` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- failing test names
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/opencode-agents/vp-check.md
+++ b/.agents/opencode-agents/vp-check.md
@@ -3,10 +3,10 @@ description: Runs vp check and reports concise failures.
 mode: subagent
 color: info
 permission:
-  edit: deny
-  bash:
-    "*": deny
-    "vp check*": allow
+    edit: deny
+    bash:
+        '*': deny
+        'vp check*': allow
 ---
 
 Run `vp check` from the repository root.

--- a/.agents/opencode-agents/vp-check.md
+++ b/.agents/opencode-agents/vp-check.md
@@ -1,0 +1,20 @@
+---
+description: Runs vp check and reports concise failures.
+mode: subagent
+color: info
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "vp check*": allow
+---
+
+Run `vp check` from the repository root.
+
+Do not edit files. Return only:
+
+- pass/fail
+- the failing phase, if visible
+- concise error excerpts
+- file paths and line numbers when available
+- the exact command run

--- a/.agents/rules/docs-sync.md
+++ b/.agents/rules/docs-sync.md
@@ -1,0 +1,9 @@
+# Documentation Sync Rule
+
+When changing `@atlowchemi/webfont-generator` public APIs, options, CLI flags, exported types, or generated bindings, keep these in sync in the same change:
+
+- Rust doc comments in `packages/webfont-generator/src/`.
+- User-facing docs in `packages/docs/webfont-generator/`.
+- Package README at `packages/webfont-generator/README.md`.
+
+Do not duplicate the webfont-generator changelog in docs; `packages/docs/webfont-generator/changelog.md` includes `packages/webfont-generator/CHANGELOG.md`.

--- a/.claude/agents/bench-build-runner.md
+++ b/.claude/agents/bench-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/bench-build-runner.md

--- a/.claude/agents/coverage-runner.md
+++ b/.claude/agents/coverage-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/coverage-runner.md

--- a/.claude/agents/docs-build-runner.md
+++ b/.claude/agents/docs-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/docs-build-runner.md

--- a/.claude/agents/fixture-refresh-runner.md
+++ b/.claude/agents/fixture-refresh-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/fixture-refresh-runner.md

--- a/.claude/agents/fmt-runner.md
+++ b/.claude/agents/fmt-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/fmt-runner.md

--- a/.claude/agents/napi-build-runner.md
+++ b/.claude/agents/napi-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/napi-build-runner.md

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/test-runner.md

--- a/.claude/agents/vp-check.md
+++ b/.claude/agents/vp-check.md
@@ -1,0 +1,1 @@
+../../.agents/agents/vp-check.md

--- a/.claude/rules/docs-sync.md
+++ b/.claude/rules/docs-sync.md
@@ -1,0 +1,1 @@
+../../.agents/rules/docs-sync.md

--- a/.cursor/agents/bench-build-runner.md
+++ b/.cursor/agents/bench-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/bench-build-runner.md

--- a/.cursor/agents/coverage-runner.md
+++ b/.cursor/agents/coverage-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/coverage-runner.md

--- a/.cursor/agents/docs-build-runner.md
+++ b/.cursor/agents/docs-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/docs-build-runner.md

--- a/.cursor/agents/fixture-refresh-runner.md
+++ b/.cursor/agents/fixture-refresh-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/fixture-refresh-runner.md

--- a/.cursor/agents/fmt-runner.md
+++ b/.cursor/agents/fmt-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/fmt-runner.md

--- a/.cursor/agents/napi-build-runner.md
+++ b/.cursor/agents/napi-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/napi-build-runner.md

--- a/.cursor/agents/test-runner.md
+++ b/.cursor/agents/test-runner.md
@@ -1,0 +1,1 @@
+../../.agents/agents/test-runner.md

--- a/.cursor/agents/vp-check.md
+++ b/.cursor/agents/vp-check.md
@@ -1,0 +1,1 @@
+../../.agents/agents/vp-check.md

--- a/.cursor/rules/docs-sync.mdc
+++ b/.cursor/rules/docs-sync.mdc
@@ -1,0 +1,1 @@
+../../.agents/rules/docs-sync.md

--- a/.opencode/agents/bench-build-runner.md
+++ b/.opencode/agents/bench-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/bench-build-runner.md

--- a/.opencode/agents/coverage-runner.md
+++ b/.opencode/agents/coverage-runner.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/coverage-runner.md

--- a/.opencode/agents/docs-build-runner.md
+++ b/.opencode/agents/docs-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/docs-build-runner.md

--- a/.opencode/agents/fixture-refresh-runner.md
+++ b/.opencode/agents/fixture-refresh-runner.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/fixture-refresh-runner.md

--- a/.opencode/agents/fmt-runner.md
+++ b/.opencode/agents/fmt-runner.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/fmt-runner.md

--- a/.opencode/agents/napi-build-runner.md
+++ b/.opencode/agents/napi-build-runner.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/napi-build-runner.md

--- a/.opencode/agents/test-runner.md
+++ b/.opencode/agents/test-runner.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/test-runner.md

--- a/.opencode/agents/vp-check.md
+++ b/.opencode/agents/vp-check.md
@@ -1,0 +1,1 @@
+../../.agents/opencode-agents/vp-check.md

--- a/.opencode/rules/docs-sync.md
+++ b/.opencode/rules/docs-sync.md
@@ -1,0 +1,1 @@
+../../.agents/rules/docs-sync.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,34 @@
-# Using Vite+, the Unified Toolchain for the Web
+# Agent Notes
 
-This project is using Vite+, a unified toolchain built on top of Vite, Rolldown, Vitest, tsdown, Oxlint, Oxfmt, and Vite Task. Vite+ wraps runtime management, package management, and frontend tooling in a single global CLI called `vp`. Vite+ is distinct from Vite, but it invokes Vite through `vp dev` and `vp build`.
+## Tooling
 
-## Vite+ Workflow
+- Use `vp` for normal repo workflows: `vp install`, `vp check`, `vp fmt`, `vp run test`, `vp run coverage`, `vp run <package>#<task>`. Do not call `pnpm`, `vite`, `vitest`, `oxlint`, `oxfmt`, or `vitepress` directly unless a checked-in Vite+ task itself does so.
+- Import Vite/Vitest APIs from `vite-plus` (`vite-plus` or `vite-plus/tests`), not from direct `vite` or `vitest` packages.
+- After pulling remote changes, run `vp install` before validation.
+- Use Conventional Commit messages if the user asks you to commit; `commitlint` enforces `type(scope): description`.
 
-`vp` is a global binary that handles the full development lifecycle. Run `vp help` to print a list of commands and `vp <command> --help` for information about a specific command.
+## Focused Commands
 
-### Develop
+- `vp run @atlowchemi/webfont-generator#build` builds the Rust/NAPI binding and can update `packages/webfont-generator/binding.{js,d.ts}` and platform `.node` artifacts.
+- `vp run @atlowchemi/webfont-generator#test` runs Rust checks/tests via the package task; workspace `vp run test` first depends on the NAPI build, then runs JS/Vitest tests.
+- `vp run @atlowchemi/webfont-generator#bench --no-run` is the compile-only check for Rust benchmark target changes; run targeted Criterion filters only when measured behavior changes.
+- `vp run @atlowchemi/vite-svg-webfont-docs#build` is the docs build task; it runs the docs `social-card` and `optimize-svg` dependencies.
+- `vp run vite-svg-2-webfont#test:fixtures:refresh` regenerates expected font fixtures after changing SVG icons in `packages/vite-svg-2-webfont/src/fixtures/webfont-test/svg/`.
 
-- dev - Run the development server
-- check - Run format, lint, and TypeScript type checks
-- lint - Lint code
-- fmt - Format code
-- run test - Run tests
+## Public API Sync
 
-### Execute
+- When changing `@atlowchemi/webfont-generator` public APIs, options, CLI flags, or exported types, update Rust doc comments, `packages/docs/webfont-generator/`, and `packages/webfont-generator/README.md` together.
+- Do not duplicate the webfont-generator changelog in docs; `packages/docs/webfont-generator/changelog.md` includes `packages/webfont-generator/CHANGELOG.md`.
 
-- run - Run monorepo tasks
-- exec - Execute a command from local `node_modules/.bin`
-- dlx - Execute a package binary without installing it as a dependency
-- cache - Manage the task cache
+## Verification Subagents
 
-### Build
-
-- build - Build for production
-- pack - Build libraries
-- preview - Preview production build
-
-### Manage Dependencies
-
-Vite+ automatically detects and wraps the underlying package manager such as pnpm, npm, or Yarn through the `packageManager` field in `package.json` or package manager-specific lockfiles.
-
-- add - Add packages to dependencies
-- remove (`rm`, `un`, `uninstall`) - Remove packages from dependencies
-- update (`up`) - Update packages to latest versions
-- dedupe - Deduplicate dependencies
-- outdated - Check for outdated packages
-- list (`ls`) - List installed packages
-- why (`explain`) - Show why a package is installed
-- info (`view`, `show`) - View package information from the registry
-- link (`ln`) / unlink - Manage local package links
-- pm - Forward a command to the package manager
-
-### Maintain
-
-- upgrade - Update `vp` itself to the latest version
-
-These commands map to their corresponding tools. For example, `vp dev --port 3000` runs Vite's dev server and works the same as Vite. `vp run test` runs JavaScript tests through the bundled Vitest. The version of all tools can be checked using `vp --version`. This is useful when researching documentation, features, and bugs.
-
-## Common Pitfalls
-
-- **Using the package manager directly:** Do not use pnpm, npm, or Yarn directly. Vite+ can handle all package manager operations.
-- **Always use Vite commands to run tools:** Don't attempt to run `vp vitest` or `vp oxlint`. They do not exist. Use `vp run test` and `vp lint` instead.
-- **Running scripts:** Vite+ commands take precedence over `package.json` scripts. If there is a `test` script defined in `scripts` that conflicts with the built-in `vp test` command, run it using `vp run test`.
-- **Docs workflow:** The VitePress docs site lives in `packages/docs/` and is managed through Vite+ run tasks. Use `vp run @atlowchemi/vite-svg-webfont-docs#dev`, `vp run @atlowchemi/vite-svg-webfont-docs#build`, and `vp run @atlowchemi/vite-svg-webfont-docs#preview` rather than calling `vitepress` directly.
-- **Do not install Vitest, Oxlint, Oxfmt, or tsdown directly:** Vite+ wraps these tools. They must not be installed directly. You cannot upgrade these tools by installing their latest versions. Always use Vite+ commands.
-- **Use Vite+ wrappers for one-off binaries:** Use `vp dlx` instead of package-manager-specific `dlx`/`npx` commands.
-- **Import JavaScript modules from `vite-plus`:** Instead of importing from `vite` or `vitest`, all modules should be imported from the project's `vite-plus` dependency. For example, `import { defineConfig } from 'vite-plus';` or `import { expect, test, vi } from 'vite-plus/tests';`. You must not install `vitest` to import test utilities.
-- **Type-Aware Linting:** There is no need to install `oxlint-tsgolint`, `vp lint --type-aware` works out of the box.
-
-## Commit Conventions
-
-All commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/) format: `type(scope): description`. Common types are `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, and `perf`. This is enforced by a `commitlint` hook and is required for release-please changelog generation.
-
-## Documentation Sync
-
-The `@atlowchemi/webfont-generator` API is documented in three places that must stay in sync:
-
-1. **Rust doc comments** (`//!` and `///`) in `packages/webfont-generator/src/lib.rs`, `types.rs`, and other source files — these generate docs.rs content.
-2. **VitePress docs** in `packages/docs/webfont-generator/` — the Node.js, Rust, and CLI pages are the primary user-facing reference.
-3. **README** at `packages/webfont-generator/README.md` — shown on npm and crates.io.
-
-When changing the public API (adding/removing/renaming options, functions, types, or CLI flags), update all three locations. The webfont-generator changelog page (`packages/docs/webfont-generator/changelog.md`) includes content from `packages/webfont-generator/CHANGELOG.md` via VitePress `@include` — do not duplicate the changelog manually.
-
-## Review Checklist for Agents
-
-- [ ] Run `vp install` after pulling remote changes and before getting started.
-- [ ] Run `vp check` and `vp run test` to validate changes.
-- [ ] Run `vp run @atlowchemi/webfont-generator#bench --no-run` after changing Rust benchmark targets or benchmark-only support code; run targeted Criterion filters when changing measured behavior.
-- [ ] Run `vp run @atlowchemi/vite-svg-webfont-docs#build` when changing the docs site, docs config, or docs deployment workflow.
-- [ ] After adding/removing/modifying SVG icons in `packages/vite-svg-2-webfont/src/fixtures/webfont-test/svg/`, run `vp run vite-svg-2-webfont#test:fixtures:refresh` to regenerate expected font fixtures.
-- [ ] Use conventional commit messages.
+- Prefer verification subagents for long/noisy commands so logs stay out of the main context.
+- Use `vp-check` for `vp check`.
+- Use `fmt-runner` for isolated `vp fmt` runs.
+- Use `test-runner` for `vp run test`.
+- Use `coverage-runner` for `vp run coverage`.
+- Use `napi-build-runner` for `vp run @atlowchemi/webfont-generator#build`.
+- Use `bench-build-runner` for `vp run @atlowchemi/webfont-generator#bench --no-run`.
+- Use `docs-build-runner` for `vp run @atlowchemi/vite-svg-webfont-docs#build`.
+- Use `fixture-refresh-runner` for `vp run vite-svg-2-webfont#test:fixtures:refresh`.
+- Run independent verification subagents in parallel and have them return pass/fail, concise failure excerpts, file paths/line numbers, generated-file changes, and the exact command run.

--- a/packages/vite-svg-2-webfont/src/utils.test.ts
+++ b/packages/vite-svg-2-webfont/src/utils.test.ts
@@ -37,7 +37,7 @@ describe('utils', () => {
         const doesFileExist = vi.fn();
 
         it("doesn't execute callback for non string events", async () => {
-            await utils.handleWatchEvent('', { eventType: 'rename', filename: Buffer.from('ex.svg') }, onChange, doesFileExist);
+            await utils.handleWatchEvent('', { eventType: 'rename', filename: Buffer.from(validFileName) }, onChange, doesFileExist);
             expect(doesFileExist).not.toHaveBeenCalled();
             expect(onChange).not.toHaveBeenCalled();
         });
@@ -247,16 +247,20 @@ describe('utils', () => {
 
         it('does not propagate watch event classification errors', async () => {
             const { watch } = fs;
+            const rejectedEvent = { eventType: 'change' as const, filename: 'unreadable.svg' };
             const validEvent = { eventType: 'change' as const, filename: 'a.svg' };
             async function* mock() {
-                yield { eventType: 'change' as const, filename: { endsWith: true } } as never;
+                yield rejectedEvent;
                 yield validEvent;
             }
             if (vi.isMockFunction(watch)) {
                 watch.mockReturnValue(mock());
             }
+            const handleWatchEvent = vi.fn<typeof utils.handleWatchEvent>().mockRejectedValueOnce(new Error('intentional classification failure'));
+            handleWatchEvent.mockImplementation((...args) => utils.handleWatchEvent(...args));
 
-            expect(await utils.setupWatcher(folderPath, ac.signal, handler)).toEqual(undefined);
+            expect(await utils.setupWatcher(folderPath, ac.signal, handler, handleWatchEvent)).toEqual(undefined);
+            expect(handleWatchEvent).toHaveBeenCalledTimes(2);
             expect(handler).toHaveBeenCalledExactlyOnceWith([{ path: pathJoin(folderPath, 'a.svg'), kind: 'changed' }]);
         });
     });

--- a/packages/vite-svg-2-webfont/src/utils.ts
+++ b/packages/vite-svg-2-webfont/src/utils.ts
@@ -69,7 +69,12 @@ function coalesceChange(previous: WatchedChange | undefined, next: WatchedChange
     return next;
 }
 
-export async function setupWatcher(folderPath: string, signal: AbortSignal, onChange: (changes: WatchedChangeBatch) => void | Promise<void>): Promise<void> {
+export async function setupWatcher(
+    folderPath: string,
+    signal: AbortSignal,
+    onChange: (changes: WatchedChangeBatch) => void | Promise<void>,
+    _handleWatchEvent: typeof handleWatchEvent = handleWatchEvent,
+): Promise<void> {
     let timer: ReturnType<typeof setTimeout> | undefined;
     let flushChain = Promise.resolve();
     const pending = new Map<string, WatchedChange>();
@@ -110,7 +115,7 @@ export async function setupWatcher(folderPath: string, signal: AbortSignal, onCh
         watcher = watch(folderPath, { signal });
         for await (const event of watcher) {
             // A single failed event classification (e.g. an unreadable file) must not tear down the watcher.
-            await handleWatchEvent(folderPath, event, queueChange).catch(() => undefined);
+            await _handleWatchEvent(folderPath, event, queueChange).catch(() => undefined);
         }
         await drain();
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Add shared verification subagents for vp check, fmt, tests, coverage, NAPI build, docs build, benchmark compile checks, and fixture refresh.
- Add shared docs-sync rule symlinked into AI tool directories.
- Compact AGENTS.md to repo-specific guidance.
- Cover setupWatcher event-classification error handling without changing production behavior.

## Testing
- vp test packages/vite-svg-2-webfont/src/utils.test.ts --run
- vp test packages/vite-svg-2-webfont/src/utils.test.ts --coverage --run