### PR TITLE
feat(webfont-generator): reuse processed and compiled glyphs during recalc

### DIFF
--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -769,7 +769,7 @@ fn bench_specialized_incremental_paths(c: &mut Criterion) {
 
 fn bench_regenerate_by_format(c: &mut Criterion) {
     let mut group = c.benchmark_group("regenerate_by_format");
-    group.sample_size(10);
+    group.sample_size(40);
     let size = 300;
     for (label, types) in [
         ("svg", vec![FontType::Svg]),

--- a/packages/webfont-generator/src/incremental/mod.rs
+++ b/packages/webfont-generator/src/incremental/mod.rs
@@ -101,6 +101,7 @@ impl GenerateWebfontsResult {
                     source_files.retain(|file| &file.path != path);
                     cache.entries.remove(path);
                     cache.content_hashes.remove(path);
+                    cache.processed_entries.remove(path);
                     changed_inputs |= source_files.len() != before;
                 }
                 GlyphChange::Added { name } => {
@@ -116,6 +117,7 @@ impl GenerateWebfontsResult {
                         cache.entries.remove(path);
                         cache.content_hashes.remove(path);
                     }
+                    cache.processed_entries.remove(path);
                     changed_inputs = true;
                 }
                 GlyphChange::Changed { name } => {
@@ -142,6 +144,7 @@ impl GenerateWebfontsResult {
                             cache.entries.remove(path);
                             cache.content_hashes.remove(path);
                         }
+                        cache.processed_entries.remove(path);
                     }
                     changed_inputs = true;
                 }
@@ -179,7 +182,7 @@ impl GenerateWebfontsResult {
 
         let svg_options = svg_options_from_options(&options);
         let prepared = prepare_svg_font_incremental(&svg_options, &source_files, &mut cache)?;
-        let fonts = build_font_outputs(&options, &svg_options, &prepared)?;
+        let fonts = build_font_outputs(&options, &svg_options, &prepared, self.ttf_cache.as_mut())?;
 
         // Rebuild the template data fresh (the font hash changed), but keep the rendered CSS/HTML
         // that can't have changed: only when the glyph names and codepoints the templates read are

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -39,10 +39,14 @@ fn temp_dir() -> std::path::PathBuf {
 }
 
 fn write_icon(dir: &Path, name: &str, d: &str) -> String {
+    write_icon_with_viewbox(dir, name, 24, 24, d)
+}
+
+fn write_icon_with_viewbox(dir: &Path, name: &str, width: u32, height: u32, d: &str) -> String {
     let path = dir.join(format!("{name}.svg"));
     std::fs::write(
         &path,
-        format!("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"{d}\"/></svg>"),
+        format!("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {width} {height}\"><path d=\"{d}\"/></svg>"),
     )
     .unwrap();
     path.to_string_lossy().into_owned()
@@ -119,6 +123,60 @@ fn regenerate_after_content_change_matches_fresh() {
         .unwrap();
 
     assert_same(&result, &generate(vec![a, b, c], false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_reuses_compiled_ttf_glyphs_for_stable_metrics() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+
+    let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
+    let processed_before = result.glyph_cache.as_ref().unwrap().process_count;
+    let before = result.ttf_cache.as_ref().unwrap().compile_count;
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, b, c], false));
+    assert_eq!(
+        result.glyph_cache.as_ref().unwrap().process_count,
+        processed_before + 1
+    );
+    assert_eq!(result.ttf_cache.as_ref().unwrap().compile_count, before + 1);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_recompiles_compiled_ttf_glyphs_after_metric_shift() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let c = write_icon(&dir, "c", D3);
+
+    let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
+    let processed_before = result.glyph_cache.as_ref().unwrap().process_count;
+    let before = result.ttf_cache.as_ref().unwrap().compile_count;
+    write_icon_with_viewbox(&dir, "b", 24, 48, D_CHANGED);
+    result
+        .regenerate(
+            &[a.clone(), b.clone(), c.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+
+    assert_same(&result, &generate(vec![a, b, c], false));
+    assert_eq!(
+        result.glyph_cache.as_ref().unwrap().process_count,
+        processed_before + 3
+    );
+    assert_eq!(result.ttf_cache.as_ref().unwrap().compile_count, before + 3);
     std::fs::remove_dir_all(&dir).ok();
 }
 

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -95,6 +95,7 @@ use templates::{
     SharedTemplateData, apply_context_function, build_css_context, build_html_context,
     build_html_registry_and_dependencies,
 };
+use ttf::TtfGlyphCache;
 #[cfg(feature = "napi")]
 use util::to_napi_err;
 use write::write_generate_webfonts_result;
@@ -205,7 +206,7 @@ pub mod bench_support {
         let sources = load_sources(sources);
         let options = resolve(options, &sources)?;
         let svg_options = svg_options_from_options(&options);
-        let fonts = build_font_outputs(&options, &svg_options, &prepared.0)?;
+        let fonts = build_font_outputs(&options, &svg_options, &prepared.0, None)?;
         Ok(fonts.svg_font.as_ref().map_or(0, |v| v.len())
             + fonts.ttf_font.as_ref().map_or(0, |v| v.len())
             + fonts.woff_font.as_ref().map_or(0, |v| v.len())
@@ -559,14 +560,14 @@ fn generate_webfonts_sync(
     // When incremental, retain the parsed-glyph cache so a later `regenerate` can reuse the
     // glyphs whose source didn't change. Otherwise the geometry is dropped as soon as the font
     // is built, so one-shot builds carry no extra memory.
-    let (prepared, glyph_cache) = if options.incremental {
+    let (prepared, glyph_cache, mut ttf_cache) = if options.incremental {
         let mut cache = GlyphCache::default();
         let prepared = prepare_svg_font_incremental(&svg_options, &source_files, &mut cache)?;
-        (prepared, Some(cache))
+        (prepared, Some(cache), Some(TtfGlyphCache::default()))
     } else {
-        (prepare_svg_font(&svg_options, &source_files)?, None)
+        (prepare_svg_font(&svg_options, &source_files)?, None, None)
     };
-    let fonts = build_font_outputs(&options, &svg_options, &prepared)?;
+    let fonts = build_font_outputs(&options, &svg_options, &prepared, ttf_cache.as_mut())?;
 
     Ok(GenerateWebfontsResult {
         cached: std::sync::OnceLock::new(),
@@ -577,6 +578,7 @@ fn generate_webfonts_sync(
         html_context: None,
         options,
         source_files,
+        ttf_cache,
         written_outputs: std::collections::HashMap::new(),
     })
 }
@@ -586,6 +588,7 @@ fn build_font_outputs(
     options: &ResolvedGenerateWebfontsOptions,
     svg_options: &SvgOptions<'_>,
     prepared: &PreparedSvgFont,
+    ttf_cache: Option<&mut TtfGlyphCache>,
 ) -> std::io::Result<FontOutputs> {
     let wants_svg = options.types.contains(&FontType::Svg);
     let wants_ttf = options.types.contains(&FontType::Ttf);
@@ -604,8 +607,19 @@ fn build_font_outputs(
         || -> std::io::Result<Option<Vec<u8>>> {
             if wants_ttf || wants_woff || wants_woff2 || wants_eot {
                 let ttf_options = ttf::ttf_options_from_options(options);
-                ttf::generate_ttf_font_bytes_from_glyphs(ttf_options, &prepared.processed_glyphs)
-                    .map(Some)
+                match ttf_cache {
+                    Some(cache) => ttf::generate_ttf_font_bytes_from_glyphs_cached(
+                        ttf_options,
+                        &prepared.processed_glyphs,
+                        cache,
+                    )
+                    .map(Some),
+                    None => ttf::generate_ttf_font_bytes_from_glyphs(
+                        ttf_options,
+                        &prepared.processed_glyphs,
+                    )
+                    .map(Some),
+                }
             } else {
                 Ok(None)
             }

--- a/packages/webfont-generator/src/svg/mod.rs
+++ b/packages/webfont-generator/src/svg/mod.rs
@@ -11,11 +11,31 @@ use std::collections::{HashMap, HashSet};
 use std::io::{Error, ErrorKind};
 
 use parse::parse_svg_glyph;
-use process::process_glyph;
+use process::{build_unicode_values, process_glyph};
 pub(crate) use serialize::build_svg_font;
-use types::{CachedGlyph, GlyphCache, GlyphWorkItem, ParsedGlyph, PreparedSvgFont, SvgOptions};
+use types::{
+    CachedGlyph, CachedProcessedGlyph, GlyphCache, GlyphWorkItem, ParsedGlyph, PreparedSvgFont,
+    ProcessedGlyph, SvgOptions,
+};
 
 use crate::types::{LoadedSvgFile, ResolvedGenerateWebfontsOptions};
+
+struct FinalizePlan {
+    normalize: bool,
+    fixed_width: bool,
+    center_horizontally: bool,
+    center_vertically: bool,
+    ligature: bool,
+    round: f64,
+    max_glyph_height: f64,
+    font_height: f64,
+    font_width: f64,
+    ascent: f64,
+    descent: f64,
+    font_id: String,
+    metadata: String,
+    optimize_output: bool,
+}
 
 pub(crate) fn svg_options_from_options(
     options: &ResolvedGenerateWebfontsOptions,
@@ -111,20 +131,34 @@ pub(crate) fn finalize_glyphs(
     options: &SvgOptions,
     glyphs: Vec<ParsedGlyph>,
 ) -> Result<PreparedSvgFont, Error> {
-    let normalize = options.normalize;
-    let fixed_width = options.fixed_width.unwrap_or(false);
-    let center_horizontally = options.center_horizontally.unwrap_or(false);
-    let center_vertically = options.center_vertically.unwrap_or(false);
-    let ligature = options.ligature;
-    let round = options.round.unwrap_or(10e12);
+    let plan = finalize_plan(options, &glyphs);
 
+    let mut processed_glyphs = glyphs
+        .into_par_iter()
+        .map(|glyph| process_glyph_with_plan(glyph, &plan))
+        .collect::<Result<Vec<_>, Error>>()
+        .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
+    processed_glyphs.sort_by_key(|glyph| glyph.index);
+
+    Ok(PreparedSvgFont {
+        ascent: plan.ascent,
+        descent: plan.descent,
+        font_height: plan.font_height,
+        font_id: plan.font_id,
+        font_width: plan.font_width,
+        metadata: plan.metadata,
+        processed_glyphs,
+    })
+}
+
+fn finalize_plan(options: &SvgOptions, glyphs: &[ParsedGlyph]) -> FinalizePlan {
+    let normalize = options.normalize;
     let max_glyph_height = glyphs
         .iter()
         .fold(0.0_f64, |current, glyph| current.max(glyph.height));
     let max_glyph_width = glyphs
         .iter()
         .fold(0.0_f64, |current, glyph| current.max(glyph.width));
-
     let font_height = options.font_height.unwrap_or(max_glyph_height.max(1.0));
     let descent = options.descent.unwrap_or(0.0);
     let mut font_width = if max_glyph_height > 0.0 {
@@ -146,42 +180,43 @@ pub(crate) fn finalize_glyphs(
     } else if options.font_height.is_some() && max_glyph_height > 0.0 {
         font_width *= font_height / max_glyph_height;
     }
-    let ascent = options.ascent.unwrap_or(font_height - descent);
-    let font_id = options.font_id.unwrap_or(options.font_name).to_owned();
-    let metadata = options.metadata.unwrap_or_default().to_owned();
-    let optimize_output = options.optimize_output.unwrap_or(false);
 
-    let mut processed_glyphs = glyphs
-        .into_par_iter()
-        .map(|glyph| {
-            process_glyph(
-                glyph,
-                normalize,
-                fixed_width,
-                center_horizontally,
-                center_vertically,
-                ligature,
-                round,
-                max_glyph_height,
-                font_height,
-                font_width,
-                descent,
-                optimize_output,
-            )
-        })
-        .collect::<Result<Vec<_>, Error>>()
-        .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
-    processed_glyphs.sort_by_key(|glyph| glyph.index);
-
-    Ok(PreparedSvgFont {
-        ascent,
-        descent,
+    FinalizePlan {
+        normalize,
+        fixed_width: options.fixed_width.unwrap_or(false),
+        center_horizontally: options.center_horizontally.unwrap_or(false),
+        center_vertically: options.center_vertically.unwrap_or(false),
+        ligature: options.ligature,
+        round: options.round.unwrap_or(10e12),
+        max_glyph_height,
         font_height,
-        font_id,
         font_width,
-        metadata,
-        processed_glyphs,
-    })
+        ascent: options.ascent.unwrap_or(font_height - descent),
+        descent,
+        font_id: options.font_id.unwrap_or(options.font_name).to_owned(),
+        metadata: options.metadata.unwrap_or_default().to_owned(),
+        optimize_output: options.optimize_output.unwrap_or(false),
+    }
+}
+
+fn process_glyph_with_plan(
+    glyph: ParsedGlyph,
+    plan: &FinalizePlan,
+) -> Result<ProcessedGlyph, Error> {
+    process_glyph(
+        glyph,
+        plan.normalize,
+        plan.fixed_width,
+        plan.center_horizontally,
+        plan.center_vertically,
+        plan.ligature,
+        plan.round,
+        plan.max_glyph_height,
+        plan.font_height,
+        plan.font_width,
+        plan.descent,
+        plan.optimize_output,
+    )
 }
 
 /// Like [`prepare_svg_font`], but reuses cached glyph geometry instead of re-parsing. A file
@@ -196,7 +231,7 @@ pub(crate) fn prepare_svg_font_incremental(
     cache: &mut GlyphCache,
 ) -> Result<PreparedSvgFont, Error> {
     let glyphs = parse_glyphs_incremental(options, source_files, cache)?;
-    finalize_glyphs(options, glyphs)
+    finalize_glyphs_incremental(options, glyphs, source_files, cache)
 }
 
 pub(crate) fn source_content_hash(contents: &str) -> [u8; 16] {
@@ -224,6 +259,9 @@ fn parse_glyphs_incremental(
         .retain(|path, _| current.contains(path.as_str()));
     cache
         .content_hashes
+        .retain(|path, _| current.contains(path.as_str()));
+    cache
+        .processed_entries
         .retain(|path, _| current.contains(path.as_str()));
 
     // Rehydrate path entries from content-addressed geometry where possible. This handles added
@@ -326,4 +364,129 @@ fn parse_glyphs_incremental(
     }
     glyphs.sort_by_key(|glyph| glyph.index);
     Ok(glyphs)
+}
+
+fn processed_glyph_cache_signature(plan: &FinalizePlan) -> [u8; 16] {
+    let mut bytes = Vec::with_capacity(8 * 5 + 5);
+    bytes.extend_from_slice(&[
+        plan.normalize as u8,
+        plan.fixed_width as u8,
+        plan.center_horizontally as u8,
+        plan.center_vertically as u8,
+        plan.optimize_output as u8,
+    ]);
+    for value in [
+        plan.round,
+        plan.max_glyph_height,
+        plan.font_height,
+        plan.font_width,
+        plan.descent,
+    ] {
+        bytes.extend_from_slice(&value.to_bits().to_le_bytes());
+    }
+    md5::compute(bytes).0
+}
+
+fn finalize_glyphs_incremental(
+    options: &SvgOptions,
+    glyphs: Vec<ParsedGlyph>,
+    source_files: &[LoadedSvgFile],
+    cache: &mut GlyphCache,
+) -> Result<PreparedSvgFont, Error> {
+    let plan = finalize_plan(options, &glyphs);
+    let signature = processed_glyph_cache_signature(&plan);
+    if cache.processed_signature != Some(signature) {
+        cache.processed_entries.clear();
+        cache.processed_signature = Some(signature);
+    }
+
+    let processed: Vec<(usize, ProcessedGlyph, CachedProcessedGlyph)> = glyphs
+        .into_par_iter()
+        .enumerate()
+        .filter(|(_, glyph)| {
+            !cache
+                .processed_entries
+                .contains_key(&source_files[glyph.index].path)
+        })
+        .map(|(_, glyph)| {
+            let path_index = glyph.index;
+            process_glyph_with_plan(glyph, &plan).map(|glyph| {
+                let cached = CachedProcessedGlyph {
+                    height: glyph.height,
+                    path_data: glyph.path_data.clone(),
+                    width: glyph.width,
+                };
+                (path_index, glyph, cached)
+            })
+        })
+        .collect::<Result<Vec<_>, Error>>()
+        .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
+
+    #[cfg(test)]
+    {
+        cache.process_count += processed.len();
+    }
+
+    let mut freshly_processed = HashMap::with_capacity(processed.len());
+    for (index, glyph, cached) in processed {
+        cache
+            .processed_entries
+            .insert(source_files[index].path.clone(), cached);
+        freshly_processed.insert(index, glyph);
+    }
+
+    let mut processed_glyphs = Vec::with_capacity(source_files.len());
+    for (index, source_file) in source_files.iter().enumerate() {
+        let glyph = match freshly_processed.remove(&index) {
+            Some(glyph) => glyph,
+            None => {
+                let cached = cache
+                    .processed_entries
+                    .get(&source_file.path)
+                    .expect("an unchanged file must have a processed cache entry");
+                let codepoint = glyphs_codepoint(options, source_file)?;
+                ProcessedGlyph {
+                    codepoint,
+                    height: cached.height,
+                    index,
+                    name: source_file.glyph_name.clone(),
+                    path_data: cached.path_data.clone(),
+                    unicode_values: build_unicode_values(
+                        &source_file.glyph_name,
+                        codepoint,
+                        plan.ligature,
+                    ),
+                    width: cached.width,
+                }
+            }
+        };
+        processed_glyphs.push(glyph);
+    }
+    processed_glyphs.sort_by_key(|glyph| glyph.index);
+
+    Ok(PreparedSvgFont {
+        ascent: plan.ascent,
+        descent: plan.descent,
+        font_height: plan.font_height,
+        font_id: plan.font_id,
+        font_width: plan.font_width,
+        metadata: plan.metadata,
+        processed_glyphs,
+    })
+}
+
+fn glyphs_codepoint(options: &SvgOptions, source_file: &LoadedSvgFile) -> Result<u32, Error> {
+    options
+        .codepoints
+        .get(source_file.glyph_name.as_str())
+        .copied()
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                format!(
+                    "Missing resolved codepoint for glyph '{}'.",
+                    source_file.glyph_name
+                ),
+            )
+        })
 }

--- a/packages/webfont-generator/src/svg/process.rs
+++ b/packages/webfont-generator/src/svg/process.rs
@@ -121,7 +121,7 @@ fn calculate_combined_bounds(paths: &[usvg::tiny_skia_path::Path]) -> Rect {
         .unwrap_or_else(|| Rect::from_xywh(0.0, 0.0, 1.0, 1.0).expect("fallback rect"))
 }
 
-fn build_unicode_values(name: &str, codepoint: u32, ligature: bool) -> Vec<String> {
+pub(crate) fn build_unicode_values(name: &str, codepoint: u32, ligature: bool) -> Vec<String> {
     let mut values = vec![format!("&#x{:X};", codepoint)];
     if ligature {
         let ligature_value = name

--- a/packages/webfont-generator/src/svg/types.rs
+++ b/packages/webfont-generator/src/svg/types.rs
@@ -53,6 +53,13 @@ pub(crate) struct ProcessedGlyph {
 }
 
 #[derive(Clone)]
+pub(crate) struct CachedProcessedGlyph {
+    pub height: f64,
+    pub path_data: String,
+    pub width: f64,
+}
+
+#[derive(Clone)]
 pub(crate) struct PreparedSvgFont {
     pub ascent: f64,
     pub descent: f64,
@@ -84,6 +91,11 @@ pub(crate) struct GlyphCache {
     pub content_hashes: HashMap<String, [u8; 16]>,
     /// Parsed geometry keyed by SVG source bytes so added/renamed duplicate icons can reuse it.
     pub by_content_hash: HashMap<[u8; 16], CachedGlyph>,
+    /// Processed path data keyed by path for unchanged files while metrics/options stay stable.
+    pub processed_entries: HashMap<String, CachedProcessedGlyph>,
+    pub processed_signature: Option<[u8; 16]>,
     #[cfg(test)]
     pub parse_count: usize,
+    #[cfg(test)]
+    pub process_count: usize,
 }

--- a/packages/webfont-generator/src/ttf/mod.rs
+++ b/packages/webfont-generator/src/ttf/mod.rs
@@ -69,6 +69,27 @@ struct CompiledGlyph {
     source_index: usize,
 }
 
+#[derive(Clone)]
+struct CachedCompiledGlyph {
+    advance_width: u16,
+    bbox: write_fonts::tables::glyf::Bbox,
+    simple_glyph: SimpleGlyph,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct TtfGlyphCache {
+    entries: HashMap<[u8; 16], CachedCompiledGlyph>,
+    #[cfg(test)]
+    pub compile_count: usize,
+}
+
+fn compiled_glyph_cache_key(path_data: &str, advance_width: u16) -> [u8; 16] {
+    let mut bytes = Vec::with_capacity(path_data.len() + 2);
+    bytes.extend_from_slice(path_data.as_bytes());
+    bytes.extend_from_slice(&advance_width.to_le_bytes());
+    md5::compute(bytes).0
+}
+
 struct LigaturePlaceholderGlyph {
     codepoint: u32,
     name: String,
@@ -161,6 +182,40 @@ pub(crate) fn generate_ttf_font_bytes_from_glyphs(
     )
 }
 
+pub(crate) fn generate_ttf_font_bytes_from_glyphs_cached(
+    options: TtfOptions,
+    glyphs: &[ProcessedGlyph],
+    cache: &mut TtfGlyphCache,
+) -> Result<Vec<u8>, Error> {
+    let font_height = options.font_height.unwrap_or_else(|| {
+        glyphs
+            .iter()
+            .fold(0.0_f64, |current, glyph| current.max(glyph.height))
+            .max(1.0)
+    });
+    let descent = options.descent.unwrap_or(0.0);
+    let ascent = options.ascent.unwrap_or(font_height - descent);
+
+    let (compiled_glyphs, cmap_aliases) = compile_and_dedup_glyphs_cached(glyphs, cache)?;
+    let ligature_placeholders = build_ligature_placeholders(&compiled_glyphs, options.ligature);
+    let (glyf, loca, loca_format) = build_glyf_table(&compiled_glyphs, &ligature_placeholders)?;
+    let metrics = compute_glyph_metrics(&compiled_glyphs);
+
+    assemble_font(
+        &options,
+        &compiled_glyphs,
+        &cmap_aliases,
+        &ligature_placeholders,
+        glyf,
+        loca,
+        loca_format,
+        &metrics,
+        ascent,
+        descent,
+        font_height,
+    )
+}
+
 /// Codepoint aliases for deduplicated glyphs: (codepoint, index of first occurrence).
 type CmapAliases = Vec<(u32, usize)>;
 
@@ -191,6 +246,63 @@ fn compile_and_dedup_glyphs(
         }
     }
 
+    Ok((compiled, aliases))
+}
+
+fn compile_and_dedup_glyphs_cached(
+    glyphs: &[ProcessedGlyph],
+    cache: &mut TtfGlyphCache,
+) -> Result<(Vec<CompiledGlyph>, CmapAliases), Error> {
+    let mut compiled: Vec<CompiledGlyph> = Vec::with_capacity(glyphs.len());
+    let mut aliases: Vec<(u32, usize)> = Vec::new();
+    let mut seen: HashMap<(usize, u16), Vec<usize>> = HashMap::new();
+    let mut next_entries = HashMap::new();
+
+    for (i, glyph) in glyphs.iter().enumerate() {
+        let advance_width = clamp_to_u16(glyph.width.round(), 0, u16::MAX);
+        let key = (glyph.path_data.len(), advance_width);
+        let duplicate_of = seen.get(&key).and_then(|indices| {
+            indices
+                .iter()
+                .find(|&&idx| glyphs[compiled[idx].source_index].path_data == glyph.path_data)
+                .copied()
+        });
+        if let Some(first_idx) = duplicate_of {
+            aliases.push((glyph.codepoint, first_idx));
+        } else {
+            let cache_key = compiled_glyph_cache_key(&glyph.path_data, advance_width);
+            let cached = cache.entries.get(&cache_key).cloned();
+            let cached = match cached {
+                Some(cached) => cached,
+                None => {
+                    #[cfg(test)]
+                    {
+                        cache.compile_count += 1;
+                    }
+                    let compiled = compile_glyph(i, glyph)?;
+                    CachedCompiledGlyph {
+                        advance_width: compiled.advance_width,
+                        bbox: compiled.bbox,
+                        simple_glyph: compiled.simple_glyph,
+                    }
+                }
+            };
+            next_entries.insert(cache_key, cached.clone());
+            let idx = compiled.len();
+            seen.entry(key).or_default().push(idx);
+            compiled.push(CompiledGlyph {
+                advance_width: cached.advance_width,
+                bbox: cached.bbox,
+                codepoint: glyph.codepoint,
+                left_side_bearing: cached.bbox.x_min,
+                name: glyph.name.clone(),
+                simple_glyph: cached.simple_glyph,
+                source_index: i,
+            });
+        }
+    }
+
+    cache.entries = next_entries;
     Ok((compiled, aliases))
 }
 

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -14,6 +14,7 @@ use crate::templates::{
     build_html_registry_and_dependencies, make_src, render_css_with_hbs_context,
     render_css_with_src_mutate, render_default_html_with_styles, render_html_with_hbs_context,
 };
+use crate::ttf::TtfGlyphCache;
 use crate::util::to_io_err;
 
 /// What happened to a file, for [`GenerateWebfontsResult::regenerate`]. `name` is the
@@ -423,6 +424,8 @@ pub struct GenerateWebfontsResult {
     pub(crate) html_context: Option<Map<String, Value>>,
     pub(crate) options: ResolvedGenerateWebfontsOptions,
     pub(crate) source_files: Vec<LoadedSvgFile>,
+    /// Compiled TTF outline cache for incremental TTF-derived output rebuilds.
+    pub(crate) ttf_cache: Option<TtfGlyphCache>,
     /// Hash per CSS/HTML output path of what was last written to disk. Seeded by the initial write
     /// when `write_files` is enabled, then updated by incremental `regenerate` writes so unchanged
     /// rendered companion files are not rewritten. Font outputs are written directly after real
@@ -885,6 +888,7 @@ mod tests {
             html_context: None,
             options: resolved,
             source_files,
+            ttf_cache: None,
             written_outputs: Default::default(),
         };
 
@@ -1157,6 +1161,7 @@ mod tests {
             html_context: None,
             options: resolved,
             source_files,
+            ttf_cache: None,
             written_outputs: Default::default(),
         }
     }


### PR DESCRIPTION
## Summary

- reuse processed SVG path data for unchanged glyphs during incremental regenerate when metrics/options are stable
- reuse compiled TTF glyph outlines for unchanged processed glyphs across TTF-derived outputs
- increase `regenerate_by_format` Criterion sample size to 40 for steadier recalc benchmark signal

## Benchmarks

Targeted 40-sample Criterion rows, `regenerate_by_format/incremental_content_edit/*/300`:

| Format | Main | PR | Improvement |
|---|---:|---:|---:|
| `ttf` | `19.067 ms` | `13.263 ms` | ~30% faster |
| `woff2` | `46.691 ms` | `41.321 ms` | ~12% faster |
| `all_formats` | `46.640 ms` | `42.294 ms` | ~9% faster |