### PR TITLE
test: use Criterion default sample size for short benchmarks

### DIFF
--- a/packages/webfont-generator/benches/features.rs
+++ b/packages/webfont-generator/benches/features.rs
@@ -317,7 +317,6 @@ fn repeated_batch_timing(
 
 fn bench_template_rendering(c: &mut Criterion) {
     let mut group = c.benchmark_group("template_rendering");
-    group.sample_size(50);
     let fixture = fixtures(300, "heavy");
     let mut opts = base_options(fixture.paths.clone(), vec![FontType::Woff2]);
     opts.css = Some(true);
@@ -412,7 +411,6 @@ fn bench_template_rendering(c: &mut Criterion) {
 
 fn bench_write_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("write_paths");
-    group.sample_size(50);
     group.measurement_time(Duration::from_secs(10));
     group.sampling_mode(SamplingMode::Flat);
     let fixture = fixtures(100, "heavy");
@@ -454,7 +452,6 @@ fn bench_write_paths(c: &mut Criterion) {
 
 fn bench_input_complexity(c: &mut Criterion) {
     let mut group = c.benchmark_group("input_complexity");
-    group.sample_size(10);
     for kind in [
         "simple",
         "heavy",
@@ -480,7 +477,6 @@ fn bench_input_complexity(c: &mut Criterion) {
 
 fn bench_geometry_options(c: &mut Criterion) {
     let mut group = c.benchmark_group("geometry_options");
-    group.sample_size(30);
     let fixture = fixtures(300, "heavy");
     for name in [
         "normalize_false",
@@ -521,7 +517,6 @@ fn bench_geometry_options(c: &mut Criterion) {
 
 fn bench_winding_normalization(c: &mut Criterion) {
     let mut group = c.benchmark_group("winding_normalization");
-    group.sample_size(10);
     for kind in [
         "winding_independent",
         "winding_nested_ok",
@@ -545,7 +540,6 @@ fn bench_winding_normalization(c: &mut Criterion) {
 
 fn bench_ttf_features(c: &mut Criterion) {
     let mut group = c.benchmark_group("ttf_features");
-    group.sample_size(10);
     for (name, fixture, ligature, explicit) in [
         (
             "ligatures_false_unique",
@@ -592,7 +586,6 @@ fn bench_ttf_features(c: &mut Criterion) {
 
 fn bench_error_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("error_paths");
-    group.sample_size(10);
     let fixture = fixtures(10, "heavy");
     let missing = temp_dir("missing")
         .join("missing.svg")
@@ -646,7 +639,6 @@ fn bench_error_paths(c: &mut Criterion) {
 
 fn bench_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("scaling");
-    group.sample_size(10);
     for size in [15, 100, 300, 600, 1000] {
         let fixture = fixtures(size, "heavy");
         group.bench_function(format!("woff2/{size}"), |b| {
@@ -664,7 +656,6 @@ fn bench_scaling(c: &mut Criterion) {
 
 fn bench_async_overhead(c: &mut Criterion) {
     let mut group = c.benchmark_group("async_overhead");
-    group.sample_size(10);
     let fixture = fixtures(15, "heavy");
     let runtime = tokio::runtime::Runtime::new().unwrap();
     group.bench_function("generate_sync/15", |b| {
@@ -689,22 +680,16 @@ fn bench_async_overhead(c: &mut Criterion) {
     group.finish();
 }
 
-fn criterion_config() -> Criterion {
-    Criterion::default().sample_size(10)
-}
-
-criterion_group! {
-    name = benches;
-    config = criterion_config();
-    targets =
-        bench_template_rendering,
-        bench_write_paths,
-        bench_input_complexity,
-        bench_geometry_options,
-        bench_winding_normalization,
-        bench_ttf_features,
-        bench_error_paths,
-        bench_scaling,
-        bench_async_overhead
-}
+criterion_group!(
+    benches,
+    bench_template_rendering,
+    bench_write_paths,
+    bench_input_complexity,
+    bench_geometry_options,
+    bench_winding_normalization,
+    bench_ttf_features,
+    bench_error_paths,
+    bench_scaling,
+    bench_async_overhead
+);
 criterion_main!(benches);

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -259,7 +259,6 @@ fn remove_position(paths: &[String], position: &str) -> (Vec<String>, String) {
 
 fn bench_svg_prepare(c: &mut Criterion) {
     let mut group = c.benchmark_group("svg_prepare");
-    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         group.bench_function(format!("full/{size}"), |b| {
@@ -291,7 +290,6 @@ fn bench_svg_prepare(c: &mut Criterion) {
 
 fn bench_regenerate(c: &mut Criterion) {
     let mut group = c.benchmark_group("regenerate");
-    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         let mut result =
@@ -766,7 +764,6 @@ fn bench_specialized_incremental_paths(c: &mut Criterion) {
 
 fn bench_regenerate_by_format(c: &mut Criterion) {
     let mut group = c.benchmark_group("regenerate_by_format");
-    group.sample_size(30);
     let size = 300;
     for (label, types) in [
         ("svg", vec![FontType::Svg]),

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -461,7 +461,6 @@ fn bench_regenerate_batches(c: &mut Criterion) {
 
 fn bench_add_remove(c: &mut Criterion) {
     let mut group = c.benchmark_group("add_remove");
-    group.sample_size(30);
     for size in SIZES {
         for position in ["start", "middle", "end"] {
             group.bench_function(format!("full_add_at_{position}/{size}"), |b| {

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -291,7 +291,7 @@ fn bench_svg_prepare(c: &mut Criterion) {
 
 fn bench_regenerate(c: &mut Criterion) {
     let mut group = c.benchmark_group("regenerate");
-    group.sample_size(10);
+    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         let mut result =
@@ -383,7 +383,7 @@ fn bench_regenerate(c: &mut Criterion) {
 
 fn bench_regenerate_batches(c: &mut Criterion) {
     let mut group = c.benchmark_group("regenerate_batches");
-    group.sample_size(10);
+    group.sample_size(30);
     let all_formats = vec![
         FontType::Svg,
         FontType::Ttf,
@@ -463,7 +463,7 @@ fn bench_regenerate_batches(c: &mut Criterion) {
 
 fn bench_add_remove(c: &mut Criterion) {
     let mut group = c.benchmark_group("add_remove");
-    group.sample_size(10);
+    group.sample_size(30);
     for size in SIZES {
         for position in ["start", "middle", "end"] {
             group.bench_function(format!("full_add_at_{position}/{size}"), |b| {
@@ -565,7 +565,6 @@ fn bench_add_remove(c: &mut Criterion) {
 
 fn bench_render_cache_after_regenerate(c: &mut Criterion) {
     let mut group = c.benchmark_group("render_cache_after_regenerate");
-    group.sample_size(10);
     let size = 300;
     group.bench_function("content_edit_css_urls_reused/300", |b| {
         b.iter_batched(
@@ -680,7 +679,6 @@ fn bench_render_cache_after_regenerate(c: &mut Criterion) {
 
 fn bench_incremental_write_content_edit(c: &mut Criterion) {
     let mut group = c.benchmark_group("write_files_after_regenerate");
-    group.sample_size(10);
     let size = 100;
     group.bench_function("content_edit/100", |b| {
         b.iter_batched(
@@ -712,7 +710,6 @@ fn bench_incremental_write_content_edit(c: &mut Criterion) {
 
 fn bench_specialized_incremental_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("specialized_incremental_paths");
-    group.sample_size(10);
     let size = 300;
     group.bench_function("rename_only/300", |b| {
         b.iter_batched(
@@ -769,7 +766,7 @@ fn bench_specialized_incremental_paths(c: &mut Criterion) {
 
 fn bench_regenerate_by_format(c: &mut Criterion) {
     let mut group = c.benchmark_group("regenerate_by_format");
-    group.sample_size(40);
+    group.sample_size(30);
     let size = 300;
     for (label, types) in [
         ("svg", vec![FontType::Svg]),
@@ -832,21 +829,15 @@ fn bench_regenerate_by_format(c: &mut Criterion) {
     group.finish();
 }
 
-fn criterion_config() -> Criterion {
-    Criterion::default().sample_size(10)
-}
-
-criterion_group! {
-    name = benches;
-    config = criterion_config();
-    targets =
-        bench_svg_prepare,
-        bench_regenerate,
-        bench_regenerate_batches,
-        bench_add_remove,
-        bench_regenerate_by_format,
-        bench_render_cache_after_regenerate,
-        bench_incremental_write_content_edit,
-        bench_specialized_incremental_paths
-}
+criterion_group!(
+    benches,
+    bench_svg_prepare,
+    bench_regenerate,
+    bench_regenerate_batches,
+    bench_add_remove,
+    bench_regenerate_by_format,
+    bench_render_cache_after_regenerate,
+    bench_incremental_write_content_edit,
+    bench_specialized_incremental_paths
+);
 criterion_main!(benches);

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -390,7 +390,7 @@ fn bench_pipeline_stages(c: &mut Criterion) {
 
 fn bench_woff2_quality(c: &mut Criterion) {
     let mut group = c.benchmark_group("woff2_quality");
-    group.sample_size(10);
+    group.sample_size(30);
     let fixture = fixtures(300);
     for quality in [9, 10, 11] {
         group.bench_function(format!("quality_{quality}"), |b| {
@@ -408,7 +408,6 @@ fn bench_woff2_quality(c: &mut Criterion) {
 
 fn bench_optimize_output(c: &mut Criterion) {
     let mut group = c.benchmark_group("optimize_output");
-    group.sample_size(10);
     let fixture = fixtures(300);
     for optimize in [false, true] {
         group.bench_function(format!("optimize_{optimize}"), |b| {
@@ -426,7 +425,7 @@ fn bench_optimize_output(c: &mut Criterion) {
 
 fn bench_recalc_finalize_inputs(c: &mut Criterion) {
     let mut group = c.benchmark_group("recalc_finalize_inputs");
-    group.sample_size(10);
+    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         let stable_sources = stable_metric_sources(&fixture);
@@ -476,7 +475,6 @@ fn bench_recalc_finalize_inputs(c: &mut Criterion) {
 
 fn bench_recalc_output_ceiling(c: &mut Criterion) {
     let mut group = c.benchmark_group("recalc_output_ceiling");
-    group.sample_size(10);
     for size in SIZES {
         let fixture = fixtures(size);
         let parsed = parse_svg_only(
@@ -515,13 +513,13 @@ fn bench_recalc_output_ceiling(c: &mut Criterion) {
     group.finish();
 }
 
-fn criterion_config() -> Criterion {
-    Criterion::default().sample_size(10)
-}
-
-criterion_group! {
-    name = benches;
-    config = criterion_config();
-    targets = bench_pipeline_slices, bench_pipeline_stages, bench_woff2_quality, bench_optimize_output, bench_recalc_finalize_inputs, bench_recalc_output_ceiling
-}
+criterion_group!(
+    benches,
+    bench_pipeline_slices,
+    bench_pipeline_stages,
+    bench_woff2_quality,
+    bench_optimize_output,
+    bench_recalc_finalize_inputs,
+    bench_recalc_output_ceiling
+);
 criterion_main!(benches);

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -305,7 +305,6 @@ fn bench_pipeline_slices(c: &mut Criterion) {
 
 fn bench_pipeline_stages(c: &mut Criterion) {
     let mut group = c.benchmark_group("pipeline_stages");
-    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         group.bench_function(format!("parse_only/{size}"), |b| {
@@ -390,7 +389,6 @@ fn bench_pipeline_stages(c: &mut Criterion) {
 
 fn bench_woff2_quality(c: &mut Criterion) {
     let mut group = c.benchmark_group("woff2_quality");
-    group.sample_size(30);
     let fixture = fixtures(300);
     for quality in [9, 10, 11] {
         group.bench_function(format!("quality_{quality}"), |b| {
@@ -425,7 +423,6 @@ fn bench_optimize_output(c: &mut Criterion) {
 
 fn bench_recalc_finalize_inputs(c: &mut Criterion) {
     let mut group = c.benchmark_group("recalc_finalize_inputs");
-    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         let stable_sources = stable_metric_sources(&fixture);

--- a/packages/webfont-generator/benches/pipeline.rs
+++ b/packages/webfont-generator/benches/pipeline.rs
@@ -258,7 +258,6 @@ fn options(
 
 fn bench_pipeline_slices(c: &mut Criterion) {
     let mut group = c.benchmark_group("pipeline");
-    group.sample_size(30);
     for size in SIZES {
         let fixture = fixtures(size);
         group.bench_function(format!("svg/{size}"), |b| {


### PR DESCRIPTION
## Summary
- Remove the blanket Criterion sample size override of 10 from Rust benchmarks
- Let short and moderate benchmark groups use Criterion's default sample size
- Keep targeted sample_size(30) reductions for longer-running benchmark groups

## Verification
- vp install
- vp run @atlowchemi/webfont-generator#bench --no-run