### PR TITLE
chore: add fresh worktree setup rule

### DIFF
--- a/.agents/rules/fresh-worktree-setup.md
+++ b/.agents/rules/fresh-worktree-setup.md
@@ -1,0 +1,5 @@
+# Fresh Worktree Setup Rule
+
+When creating or switching into a fresh git worktree, run `vp i` before any build, test, benchmark, docs, or fixture task.
+
+If benchmarks fail because the default icon set/path is missing, treat the worktree as not installed; do not override `BENCH_ICON_SET` to a smaller/different icon set unless the task explicitly asks to benchmark that set.


### PR DESCRIPTION
## Summary
- add a shared agent rule requiring `vp i` before tasks in fresh worktrees
- prevent using `BENCH_ICON_SET` as a workaround for missing default benchmark icons

## Testing
- not run; documentation/rule-only change