### PR TITLE
test(vite-svg-2-webfont): fix IPv4/IPv6 host race in dev server fetches

### DIFF
--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -10,6 +10,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
 import { viteSvgToWebfont } from './index';
 import { base64ToArrayBuffer } from './utils';
 import type { IconPluginOptions } from './optionParser';
+import type { AddressInfo } from 'node:net';
 
 const { generateWebfontsMock } = vi.hoisted(() => ({
     generateWebfontsMock: vi.fn<typeof import('@atlowchemi/webfont-generator').generateWebfonts>(),
@@ -116,21 +117,36 @@ const getConfig = (configType: ConfigType, overrides?: Partial<IconPluginOptions
     }
 };
 
-const getServerPort = (server: ViteDevServer | PreviewServer) => {
+const getServerAddress = (server: ViteDevServer | PreviewServer) => {
     const address = server.httpServer?.address();
     if (!address) {
         throw new Error('Address not found');
     }
     if (typeof address === 'string') {
-        const [, port] = address.split(':', 2);
-        return parseInt(port || '80', 10);
+        const [host, port] = address.split(':', 2);
+        return { host: host || '127.0.0.1', port: parseInt(port || '80', 10) };
     }
-    return address.port;
+    // Connect to the exact address the server bound to instead of "localhost". localhost resolves
+    // to ::1 on macOS and to both ::1/127.0.0.1 on Windows CI, so a fixed hostname races the
+    // IPv4/IPv6 stacks against whichever one the server chose - the ETIMEDOUT/ECONNREFUSED flake.
+    return { host: resolveConnectHost(address), port: address.port };
+};
+
+/**
+ * Turns the server's bound address into a connectable host. A wildcard bind (0.0.0.0 / ::) is
+ * reachable via the matching loopback, and IPv6 hosts get bracketed for use in a URL.
+ */
+const resolveConnectHost = (address: AddressInfo) => {
+    const isWildcard = address.address === '0.0.0.0' || address.address === '::' || address.address === '';
+    if (address.family === 'IPv6') {
+        return `[${isWildcard ? '::1' : address.address}]`;
+    }
+    return isWildcard ? '127.0.0.1' : address.address;
 };
 
 const fetchFromServer = async (server: ViteDevServer | PreviewServer, path: string) => {
-    const port = getServerPort(server);
-    const url = `http://localhost:${port}${path}`;
+    const { host, port } = getServerAddress(server);
+    const url = `http://${host}:${port}${path}`;
     return await fetch(url);
 };
 


### PR DESCRIPTION
## Problem

CI flaked on `test aarch64-pc-windows-msvc (node 24)` ([run](https://github.com/atlowChemi/vite-svg-2-webfont/actions/runs/28991442404/job/86032748937)) with:

```
TypeError: fetch failed
  Error: connect ETIMEDOUT ::1:5173
  Error: connect ECONNREFUSED 127.0.0.1:5173
```

## Root cause

`index.test.ts` fetched the dev/preview server via a **fixed hostname** while the server bound to whatever `localhost` resolved to:

- On **Windows CI**, `localhost` resolves to **both** `::1` and `127.0.0.1`. undici's Happy Eyeballs raced the stacks — the `::1` attempt hung to `ETIMEDOUT` while `127.0.0.1` gave `ECONNREFUSED`.
- On **macOS**, `localhost` resolves to `::1` first, producing the mirror failure locally.

The port in the error (`5173`) was a red herring — the mismatch was the *host*, not the port.

## Fix

In `fetchFromServer` (the single point every test fetch flows through), derive the connect host from the address the server **actually bound to** (`httpServer.address()`) instead of a fixed hostname, so the fetch always matches the bind. Wildcard binds (`0.0.0.0` / `::`) map to the matching loopback; IPv6 hosts are bracketed. Extracted to a small `resolveConnectHost` helper to avoid nested ternaries. One change covers all 25 server configs in the file.

## Verification

- `index.test.ts`: 62/62 pass (was flaking / 13 local failures pre-fix)
- Full suite: 318/318 pass
- No `ETIMEDOUT`/`ECONNREFUSED` errors
- `vp fmt` clean on the changed file
