### PR TITLE
perf(vite-svg-2-webfont): memoize generated font buffers

### DIFF
--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -629,7 +629,7 @@ describe('serve - memoizes generated font outputs', () => {
             if (!watcherHandler) {
                 throw new Error('Watcher not initialized');
             }
-            await watcherHandler([{ path: fileURLToNormalizedPath(svgUrl), kind: 'added' }]);
+            await watcherHandler([{ path: pathJoin(webfontFolder, filename), kind: 'added' }]);
 
             const after = await fetchBufferContent(server, '/iconfont.woff2');
             expect(after).not.toStrictEqual(before);

--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -6,7 +6,7 @@ import { setTimeout } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import type { IndexHtmlTransformContext, InlineConfig, PreviewServer, ViteDevServer } from 'vite';
 import { build, createServer, normalizePath, preview } from 'vite';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
+import { afterAll, beforeAll, describe, expect, it, vi, type MockInstance } from 'vite-plus/test';
 import { viteSvgToWebfont } from './index';
 import type { IconPluginOptions } from './optionParser';
 import type { AddressInfo } from 'node:net';
@@ -574,6 +574,108 @@ describe('build font write ordering', () => {
                 .map(({ type }) => type)
                 .toSorted(),
         ).toEqual(['ttf', 'woff2']);
+    });
+
+    it('reads each generated font getter once', async () => {
+        const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
+        let getterSpy: MockInstance | undefined;
+        generateWebfontsMock.mockImplementationOnce(async options => {
+            const result = await realGen(options);
+            getterSpy = vi.spyOn(result, 'woff2', 'get');
+            return result;
+        });
+
+        await build({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            build: { assetsInlineLimit: 0, write: false },
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+
+        expect(getterSpy).toHaveBeenCalledOnce();
+    });
+});
+
+describe('serve - memoizes generated font outputs', () => {
+    it('reads the getter once per successful watch generation', async () => {
+        const filename = '__memoized-font-test__.svg';
+        const svgUrl = new URL(`webfont-test/svg/${filename}`, root);
+        let watcherHandler: Parameters<typeof setupWatcherMock>[2] | undefined;
+        let getterSpy: MockInstance | undefined;
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
+        const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
+        generateWebfontsMock.mockImplementationOnce(async options => {
+            const result = await realGen(options);
+            getterSpy = vi.spyOn(result, 'woff2', 'get');
+            return result;
+        });
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+        const server = await created.listen();
+
+        try {
+            const before = await fetchBufferContent(server, '/iconfont.woff2');
+            expect(await fetchBufferContent(server, '/iconfont.woff2')).toStrictEqual(before);
+            expect(getterSpy).toHaveBeenCalledOnce();
+
+            await writeFile(svgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>');
+            if (!watcherHandler) {
+                throw new Error('Watcher not initialized');
+            }
+            await watcherHandler([{ path: fileURLToNormalizedPath(svgUrl), kind: 'added' }]);
+
+            const after = await fetchBufferContent(server, '/iconfont.woff2');
+            expect(after).not.toStrictEqual(before);
+            expect(await fetchBufferContent(server, '/iconfont.woff2')).toStrictEqual(after);
+            expect(getterSpy).toHaveBeenCalledTimes(2);
+        } finally {
+            await Promise.all([server.close(), rm(svgUrl, { force: true })]);
+        }
+    });
+
+    it('keeps the previous output cached when regeneration fails', async () => {
+        let watcherHandler: Parameters<typeof setupWatcherMock>[2] | undefined;
+        let getterSpy: MockInstance | undefined;
+        setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
+            watcherHandler = handler;
+        });
+        const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
+        generateWebfontsMock.mockImplementationOnce(async options => {
+            const result = await realGen(options);
+            result.regenerate = () => {
+                throw new Error('incremental regeneration failed');
+            };
+            getterSpy = vi.spyOn(result, 'woff2', 'get');
+            return result;
+        });
+        generateWebfontsMock.mockRejectedValueOnce(new Error('fallback generation failed'));
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+        const server = await created.listen();
+
+        try {
+            const before = await fetchBufferContent(server, '/iconfont.woff2');
+            expect(await fetchBufferContent(server, '/iconfont.woff2')).toStrictEqual(before);
+            if (!watcherHandler) {
+                throw new Error('Watcher not initialized');
+            }
+            await expect(watcherHandler([{ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' }])).rejects.toThrow('fallback generation failed');
+            expect(await fetchBufferContent(server, '/iconfont.woff2')).toStrictEqual(before);
+            expect(getterSpy).toHaveBeenCalledOnce();
+        } finally {
+            await server.close();
+        }
     });
 });
 

--- a/packages/vite-svg-2-webfont/src/index.ts
+++ b/packages/vite-svg-2-webfont/src/index.ts
@@ -47,10 +47,25 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
     let _moduleGraph: ModuleGraph | undefined;
     let _reloadModule: undefined | ((module: ModuleNode) => Promise<void>);
     let generatedFonts: GenerateWebfontsResult<T> | undefined;
+    const generatedFontBuffers = new Map<T, Buffer>();
     const generatedWebfonts: GeneratedWebfont[] = [];
     const moduleId = options.moduleId ?? DEFAULT_MODULE_ID;
     const virtualModuleId = getVirtualModuleId(moduleId);
     const resolvedVirtualModuleId = getResolvedVirtualModuleId(virtualModuleId);
+
+    const getGeneratedFont = (type: T) => {
+        const cached = generatedFontBuffers.get(type);
+        if (cached) {
+            return cached;
+        }
+        const value = generatedFonts?.[type];
+        if (!value) {
+            return undefined;
+        }
+        const font = Buffer.from(value);
+        generatedFontBuffers.set(type, font);
+        return font;
+    };
 
     const resolveGeneratedWebfonts = (bundle: OutputBundle) => {
         const resolvedWebfonts = new Map<T, string>();
@@ -82,8 +97,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
             return css;
         }
         return css?.replace(/url\(".*?\.([^?]+)\?[^"]+"\)/g, (_, type: T) => {
-            const value = generatedFonts![type]!;
-            const font = Buffer.from(value);
+            const font = getGeneratedFont(type)!;
             return `url("data:${MIME_TYPES[type]};charset=utf-8;base64,${font.toString('base64')}")`;
         }) as U;
     };
@@ -130,6 +144,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         }
         const generateWebfonts = await getGenerateWebfonts();
         generatedFonts = await generateWebfonts(processedOptions);
+        generatedFontBuffers.clear();
         await writeDevFiles();
         if (updateFiles) {
             reloadVirtualModule();
@@ -152,6 +167,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
             const orderedFiles = parseFiles(options);
             processedOptions.files = orderedFiles;
             generatedFonts.regenerate(orderedFiles, changes.map(toGlyphChange));
+            generatedFontBuffers.clear();
         } catch {
             await generate(true);
             return;
@@ -243,11 +259,11 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
             if (isBuild && !options.inline) {
                 const emitted = await Promise.all(
                     processedOptions.types.map(async (type): Promise<[T, string]> => {
-                        if (!generatedFonts?.[type]) {
+                        const fileContents = getGeneratedFont(type);
+                        if (!fileContents) {
                             throw new Error(`Failed to generate font of type ${type}`);
                         }
 
-                        const fileContents = Buffer.from(generatedFonts[type]);
                         const hash = getBufferHash(fileContents);
                         const filePath = pathJoin(tmpDir, `${processedOptions.fontName}-${hash}.${type}`);
                         // Await the write: Vite reads these temp files when it resolves the
@@ -278,7 +294,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
                         res.statusCode = 404;
                         return res.end();
                     }
-                    const font = generatedFonts[fontType];
+                    const font = getGeneratedFont(fontType);
                     res.setHeader('content-type', MIME_TYPES[fontType]);
                     res.setHeader('content-length', font!.length);
                     res.statusCode = 200;
@@ -290,6 +306,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
             ac.abort();
             rmDir(tmpDir);
             generatedFonts = undefined;
+            generatedFontBuffers.clear();
             fileRefs = undefined;
             _moduleGraph = undefined;
             _reloadModule = undefined;


### PR DESCRIPTION
## Summary
- cache each generated font as a plugin-local `Buffer` on first access
- reuse cached buffers across build validation, inline CSS transforms, and dev middleware requests
- clear the cache after successful generation or regeneration while preserving previous output when regeneration fails