### PR TITLE
feat(webfont-generator): add async regeneration

### DIFF
--- a/packages/docs/webfont-generator/node.md
+++ b/packages/docs/webfont-generator/node.md
@@ -178,7 +178,7 @@ const cssCustom = result.generateCss({ woff2: '/fonts/icons.woff2' });
 
 - Type: `boolean`
 - Default: `false`
-- Description: Retain parsed glyph data on the result so [`regenerate()`](#regeneratefiles-changes) can rebuild after file changes without re-parsing the glyphs that didn't change. Enable for watch/dev; leave it off for one-shot builds so the parsed geometry isn't held in memory.
+- Description: Retain parsed glyph data on the result so [`regenerateAsync()`](#regenerateasyncfiles-changes) or [`regenerate()`](#regeneratefiles-changes) can rebuild after file changes without re-parsing the glyphs that didn't change. Enable for watch/dev; leave it off for one-shot builds so the parsed geometry isn't held in memory.
 
 ### `fixedWidth`
 
@@ -344,6 +344,18 @@ interface GlyphChangeEntry {
     // the file stem; changed files default to the current name; removed files ignore it.
     name?: string;
 }
+```
+
+### `regenerateAsync(files, changes?)`
+
+- Type: `(files: string[], changes?: GlyphChangeEntry[] | null) => Promise<GenerateWebfontsResult>`
+- Requires: the result was produced with [`incremental: true`](#incremental) (rejects otherwise).
+- Description: Performs the same rebuild as [`regenerate()`](#regeneratefiles-changes) off the Node.js event loop and resolves with a replacement result. The receiver remains readable and unchanged while the rebuild runs and after failure. Assign the replacement before starting another rebuild; overlapping calls from the same result lineage reject. In-memory state is replaced only on success, but writes made with [`writeFiles: true`](#writefiles) are not transactional.
+
+```ts
+let files = ['/icons/add.svg', '/icons/search.svg'];
+let result = await generateWebfonts({ files, dest, incremental: true });
+result = await result.regenerateAsync(files, [{ path: '/icons/add.svg', changeType: 'changed' }]);
 ```
 
 ## Templates

--- a/packages/docs/webfont-generator/rust.md
+++ b/packages/docs/webfont-generator/rust.md
@@ -187,10 +187,12 @@ Both methods accept `Option<HashMap<FontType, String>>` for the `urls` parameter
 
 ### Incremental rebuild
 
-| Method                               | Return type      | Description                                                          |
-| ------------------------------------ | ---------------- | -------------------------------------------------------------------- |
-| `regenerate(ordered_paths, changes)` | `io::Result<()>` | Rebuild after known file changes, reusing unchanged glyphs           |
-| `regenerate_all(ordered_paths)`      | `io::Result<()>` | Re-read/hash the full file set and infer added/changed/removed paths |
+| Method                                     | Return type                     | Description                                                          |
+| ------------------------------------------ | ------------------------------- | -------------------------------------------------------------------- |
+| `regenerate(ordered_paths, changes)`       | `io::Result<()>`                | Rebuild after known file changes, reusing unchanged glyphs           |
+| `regenerate_all(ordered_paths)`            | `io::Result<()>`                | Re-read/hash the full file set and infer added/changed/removed paths |
+| `regenerate_async(ordered_paths, changes)` | `Result<Self, RegenerateError>` | Consume the result and rebuild on Tokio's blocking pool              |
+| `regenerate_all_async(ordered_paths)`      | `Result<Self, RegenerateError>` | Consume the result, re-diff, and rebuild on Tokio's blocking pool    |
 
 Requires the result to have been generated with `incremental: Some(true)` (errors otherwise).
 `ordered_paths: &[String]` is the complete file set after the changes, in the order a fresh build
@@ -203,6 +205,19 @@ too, while unchanged CSS/HTML companion files are skipped. Rendered
 CSS/HTML is reused when glyph names and codepoints are unchanged. Use `regenerate_all` when you have
 the fresh ordered file set but no reliable watcher change batch; existing glyph names are preserved,
 and added paths derive their glyph name from the file stem.
+
+The async methods take owned `Vec` inputs and consume the result, so Rust rejects stale-result
+reuse after a successful rebuild. Assign the returned generation:
+
+```rust
+result = result.regenerate_async(files, changes).await?;
+```
+
+For ordinary regeneration failures, `RegenerateError::into_result()` returns the consumed result
+so it can be retried. It returns `None` only if Tokio cancelled the blocking task before the result
+could be returned. The consuming futures are not cancellation-safe: dropping one does not stop an
+already-started blocking task, filesystem writes may continue, and the consumed result cannot be
+recovered. Panics resume unwinding on the awaiting task.
 
 For Node.js results, `regenerate()` errors if the initial build used `cssContext` or `htmlContext`
 callbacks because the synchronous method cannot re-run JavaScript callbacks during the rebuild.

--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -1167,6 +1167,50 @@ describe('serve - releases retained watch state on close', () => {
         expect(rmDirMock.mock.calls.length).toBe(rmDirCallsBefore + 1);
     });
 
+    it('waits for an in-flight watch rebuild before releasing state', async () => {
+        const startFlush = Promise.withResolvers<void>();
+        const regenerationStarted = Promise.withResolvers<void>();
+        const finishRegeneration = Promise.withResolvers<void>();
+        let watchSignal: AbortSignal | undefined;
+        setupWatcherMock.mockImplementationOnce(async (_path, signal, handler) => {
+            watchSignal = signal;
+            await startFlush.promise;
+            await handler([{ path: pathJoin(webfontFolder, 'add.svg'), kind: 'changed' }]);
+        });
+        const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
+        generateWebfontsMock.mockImplementationOnce(async options => {
+            const result = await realGen(options);
+            const regenerateAsync = result.regenerateAsync.bind(result);
+            result.regenerateAsync = async (...args) => {
+                regenerationStarted.resolve();
+                await finishRegeneration.promise;
+                return regenerateAsync(...args);
+            };
+            return result;
+        });
+        const created = await createServer({
+            logLevel: 'silent',
+            root: fileURLToNormalizedPath(root),
+            configFile: false,
+            plugins: [viteSvgToWebfont({ context: webfontFolder, types: ['woff2'] })],
+        });
+        const server = await created.listen();
+
+        startFlush.resolve();
+        await regenerationStarted.promise;
+        let closed = false;
+        const close = server.close().then(() => {
+            closed = true;
+            return undefined;
+        });
+        await vi.waitFor(() => expect(watchSignal?.aborted).toBe(true));
+        expect(closed).toBe(false);
+
+        finishRegeneration.resolve();
+        await close;
+        expect(closed).toBe(true);
+    });
+
     it('does not fail server startup when watcher setup rejects', async () => {
         setupWatcherMock.mockRejectedValueOnce(new Error('intentional watcher setup failure'));
 

--- a/packages/vite-svg-2-webfont/src/index.test.ts
+++ b/packages/vite-svg-2-webfont/src/index.test.ts
@@ -602,15 +602,19 @@ describe('serve - memoizes generated font outputs', () => {
         const filename = '__memoized-font-test__.svg';
         const svgUrl = new URL(`webfont-test/svg/${filename}`, root);
         let watcherHandler: Parameters<typeof setupWatcherMock>[2] | undefined;
-        let getterSpy: MockInstance | undefined;
+        const getterSpies: MockInstance[] = [];
         setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
             watcherHandler = handler;
         });
         const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
         generateWebfontsMock.mockImplementationOnce(async options => {
-            const result = await realGen(options);
-            getterSpy = vi.spyOn(result, 'woff2', 'get');
-            return result;
+            const trackGetter = (result: Awaited<ReturnType<typeof realGen>>): Awaited<ReturnType<typeof realGen>> => {
+                getterSpies.push(vi.spyOn(result, 'woff2', 'get'));
+                const regenerateAsync = result.regenerateAsync.bind(result);
+                result.regenerateAsync = async (...args) => trackGetter(await regenerateAsync(...args));
+                return result;
+            };
+            return trackGetter(await realGen(options));
         });
         const created = await createServer({
             logLevel: 'silent',
@@ -623,7 +627,7 @@ describe('serve - memoizes generated font outputs', () => {
         try {
             const before = await fetchBufferContent(server, '/iconfont.woff2');
             expect(await fetchBufferContent(server, '/iconfont.woff2')).toStrictEqual(before);
-            expect(getterSpy).toHaveBeenCalledOnce();
+            expect(getterSpies.reduce((calls, spy) => calls + spy.mock.calls.length, 0)).toBe(1);
 
             await writeFile(svgUrl, '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>');
             if (!watcherHandler) {
@@ -634,7 +638,7 @@ describe('serve - memoizes generated font outputs', () => {
             const after = await fetchBufferContent(server, '/iconfont.woff2');
             expect(after).not.toStrictEqual(before);
             expect(await fetchBufferContent(server, '/iconfont.woff2')).toStrictEqual(after);
-            expect(getterSpy).toHaveBeenCalledTimes(2);
+            expect(getterSpies.reduce((calls, spy) => calls + spy.mock.calls.length, 0)).toBe(2);
         } finally {
             await Promise.all([server.close(), rm(svgUrl, { force: true })]);
         }
@@ -649,9 +653,7 @@ describe('serve - memoizes generated font outputs', () => {
         const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
         generateWebfontsMock.mockImplementationOnce(async options => {
             const result = await realGen(options);
-            result.regenerate = () => {
-                throw new Error('incremental regeneration failed');
-            };
+            result.regenerateAsync = async () => Promise.reject(new Error('incremental regeneration failed'));
             getterSpy = vi.spyOn(result, 'woff2', 'get');
             return result;
         });
@@ -885,24 +887,26 @@ describe('serve - incrementally regenerates on a content edit', () => {
     const reloadedIds: string[] = [];
     const { promise: waitForCssReload, resolve: markCssReloaded } = Promise.withResolvers<void>();
     let watcherHandler: Parameters<typeof setupWatcherMock>[2];
-    const regenerateCalls: Array<Parameters<RegenResult['regenerate']>> = [];
+    const regenerateCalls: Array<Parameters<RegenResult['regenerateAsync']>> = [];
     let server: ViteDevServer;
 
     beforeAll(async () => {
         setupWatcherMock.mockImplementationOnce(async (_path, _signal, handler) => {
             watcherHandler = handler;
         });
-        // Wrap the result's `regenerate` to prove the change goes through the incremental path
+        // Wrap the result's `regenerateAsync` to prove the change goes through the incremental path
         // (not the full-rebuild fallback) for a content edit, and to capture its arguments.
         const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
         generateWebfontsMock.mockImplementationOnce(async options => {
-            const result = await realGen(options);
-            const original = result.regenerate.bind(result);
-            result.regenerate = (...args: Parameters<RegenResult['regenerate']>) => {
-                regenerateCalls.push(args);
-                return original(...args);
+            const trackRegeneration = (result: RegenResult): RegenResult => {
+                const original = result.regenerateAsync.bind(result);
+                result.regenerateAsync = async (...args: Parameters<RegenResult['regenerateAsync']>) => {
+                    regenerateCalls.push(args);
+                    return trackRegeneration(await original(...args));
+                };
+                return result;
             };
-            return result;
+            return trackRegeneration(await realGen(options));
         });
         const created = await createServer({
             logLevel: 'silent',
@@ -1049,9 +1053,7 @@ describe('serve - falls back when regenerate throws', () => {
         const { generateWebfonts: realGen } = await vi.importActual<typeof import('@atlowchemi/webfont-generator')>('@atlowchemi/webfont-generator');
         generateWebfontsMock.mockImplementationOnce(async options => {
             const result = await realGen(options);
-            result.regenerate = () => {
-                throw new Error('intentional regenerate failure');
-            };
+            result.regenerateAsync = async () => Promise.reject(new Error('intentional regenerate failure'));
             return result;
         });
         const created = await createServer({

--- a/packages/vite-svg-2-webfont/src/index.ts
+++ b/packages/vite-svg-2-webfont/src/index.ts
@@ -47,6 +47,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
     let _moduleGraph: ModuleGraph | undefined;
     let _reloadModule: undefined | ((module: ModuleNode) => Promise<void>);
     let generatedFonts: GenerateWebfontsResult<T> | undefined;
+    let watcherTask: Promise<void> | undefined;
     const generatedFontBuffers = new Map<T, Buffer>();
     const generatedWebfonts: GeneratedWebfont[] = [];
     const moduleId = options.moduleId ?? DEFAULT_MODULE_ID;
@@ -143,10 +144,14 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
             processedOptions.writeFiles = false;
         }
         const generateWebfonts = await getGenerateWebfonts();
-        generatedFonts = await generateWebfonts(processedOptions);
+        const replacement = await generateWebfonts(processedOptions);
+        if (updateFiles && ac.signal.aborted) {
+            return;
+        }
+        generatedFonts = replacement;
         generatedFontBuffers.clear();
         await writeDevFiles();
-        if (updateFiles) {
+        if (updateFiles && !ac.signal.aborted) {
             reloadVirtualModule();
         }
     };
@@ -166,13 +171,23 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         try {
             const orderedFiles = parseFiles(options);
             processedOptions.files = orderedFiles;
-            generatedFonts = await generatedFonts.regenerateAsync(orderedFiles, changes.map(toGlyphChange));
+            const replacement = await generatedFonts.regenerateAsync(orderedFiles, changes.map(toGlyphChange));
+            if (ac.signal.aborted) {
+                return;
+            }
+            generatedFonts = replacement;
             generatedFontBuffers.clear();
         } catch {
+            if (ac.signal.aborted) {
+                return;
+            }
             await generate(true);
             return;
         }
         await writeDevFiles();
+        if (ac.signal.aborted) {
+            return;
+        }
         reloadVirtualModule();
     };
     return {
@@ -253,7 +268,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         },
         async buildStart() {
             if (!isBuild) {
-                setupWatcher(options.context, ac.signal, changes => regenerateFromWatch(changes)).catch(() => null);
+                watcherTask = setupWatcher(options.context, ac.signal, changes => regenerateFromWatch(changes)).catch(() => undefined);
             }
             await generate();
             if (isBuild && !options.inline) {
@@ -302,8 +317,10 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
                 });
             }
         },
-        buildEnd() {
+        async buildEnd() {
             ac.abort();
+            await watcherTask;
+            watcherTask = undefined;
             rmDir(tmpDir);
             generatedFonts = undefined;
             generatedFontBuffers.clear();

--- a/packages/vite-svg-2-webfont/src/index.ts
+++ b/packages/vite-svg-2-webfont/src/index.ts
@@ -157,7 +157,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
             return;
         }
         // Reuse cached glyphs, handing the engine the fresh glob order so additions land in their
-        // correct position (byte-identical to a fresh build). When `writeFiles` is set, `regenerate`
+        // correct position (byte-identical to a fresh build). When `writeFiles` is set, regeneration
         // refreshes the on-disk fonts itself; otherwise `writeDevFiles` handles the CSS/HTML below.
         if (!generatedFonts || !processedOptions.incremental) {
             await generate(true);
@@ -166,7 +166,7 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         try {
             const orderedFiles = parseFiles(options);
             processedOptions.files = orderedFiles;
-            generatedFonts.regenerate(orderedFiles, changes.map(toGlyphChange));
+            generatedFonts = await generatedFonts.regenerateAsync(orderedFiles, changes.map(toGlyphChange));
             generatedFontBuffers.clear();
         } catch {
             await generate(true);
@@ -186,9 +186,9 @@ export function viteSvgToWebfont<T extends FontType = FontType>(options: IconPlu
         configResolved(_config) {
             isBuild = _config.command === 'build';
             if (!isBuild) {
-                // Retain parsed glyphs so watch rebuilds can reuse them via `result.regenerate(...)`.
-                // cssContext runs in JS during generation; regenerate is sync, so skip the
-                // incremental path when callbacks would need to be replayed after a rebuild.
+                // Retain parsed glyphs so watch rebuilds can reuse them via `result.regenerateAsync(...)`.
+                // cssContext runs in JS during generation, so skip the incremental path when
+                // callbacks would need to be replayed after a rebuild.
                 if (!processedOptions.cssContext) {
                     processedOptions.incremental = true;
                 }

--- a/packages/webfont-generator/README.md
+++ b/packages/webfont-generator/README.md
@@ -21,7 +21,7 @@ The API is largely compatible with `@vusion/webfonts-generator`, with a few diff
 - `formatOptions` is now strictly typed as `{ svg?: SvgFormatOptions; ttf?: TtfFormatOptions; woff?: WoffFormatOptions; woff2?: Woff2FormatOptions }`. The original accepted arbitrary `{ [format]: unknown }`; the `eot` key is no longer accepted (EOT is derived from the TTF output).
 - A new `optimizeOutput` option runs an SVG path optimizer over each glyph before assembling the font. Defaults to `false`; opt in for smaller output bytes at a small build-time cost. Also available as `formatOptions.svg.optimizeOutput`.
 - `formatOptions.woff2.compressionQuality` sets the Brotli compression quality (0–11) for WOFF2 output. Defaults to `11` (smallest output); lower it (e.g. to `10`) for faster encoding at a marginal size cost.
-- A new `incremental` option (default `false`) retains parsed glyph data on the result so `result.regenerate(files, changes?)` can rebuild after file changes without re-parsing the glyphs that didn't change — for dev/watch rebuilds. It refreshes the outputs in memory and, when the result was generated with `writeFiles`, writes refreshed fonts to disk too while skipping unchanged CSS/HTML companion files. You pass the full file set (in the order a fresh build would use) plus what changed, or omit `changes` to re-read/hash the full set and infer changes; the result is byte-identical to a fresh `generateWebfonts()` of that set, additions included.
+- A new `incremental` option (default `false`) retains parsed glyph data on the result so `result.regenerateAsync(files, changes?)` can rebuild after file changes without re-parsing the glyphs that didn't change or blocking the Node.js event loop. It refreshes the outputs in memory and, when the result was generated with `writeFiles`, writes refreshed fonts to disk too while skipping unchanged CSS/HTML companion files. You pass the full file set (in the order a fresh build would use) plus what changed, or omit `changes` to re-read/hash the full set and infer changes; the result is byte-identical to a fresh `generateWebfonts()` of that set, additions included.
 - Generated font binaries (TTF, WOFF, etc.) may differ at the byte level because a different encoder is used, but the fonts are equally valid.
 - CSS, HTML, and template output is identical.
 
@@ -31,17 +31,17 @@ Performance scales better with glyph count — for larger icon sets the native p
 
 ```js
 let files = ['./icons/home.svg', './icons/search.svg'];
-const result = await generateWebfonts({ files, dest, fontName: 'my-icons', incremental: true });
+let result = await generateWebfonts({ files, dest, fontName: 'my-icons', incremental: true });
 
 // On a watch event, rebuild reusing cached geometry for unchanged glyphs. Pass the full file set
 // (in fresh-build order) so additions land in the right position, plus what changed:
-result.regenerate(files, [{ path: './icons/home.svg', changeType: 'changed' }]);
+result = await result.regenerateAsync(files, [{ path: './icons/home.svg', changeType: 'changed' }]);
 // Or omit changes when watcher hints are unavailable/untrusted:
-result.regenerate(files);
+result = await result.regenerateAsync(files);
 result.woff2; // refreshed bytes
 ```
 
-The first argument is the complete file set after the change, in the order a fresh build would use (e.g. your glob result) — any file omitted from it is dropped. Each change is `{ path, changeType: 'added' | 'changed' | 'removed', name? }`, where `name` is the resolved glyph name if you apply a custom rename; otherwise added files derive their name from the file stem, changed files keep their current name, and removed files ignore it. When `changes` is omitted or `null`, every current file is re-read and hashed to detect added/changed/removed paths automatically. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run by the synchronous method.
+The first argument is the complete file set after the change, in the order a fresh build would use (e.g. your glob result) — any file omitted from it is dropped. Each change is `{ path, changeType: 'added' | 'changed' | 'removed', name? }`, where `name` is the resolved glyph name if you apply a custom rename; otherwise added files derive their name from the file stem, changed files keep their current name, and removed files ignore it. When `changes` is omitted or `null`, every current file is re-read and hashed to detect added/changed/removed paths automatically. `regenerateAsync()` returns a replacement result; the receiver stays readable and unchanged while work runs and after failure. Assign the replacement before starting another rebuild because overlapping calls from the same result lineage are rejected. Disk writes are not transactional. The synchronous, mutating `regenerate()` method remains available when blocking the event loop is acceptable. Results generated with `cssContext` or `htmlContext` callbacks cannot be regenerated because those JavaScript callbacks cannot be re-run during a rebuild.
 
 ## Node.js (npm)
 
@@ -95,7 +95,18 @@ let result = webfont_generator::generate_sync(
 let css = result.generate_css_pure(None).unwrap();
 ```
 
-An async API (`webfont_generator::generate`) is also available for use with tokio.
+Async generation and incremental regeneration are available for Tokio applications. Async
+regeneration consumes the old result, preventing stale-result reuse, and returns the next result:
+
+```rust
+let result = result.regenerate_async(files.clone(), changes).await?;
+// Or re-diff the complete file set:
+let result = result.regenerate_all_async(files).await?;
+```
+
+On failure, `RegenerateError::into_result()` recovers the consumed result for retry when the
+blocking task returned normally. These consuming futures are not cancellation-safe: dropping one
+does not stop already-started blocking work and the consumed result cannot be recovered.
 
 ## CLI
 

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -299,6 +299,31 @@ fn bench_regenerate(c: &mut Criterion) {
             )
         });
 
+        group.bench_function(format!("owned_incremental_content_edit/{size}"), |b| {
+            b.iter_batched(
+                || {
+                    let fixture = fixtures(size);
+                    let result = webfont_generator::generate_sync(
+                        options(fixture.paths.clone(), true),
+                        None,
+                    )
+                    .unwrap();
+                    let changed = fixture.paths[size / 2].clone();
+                    std::fs::write(&changed, svg(&changed_path_data())).unwrap();
+                    (fixture, result, changed)
+                },
+                |(fixture, result, changed)| {
+                    result
+                        .regenerate_owned_for_bench(
+                            &fixture.paths,
+                            &[(changed, GlyphChange::Changed { name: None })],
+                        )
+                        .unwrap()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+
         group.bench_function(format!("rediff_content_edit/{size}"), |b| {
             b.iter_batched(
                 || {

--- a/packages/webfont-generator/binding.d.ts
+++ b/packages/webfont-generator/binding.d.ts
@@ -43,6 +43,13 @@ export declare class GenerateWebfontsResult {
    * rendered bytes are unchanged since the last write.
    */
   regenerate(files: Array<string>, changes?: Array<GlyphChangeEntry> | undefined | null): void
+  /**
+   * Rebuild off the Node.js event loop and resolve with a replacement result. The receiver
+   * remains readable and unchanged while regeneration runs and after failure. Assign the
+   * resolved result before starting another regeneration. Overlapping calls on the same result
+   * lineage are rejected, and disk writes remain non-transactional.
+   */
+  regenerateAsync(files: Array<string>, changes?: Array<GlyphChangeEntry> | undefined | null): Promise<GenerateWebfontsResult>
 }
 
 /**

--- a/packages/webfont-generator/binding.js
+++ b/packages/webfont-generator/binding.js
@@ -527,47 +527,163 @@ function requireNative() {
   }
 }
 
-nativeBinding = requireNative()
+function createLoadErrorChain(errors) {
+  return errors.reduce((previous, current) => {
+    let message
+    try {
+      message =
+        current && typeof current.message === 'string'
+          ? current.message
+          : String(current)
+    } catch {
+      message = 'Unknown error'
+    }
+    const error = new Error(message)
+    error.cause = previous
+    return error
+  }, null)
+}
 
 // NAPI_RS_FORCE_WASI is a tri-state flag:
 //   unset / any other value → native binding preferred, WASI is only a fallback
-//   'true'                   → force WASI fallback even if native loaded
-//   'error'                  → force WASI and throw if no WASI binding is found
+//   'true'                   → prefer WASI, but retain native as a lazy fallback
+//   'error'                  → require WASI without initializing a native fallback
 // Treating any non-empty string as truthy (the historical behavior) meant
 // NAPI_RS_FORCE_WASI=false, NAPI_RS_FORCE_WASI=0, etc. inadvertently triggered
 // the WASI path, causing ENOENT for packages shipped without a .wasi.cjs file.
+//
+// NAPI_RS_WASI_FLAVOR selects one exact generated flavor and implies strict
+// WASI loading. It never crosses into another flavor or falls back to native.
+const __napiWasiFlavors = ["wasm32-wasi"]
+const __napiWasiFlavor = process.env.NAPI_RS_WASI_FLAVOR
+const __napiWasiFlavorRequested =
+  typeof __napiWasiFlavor === 'string' && __napiWasiFlavor.length > 0
+if (
+  __napiWasiFlavorRequested &&
+  __napiWasiFlavors.indexOf(__napiWasiFlavor) === -1
+) {
+  throw new Error(
+    'Unsupported WASI flavor "' +
+      __napiWasiFlavor +
+      '". Available flavors: ' +
+      __napiWasiFlavors.join(', '),
+  )
+}
+const forceWasiError = process.env.NAPI_RS_FORCE_WASI === 'error'
 const forceWasi =
-  process.env.NAPI_RS_FORCE_WASI === 'true' || process.env.NAPI_RS_FORCE_WASI === 'error'
+  process.env.NAPI_RS_FORCE_WASI === 'true' ||
+  forceWasiError ||
+  __napiWasiFlavorRequested
+
+if (!forceWasi) {
+  nativeBinding = requireNative()
+}
 
 if (!nativeBinding || forceWasi) {
   let wasiBinding = null
-  let wasiBindingError = null
-  try {
-    wasiBinding = require('./webfont-generator.wasi.cjs')
-    nativeBinding = wasiBinding
-  } catch (err) {
-    if (forceWasi) {
-      wasiBindingError = err
-    }
-  }
-  if (!nativeBinding || forceWasi) {
+  let wasiBindingLoaded = false
+  const wasiBindingErrors = []
+  const __napiWasiResolveCandidate = (specifier, isPackage, localArtifacts) => {
     try {
-      wasiBinding = require('@atlowchemi/webfont-generator-wasm32-wasi')
-      nativeBinding = wasiBinding
-    } catch (err) {
-      if (forceWasi) {
-        if (!wasiBindingError) {
-          wasiBindingError = err
-        } else {
-          wasiBindingError.cause = err
-        }
-        loadErrors.push(err)
+      require.resolve(specifier)
+    } catch (resolveError) {
+      if (!resolveError || resolveError.code !== 'MODULE_NOT_FOUND') {
+        throw resolveError
       }
+      if (isPackage) {
+        try {
+          require.resolve(specifier + '/package.json')
+        } catch (packageError) {
+          if (packageError && packageError.code === 'MODULE_NOT_FOUND') {
+            return resolveError
+          }
+          // An exports restriction proves the package exists even when its
+          // package.json is not public. Preserve the root resolution failure.
+          throw resolveError
+        }
+        // The package exists but its main/export target is broken.
+        throw resolveError
+      }
+      return resolveError
+    }
+    if (localArtifacts) {
+      let artifactError = null
+      for (let i = 0; i < localArtifacts.length; i++) {
+        try {
+          require.resolve(localArtifacts[i])
+          return null
+        } catch (resolveError) {
+          if (!resolveError || resolveError.code !== 'MODULE_NOT_FOUND') {
+            throw resolveError
+          }
+          artifactError = resolveError
+        }
+      }
+      return artifactError
+    }
+    return null
+  }
+  if (!wasiBindingLoaded && (!__napiWasiFlavorRequested || __napiWasiFlavor === "wasm32-wasi")) {
+    let candidateError = null
+    let candidateFailed = false
+    try {
+      candidateError = __napiWasiResolveCandidate('./webfont-generator.wasi.cjs', false, ["./webfont-generator.wasm32-wasi.debug.wasm","./webfont-generator.wasm32-wasi.wasm"])
+      candidateFailed = candidateError !== null
+      if (!candidateFailed) {
+        wasiBinding = require('./webfont-generator.wasi.cjs')
+        nativeBinding = wasiBinding
+        wasiBindingLoaded = true
+      }
+    } catch (err) {
+      candidateError = err
+      candidateFailed = true
+    }
+    if (candidateFailed) {
+      wasiBindingErrors.push(candidateError)
+      loadErrors.push(candidateError)
     }
   }
-  if (process.env.NAPI_RS_FORCE_WASI === 'error' && !wasiBinding) {
-    const error = new Error('WASI binding not found and NAPI_RS_FORCE_WASI is set to error')
-    error.cause = wasiBindingError
+  if (!wasiBindingLoaded && (!__napiWasiFlavorRequested || __napiWasiFlavor === "wasm32-wasi")) {
+    let candidateError = null
+    let candidateFailed = false
+    try {
+      candidateError = __napiWasiResolveCandidate('@atlowchemi/webfont-generator-wasm32-wasi', true, undefined)
+      candidateFailed = candidateError !== null
+      if (!candidateFailed) {
+        if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          const bindingPackageVersion = require('@atlowchemi/webfont-generator-wasm32-wasi/package.json').version
+          if (bindingPackageVersion !== '0.5.1') {
+            throw new Error(`WASI binding package version mismatch, expected 0.5.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          }
+        }
+        wasiBinding = require('@atlowchemi/webfont-generator-wasm32-wasi')
+        nativeBinding = wasiBinding
+        wasiBindingLoaded = true
+      }
+    } catch (err) {
+      candidateError = err
+      candidateFailed = true
+    }
+    if (candidateFailed) {
+      wasiBindingErrors.push(candidateError)
+      loadErrors.push(candidateError)
+    }
+  }
+  if (
+    !wasiBindingLoaded &&
+    forceWasi &&
+    !forceWasiError &&
+    !__napiWasiFlavorRequested
+  ) {
+    nativeBinding = requireNative()
+  }
+  if ((forceWasiError || __napiWasiFlavorRequested) && !wasiBindingLoaded) {
+    const error = new Error(
+      __napiWasiFlavorRequested
+        ? 'WASI binding for flavor "' + __napiWasiFlavor + '" not found'
+        : 'WASI binding not found and NAPI_RS_FORCE_WASI is set to error',
+    )
+    error.cause = createLoadErrorChain(wasiBindingErrors)
     throw error
   }
 }
@@ -581,10 +697,7 @@ if (!nativeBinding) {
     )
     // assign instead of the `new Error(message, { cause })` options form,
     // which Node < 16.9 silently ignores
-    error.cause = loadErrors.reduce((err, cur) => {
-      cur.cause = err
-      return cur
-    })
+    error.cause = createLoadErrorChain(loadErrors)
     throw error
   }
   throw new Error(`Failed to load native binding`)

--- a/packages/webfont-generator/index.d.ts
+++ b/packages/webfont-generator/index.d.ts
@@ -81,7 +81,9 @@ type FontValue<F extends FontType> = F extends 'svg' ? string : Uint8Array;
  */
 export type GenerateWebfontsResult<T extends FontType = FontType> = {
     [F in FontType]: F extends T ? FontValue<F> : null;
-} & Pick<RawGenerateWebfontsResult, 'generateCss' | 'generateHtml' | 'regenerate'>;
+} & Pick<RawGenerateWebfontsResult, 'generateCss' | 'generateHtml' | 'regenerate'> & {
+        regenerateAsync(files: string[], changes?: GlyphChangeEntry[] | null): Promise<GenerateWebfontsResult<T>>;
+    };
 
 /**
  * Generate a webfont from a set of SVG files.

--- a/packages/webfont-generator/src/incremental/mod.rs
+++ b/packages/webfont-generator/src/incremental/mod.rs
@@ -6,7 +6,9 @@ use std::io::ErrorKind;
 use std::path::Path;
 
 use crate::svg::{prepare_svg_font_incremental, source_content_hash, svg_options_from_options};
-use crate::types::{GenerateWebfontsResult, GlyphChange, LoadedSvgFile};
+use crate::types::{
+    GenerateWebfontsResult, GlyphChange, LoadedSvgFile, RegenerateError, RegenerationState,
+};
 use crate::write::write_generate_webfonts_result_sync;
 use crate::{build_font_outputs, finalize_generate_webfonts_options, validate_glyph_names};
 
@@ -69,14 +71,57 @@ impl GenerateWebfontsResult {
             ));
         }
 
-        let mut cache = self.glyph_cache.clone().ok_or_else(|| {
-            std::io::Error::new(
-                ErrorKind::InvalidInput,
-                "regenerate requires the font to be generated with `incremental` enabled.",
-            )
-        })?;
-        let mut source_files = self.source_files.clone();
-        let mut options = self.options.clone();
+        let mut state = self.take_regeneration_state_lease()?;
+        let result = self.regenerate_with_state(ordered_paths, changes, state.state_mut());
+        if result.is_ok() {
+            state.commit();
+        }
+        result
+    }
+
+    /// Asynchronously rebuild on Tokio's blocking pool and return the next result generation.
+    /// This consumes `self`, so Rust prevents reuse of a stale result after success. On ordinary
+    /// failure, [`RegenerateError::into_result`] returns the input result for retry. This future is
+    /// not cancellation-safe: dropping it lets already-started blocking work finish and drops the
+    /// consumed result; filesystem writes may continue.
+    ///
+    /// ```rust,no_run
+    /// use webfont_generator::{generate_sync, GenerateWebfontsOptions, GlyphChange};
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let files = vec!["icons/add.svg".to_owned()];
+    /// let result = generate_sync(GenerateWebfontsOptions {
+    ///     files: files.clone(),
+    ///     dest: "dist".to_owned(),
+    ///     incremental: Some(true),
+    ///     ..Default::default()
+    /// }, None)?;
+    /// let result = result.regenerate_async(
+    ///     files.clone(),
+    ///     vec![(files[0].clone(), GlyphChange::Changed { name: None })],
+    /// ).await?;
+    /// # let _ = result;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn regenerate_async(
+        self,
+        ordered_paths: Vec<String>,
+        changes: Vec<(String, GlyphChange)>,
+    ) -> Result<Self, RegenerateError> {
+        self.regenerate_in_background(ordered_paths, Some(changes))
+            .await
+    }
+
+    fn regenerate_with_state(
+        &mut self,
+        ordered_paths: &[String],
+        changes: &[(String, GlyphChange)],
+        state: &mut RegenerationState,
+    ) -> std::io::Result<()> {
+        let cache = &mut state.glyph_cache;
+        let mut source_files = self.source_files.as_ref().clone();
+        let mut options = self.options.as_ref().clone();
 
         // Snapshot the inputs the CSS/HTML templates depend on (glyph names + codepoints) so we
         // can tell, after rebuilding, whether the rendered output could have changed.
@@ -97,6 +142,7 @@ impl GenerateWebfontsResult {
         for (path, change) in changes {
             match change {
                 GlyphChange::Removed => {
+                    state.caches_dirty = true;
                     let before = source_files.len();
                     source_files.retain(|file| &file.path != path);
                     cache.entries.remove(path);
@@ -106,6 +152,7 @@ impl GenerateWebfontsResult {
                 }
                 GlyphChange::Added { name } => {
                     let contents = std::fs::read_to_string(path)?;
+                    state.caches_dirty = true;
                     let hash = source_content_hash(&contents);
                     upsert_source_file(&mut source_files, path, contents, name.clone());
                     // Reuse identical SVG geometry if another path already parsed these bytes;
@@ -137,6 +184,7 @@ impl GenerateWebfontsResult {
 
                     upsert_source_file(&mut source_files, path, contents, name.clone());
                     if content_changed {
+                        state.caches_dirty = true;
                         if let Some(cached) = cache.by_content_hash.get(&hash) {
                             cache.entries.insert(path.clone(), cached.clone());
                             cache.content_hashes.insert(path.clone(), hash);
@@ -181,26 +229,42 @@ impl GenerateWebfontsResult {
         finalize_generate_webfonts_options(&mut options, &source_files)?;
 
         let svg_options = svg_options_from_options(&options);
-        let prepared = prepare_svg_font_incremental(&svg_options, &source_files, &mut cache)?;
-        let fonts = build_font_outputs(&options, &svg_options, &prepared, self.ttf_cache.as_mut())?;
+        state.caches_dirty = true;
+        let prepared = prepare_svg_font_incremental(&svg_options, &source_files, cache)?;
+        let fonts =
+            build_font_outputs(&options, &svg_options, &prepared, state.ttf_cache.as_mut())?;
 
         // Rebuild the template data fresh (the font hash changed), but keep the rendered CSS/HTML
         // that can't have changed: only when the glyph names and codepoints the templates read are
-        // unchanged (e.g. a pure content edit). reset_render_cache carries the safe entries.
+        // unchanged (e.g. a pure content edit). Carry those safe entries into the new result.
         let names_unchanged = source_files
             .iter()
             .map(|file| file.glyph_name.as_str())
             .eq(prev_names.iter().map(String::as_str));
         let codepoints_unchanged = options.codepoints == prev_codepoints;
-        self.source_files = source_files;
-        self.options = options;
-        self.fonts = fonts;
-        self.glyph_cache = Some(cache);
-        self.reset_render_cache(names_unchanged, codepoints_unchanged);
+        let carried = self.reusable_render_cache(names_unchanged, codepoints_unchanged);
+        let previous_source_files =
+            std::mem::replace(&mut self.source_files, std::sync::Arc::new(source_files));
+        let previous_options = std::mem::replace(&mut self.options, std::sync::Arc::new(options));
+        let previous_fonts = std::mem::replace(&mut self.fonts, fonts);
+        let previous_cached = std::mem::take(&mut self.cached);
+        let previous_carried = std::mem::replace(&mut self.carried_render, carried);
+        let previous_css_context = self.css_context.take();
+        let previous_html_context = self.html_context.take();
 
         // Match `generate`'s write behavior: refresh font files, and skip unchanged CSS/HTML.
-        if self.options.write_files {
-            write_generate_webfonts_result_sync(self)?;
+        if self.options.write_files
+            && let Err(error) =
+                write_generate_webfonts_result_sync(self, &mut state.written_outputs)
+        {
+            self.source_files = previous_source_files;
+            self.options = previous_options;
+            self.fonts = previous_fonts;
+            self.cached = previous_cached;
+            self.carried_render = previous_carried;
+            self.css_context = previous_css_context;
+            self.html_context = previous_html_context;
+            return Err(error);
         }
         Ok(())
     }
@@ -210,18 +274,44 @@ impl GenerateWebfontsResult {
     /// change batch: every current path is re-read and hashed, missing prior paths are treated as
     /// removed, new paths as added, and paths whose content hash changed as changed. Existing glyph
     /// names are preserved; added paths derive their glyph name from the file stem.
+    ///
+    /// ```rust,no_run
+    /// use webfont_generator::{generate_sync, GenerateWebfontsOptions};
+    ///
+    /// # fn run() -> std::io::Result<()> {
+    /// let files = vec!["icons/add.svg".to_owned()];
+    /// let mut result = generate_sync(GenerateWebfontsOptions {
+    ///     files: files.clone(),
+    ///     dest: "dist".to_owned(),
+    ///     incremental: Some(true),
+    ///     ..Default::default()
+    /// }, None)?;
+    /// result.regenerate_all(&files)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn regenerate_all(&mut self, ordered_paths: &[String]) -> std::io::Result<()> {
-        let cache = self.glyph_cache.as_ref().ok_or_else(|| {
-            std::io::Error::new(
+        if !self.options.incremental {
+            return Err(std::io::Error::new(
                 ErrorKind::InvalidInput,
                 "regenerate requires the font to be generated with `incremental` enabled.",
-            )
-        })?;
+            ));
+        }
+        let state = self.regeneration_state.lock().unwrap();
+        let cache = &state
+            .as_ref()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    ErrorKind::WouldBlock,
+                    "This result is already regenerating or has been replaced.",
+                )
+            })?
+            .glyph_cache;
         let ordered_set: HashSet<&str> = ordered_paths.iter().map(String::as_str).collect();
         let mut previous_paths = HashSet::with_capacity(self.source_files.len());
         let mut changes = Vec::new();
 
-        for source_file in &self.source_files {
+        for source_file in self.source_files.iter() {
             previous_paths.insert(source_file.path.as_str());
             if !ordered_set.contains(source_file.path.as_str()) {
                 changes.push((source_file.path.clone(), GlyphChange::Removed));
@@ -241,7 +331,60 @@ impl GenerateWebfontsResult {
             }
         }
 
+        drop(state);
         self.regenerate(ordered_paths, &changes)
+    }
+
+    /// Asynchronously re-diff and rebuild on Tokio's blocking pool, consuming the old result and
+    /// returning the next result generation. This future is not cancellation-safe: dropping it
+    /// lets already-started blocking work finish and drops the consumed result.
+    ///
+    /// ```rust,no_run
+    /// use webfont_generator::{generate_sync, GenerateWebfontsOptions};
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let files = vec!["icons/add.svg".to_owned()];
+    /// let result = generate_sync(GenerateWebfontsOptions {
+    ///     files: files.clone(),
+    ///     dest: "dist".to_owned(),
+    ///     incremental: Some(true),
+    ///     ..Default::default()
+    /// }, None)?;
+    /// let result = result.regenerate_all_async(files).await?;
+    /// # let _ = result;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn regenerate_all_async(
+        self,
+        ordered_paths: Vec<String>,
+    ) -> Result<Self, RegenerateError> {
+        self.regenerate_in_background(ordered_paths, None).await
+    }
+
+    async fn regenerate_in_background(
+        mut self,
+        ordered_paths: Vec<String>,
+        changes: Option<Vec<(String, GlyphChange)>>,
+    ) -> Result<Self, RegenerateError> {
+        let task = tokio::task::spawn_blocking(move || {
+            let outcome = match changes {
+                Some(changes) => self.regenerate(&ordered_paths, &changes),
+                None => self.regenerate_all(&ordered_paths),
+            };
+            match outcome {
+                Ok(()) => Ok(self),
+                Err(source) => Err(RegenerateError::new(Some(self), source)),
+            }
+        });
+        match task.await {
+            Ok(result) => result,
+            Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+            Err(error) => Err(RegenerateError::new(
+                None,
+                std::io::Error::other(format!("asynchronous regeneration task failed: {error}")),
+            )),
+        }
     }
 }
 

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -810,10 +810,7 @@ fn consecutive_async_snapshots_invalidate_codepoint_dependent_css() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);
     let b = write_icon(&dir, "b", D2);
-    let template = write_temp_template(
-        "css-codepoints-async",
-        "{{#each codepoints}}{{this}}{{/each}}",
-    );
+    let template = write_temp_template("css-codepoints-async", "{{codepoints.a}}");
     let result = generate_with_templates(vec![a.clone(), b.clone()], true, Some(template), None);
     result.generate_css_pure(None).unwrap();
 
@@ -847,7 +844,7 @@ fn consecutive_async_snapshots_invalidate_name_dependent_html() {
     let dir = temp_dir();
     let a = write_icon(&dir, "a", D1);
     let b = write_icon(&dir, "b", D2);
-    let template = write_temp_template("html-names-async", "{{#each names}}{{this}}{{/each}}");
+    let template = write_temp_template("html-names-async", "{{names.0}}");
     let result = generate_with_templates(vec![a.clone(), b.clone()], true, None, Some(template));
     result.generate_html_pure(None).unwrap();
 

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use serde_json::{Map, Value};
 
 use crate::test_helpers::write_temp_template;
-use crate::types::{FontType, GenerateWebfontsResult, GlyphChange, LoadedSvgFile};
+use crate::types::{
+    FontType, GenerateWebfontsResult, GlyphChange, LoadedSvgFile, RegenerationState,
+};
 use crate::{FormatOptions, GenerateWebfontsOptions, TtfFormatOptions};
 use crate::{
     finalize_generate_webfonts_options, generate_webfonts_sync, resolve_generate_webfonts_options,
@@ -15,6 +17,14 @@ const D2: &str = "M2 2 L22 2 L12 22 Z";
 const D3: &str = "M4 4 L20 4 L20 20 L4 20 Z";
 const D_CHANGED: &str = "M0 0 L24 0 L24 24 Z";
 const TEST_TTF_TIMESTAMP: i64 = 1_700_000_000;
+
+fn with_regeneration_state<T>(
+    result: &GenerateWebfontsResult,
+    read: impl FnOnce(&RegenerationState) -> T,
+) -> T {
+    let state = result.regeneration_state.lock().unwrap();
+    read(state.as_ref().unwrap())
+}
 
 fn stable_format_options() -> FormatOptions {
     FormatOptions {
@@ -126,6 +136,56 @@ fn regenerate_after_content_change_matches_fresh() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+#[tokio::test]
+async fn regenerate_async_matches_fresh_and_recovers_after_failure() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let files = vec![a.clone(), b.clone()];
+    let result = generate(files.clone(), true);
+
+    std::fs::remove_file(&b).unwrap();
+    let error = match result
+        .regenerate_async(
+            files.clone(),
+            vec![(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .await
+    {
+        Err(error) => error,
+        Ok(_) => panic!("missing changed file should fail"),
+    };
+    let result = error
+        .into_result()
+        .expect("ordinary failures are recoverable");
+
+    write_icon(&dir, "b", D_CHANGED);
+    let result = result
+        .regenerate_async(
+            files.clone(),
+            vec![(b, GlyphChange::Changed { name: None })],
+        )
+        .await
+        .unwrap();
+    assert_same(&result, &generate(files, false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn regenerate_all_async_matches_fresh() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let files = vec![a.clone(), b.clone()];
+    let result = generate(files.clone(), true);
+
+    write_icon(&dir, "b", D_CHANGED);
+    let result = result.regenerate_all_async(files.clone()).await.unwrap();
+
+    assert_same(&result, &generate(files, false));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 #[test]
 fn regenerate_reuses_compiled_ttf_glyphs_for_stable_metrics() {
     let dir = temp_dir();
@@ -134,13 +194,14 @@ fn regenerate_reuses_compiled_ttf_glyphs_for_stable_metrics() {
     let c = write_icon(&dir, "c", D3);
 
     let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
-    let processed_before = result.glyph_cache.as_ref().unwrap().process_count;
-    let before = result.ttf_cache.as_ref().unwrap().compile_count;
-    let woff2_before = result
-        .ttf_cache
-        .as_ref()
-        .unwrap()
-        .woff2_transform_compile_count();
+    let (processed_before, before, woff2_before) = with_regeneration_state(&result, |state| {
+        let ttf = state.ttf_cache.as_ref().unwrap();
+        (
+            state.glyph_cache.process_count,
+            ttf.compile_count,
+            ttf.woff2_transform_compile_count(),
+        )
+    });
     write_icon(&dir, "b", D_CHANGED);
     result
         .regenerate(
@@ -151,16 +212,23 @@ fn regenerate_reuses_compiled_ttf_glyphs_for_stable_metrics() {
 
     assert_same(&result, &generate(vec![a, b, c], false));
     assert_eq!(
-        result.glyph_cache.as_ref().unwrap().process_count,
+        with_regeneration_state(&result, |state| state.glyph_cache.process_count),
         processed_before + 1
     );
-    assert_eq!(result.ttf_cache.as_ref().unwrap().compile_count, before + 1);
     assert_eq!(
-        result
+        with_regeneration_state(&result, |state| state
             .ttf_cache
             .as_ref()
             .unwrap()
-            .woff2_transform_compile_count(),
+            .compile_count),
+        before + 1
+    );
+    assert_eq!(
+        with_regeneration_state(&result, |state| state
+            .ttf_cache
+            .as_ref()
+            .unwrap()
+            .woff2_transform_compile_count()),
         woff2_before + 1
     );
     std::fs::remove_dir_all(&dir).ok();
@@ -174,17 +242,14 @@ fn regenerate_reuses_unchanged_ttf_tables_on_rename() {
     let c = write_icon(&dir, "c", D3);
 
     let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
-    let before = result.ttf_cache.as_ref().unwrap().table_compile_count;
-    let woff_before = result
-        .ttf_cache
-        .as_ref()
-        .unwrap()
-        .woff1_payload_compile_count();
-    let woff2_before = result
-        .ttf_cache
-        .as_ref()
-        .unwrap()
-        .woff2_transform_compile_count();
+    let (before, woff_before, woff2_before) = with_regeneration_state(&result, |state| {
+        let ttf = state.ttf_cache.as_ref().unwrap();
+        (
+            ttf.table_compile_count,
+            ttf.woff1_payload_compile_count(),
+            ttf.woff2_transform_compile_count(),
+        )
+    });
     result
         .regenerate(
             &[a.clone(), b.clone(), c.clone()],
@@ -198,23 +263,27 @@ fn regenerate_reuses_unchanged_ttf_tables_on_rename() {
         .unwrap();
 
     assert_eq!(
-        result.ttf_cache.as_ref().unwrap().table_compile_count,
+        with_regeneration_state(&result, |state| state
+            .ttf_cache
+            .as_ref()
+            .unwrap()
+            .table_compile_count),
         before + 1
     );
     assert_eq!(
-        result
+        with_regeneration_state(&result, |state| state
             .ttf_cache
             .as_ref()
             .unwrap()
-            .woff1_payload_compile_count(),
+            .woff1_payload_compile_count()),
         woff_before + 2
     );
     assert_eq!(
-        result
+        with_regeneration_state(&result, |state| state
             .ttf_cache
             .as_ref()
             .unwrap()
-            .woff2_transform_compile_count(),
+            .woff2_transform_compile_count()),
         woff2_before
     );
     std::fs::remove_dir_all(&dir).ok();
@@ -228,8 +297,12 @@ fn regenerate_recompiles_compiled_ttf_glyphs_after_metric_shift() {
     let c = write_icon(&dir, "c", D3);
 
     let mut result = generate(vec![a.clone(), b.clone(), c.clone()], true);
-    let processed_before = result.glyph_cache.as_ref().unwrap().process_count;
-    let before = result.ttf_cache.as_ref().unwrap().compile_count;
+    let (processed_before, before) = with_regeneration_state(&result, |state| {
+        (
+            state.glyph_cache.process_count,
+            state.ttf_cache.as_ref().unwrap().compile_count,
+        )
+    });
     write_icon_with_viewbox(&dir, "b", 24, 48, D_CHANGED);
     result
         .regenerate(
@@ -240,10 +313,17 @@ fn regenerate_recompiles_compiled_ttf_glyphs_after_metric_shift() {
 
     assert_same(&result, &generate(vec![a, b, c], false));
     assert_eq!(
-        result.glyph_cache.as_ref().unwrap().process_count,
+        with_regeneration_state(&result, |state| state.glyph_cache.process_count),
         processed_before + 3
     );
-    assert_eq!(result.ttf_cache.as_ref().unwrap().compile_count, before + 3);
+    assert_eq!(
+        with_regeneration_state(&result, |state| state
+            .ttf_cache
+            .as_ref()
+            .unwrap()
+            .compile_count),
+        before + 3
+    );
     std::fs::remove_dir_all(&dir).ok();
 }
 
@@ -343,11 +423,14 @@ fn regenerate_all_noop_returns_before_parsing() {
     let a = write_icon(&dir, "a", D1);
     let b = write_icon(&dir, "b", D2);
     let mut result = generate(vec![a.clone(), b.clone()], true);
-    let before = result.glyph_cache.as_ref().unwrap().parse_count;
+    let before = with_regeneration_state(&result, |state| state.glyph_cache.parse_count);
 
     result.regenerate_all(&[a, b]).unwrap();
 
-    assert_eq!(result.glyph_cache.as_ref().unwrap().parse_count, before);
+    assert_eq!(
+        with_regeneration_state(&result, |state| state.glyph_cache.parse_count),
+        before
+    );
     std::fs::remove_dir_all(&dir).ok();
 }
 
@@ -382,7 +465,7 @@ fn non_incremental_results_do_not_retain_glyph_cache() {
     let result = generate(vec![a], false);
 
     assert!(
-        result.glyph_cache.is_none(),
+        result.regeneration_state.lock().unwrap().is_none(),
         "one-shot builds must not retain parsed glyph geometry"
     );
     std::fs::remove_dir_all(&dir).ok();
@@ -394,11 +477,11 @@ fn incremental_results_seed_glyph_cache_for_active_files() {
     let a = write_icon(&dir, "a", D1);
     let b = write_icon(&dir, "b", D2);
     let result = generate(vec![a, b], true);
-    let cache = result.glyph_cache.as_ref().unwrap();
-
-    assert_eq!(cache.entries.len(), 2);
-    assert_eq!(cache.content_hashes.len(), 2);
-    assert_eq!(cache.by_content_hash.len(), 2);
+    with_regeneration_state(&result, |state| {
+        assert_eq!(state.glyph_cache.entries.len(), 2);
+        assert_eq!(state.glyph_cache.content_hashes.len(), 2);
+        assert_eq!(state.glyph_cache.by_content_hash.len(), 2);
+    });
     std::fs::remove_dir_all(&dir).ok();
 }
 
@@ -408,7 +491,7 @@ fn regenerate_noop_changed_event_returns_before_parsing() {
     let a = write_icon(&dir, "a", D1);
     let b = write_icon(&dir, "b", D2);
     let mut result = generate(vec![a.clone(), b.clone()], true);
-    let before = result.glyph_cache.as_ref().unwrap().parse_count;
+    let before = with_regeneration_state(&result, |state| state.glyph_cache.parse_count);
 
     result
         .regenerate(
@@ -418,7 +501,7 @@ fn regenerate_noop_changed_event_returns_before_parsing() {
         .unwrap();
 
     assert_eq!(
-        result.glyph_cache.as_ref().unwrap().parse_count,
+        with_regeneration_state(&result, |state| state.glyph_cache.parse_count),
         before,
         "unchanged watcher events should return before SVG parsing"
     );
@@ -432,7 +515,7 @@ fn regenerate_added_duplicate_reuses_content_addressed_cache() {
     let b = write_icon(&dir, "b", D2);
     let mut result = generate(vec![a.clone(), b.clone()], true);
     let c = write_icon(&dir, "c", D1);
-    let before = result.glyph_cache.as_ref().unwrap().parse_count;
+    let before = with_regeneration_state(&result, |state| state.glyph_cache.parse_count);
 
     result
         .regenerate(
@@ -447,7 +530,7 @@ fn regenerate_added_duplicate_reuses_content_addressed_cache() {
         .unwrap();
 
     assert_eq!(
-        result.glyph_cache.as_ref().unwrap().parse_count,
+        with_regeneration_state(&result, |state| state.glyph_cache.parse_count),
         before,
         "added files with SVG bytes already in the cache should not be parsed again"
     );
@@ -467,12 +550,13 @@ fn regenerate_remove_prunes_inactive_cache_entries() {
         .regenerate(&[a.clone(), c.clone()], &[(b, GlyphChange::Removed)])
         .unwrap();
 
-    let cache = result.glyph_cache.as_ref().unwrap();
-    assert_eq!(cache.entries.len(), 2);
-    assert_eq!(cache.content_hashes.len(), 2);
-    assert_eq!(cache.by_content_hash.len(), 2);
-    assert!(cache.entries.contains_key(&a));
-    assert!(cache.entries.contains_key(&c));
+    with_regeneration_state(&result, |state| {
+        assert_eq!(state.glyph_cache.entries.len(), 2);
+        assert_eq!(state.glyph_cache.content_hashes.len(), 2);
+        assert_eq!(state.glyph_cache.by_content_hash.len(), 2);
+        assert!(state.glyph_cache.entries.contains_key(&a));
+        assert!(state.glyph_cache.entries.contains_key(&c));
+    });
     assert_same(&result, &generate(vec![a, c], false));
     std::fs::remove_dir_all(&dir).ok();
 }
@@ -496,21 +580,23 @@ fn regenerate_add_remove_cycles_do_not_grow_cache() {
             )
             .unwrap();
 
-        let cache = result.glyph_cache.as_ref().unwrap();
-        assert_eq!(cache.entries.len(), 3);
-        assert_eq!(cache.content_hashes.len(), 3);
-        assert_eq!(cache.by_content_hash.len(), 3);
+        with_regeneration_state(&result, |state| {
+            assert_eq!(state.glyph_cache.entries.len(), 3);
+            assert_eq!(state.glyph_cache.content_hashes.len(), 3);
+            assert_eq!(state.glyph_cache.by_content_hash.len(), 3);
+        });
 
         result
             .regenerate(&[a.clone(), b.clone()], &[(extra, GlyphChange::Removed)])
             .unwrap();
 
-        let cache = result.glyph_cache.as_ref().unwrap();
-        assert_eq!(cache.entries.len(), 2);
-        assert_eq!(cache.content_hashes.len(), 2);
-        assert_eq!(cache.by_content_hash.len(), 2);
-        assert!(cache.entries.contains_key(&a));
-        assert!(cache.entries.contains_key(&b));
+        with_regeneration_state(&result, |state| {
+            assert_eq!(state.glyph_cache.entries.len(), 2);
+            assert_eq!(state.glyph_cache.content_hashes.len(), 2);
+            assert_eq!(state.glyph_cache.by_content_hash.len(), 2);
+            assert!(state.glyph_cache.entries.contains_key(&a));
+            assert!(state.glyph_cache.entries.contains_key(&b));
+        });
     }
 
     assert_same(&result, &generate(vec![a, b], false));
@@ -541,6 +627,7 @@ fn regenerate_failure_preserves_incremental_state_for_retry() {
     let c = dir.join("c.svg").to_string_lossy().into_owned();
     let mut result = generate(vec![a.clone(), b.clone()], true);
     let before = result.svg_string().unwrap().to_owned();
+    let parse_count = with_regeneration_state(&result, |state| state.glyph_cache.parse_count);
 
     let error = result
         .regenerate(
@@ -555,10 +642,15 @@ fn regenerate_failure_preserves_incremental_state_for_retry() {
         .expect_err("missing added file should fail");
     assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
     assert!(
-        result.glyph_cache.is_some(),
+        result.regeneration_state.lock().unwrap().is_some(),
         "failed regenerate must leave the incremental cache available"
     );
     assert_eq!(result.svg_string().unwrap(), before);
+    assert_eq!(
+        with_regeneration_state(&result, |state| state.glyph_cache.parse_count),
+        parse_count,
+        "failure before cache mutation should preserve the warm cache"
+    );
 
     write_icon(&dir, "c", D3);
     result
@@ -599,7 +691,7 @@ fn regenerate_rejects_duplicate_glyph_names() {
 
     assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
     assert!(error.to_string().contains("must be unique"));
-    assert!(result.glyph_cache.is_some());
+    assert!(result.regeneration_state.lock().unwrap().is_some());
     assert_eq!(result.svg_string().unwrap(), before);
     std::fs::remove_dir_all(&dir).ok();
 }
@@ -1117,6 +1209,31 @@ fn regenerate_writes_changed_outputs_and_skips_unchanged() {
         "an unchanged output must not be rewritten"
     );
 
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn regenerate_write_failure_restores_published_output() {
+    let dir = temp_dir();
+    let dest = dir.join("blocked-output");
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let files = vec![a.clone(), b.clone()];
+    let mut result = generate_writing(files.clone(), &dest);
+    let before = result.woff2_bytes().unwrap().to_vec();
+
+    std::fs::write(&dest, "not a directory").unwrap();
+    write_icon(&dir, "b", D_CHANGED);
+    result
+        .regenerate(&files, &[(b.clone(), GlyphChange::Changed { name: None })])
+        .expect_err("writing below a file must fail");
+    assert_eq!(result.woff2_bytes().unwrap(), before);
+
+    std::fs::remove_file(&dest).unwrap();
+    result
+        .regenerate(&files, &[(b, GlyphChange::Changed { name: None })])
+        .unwrap();
+    assert_same(&result, &generate_with_css(files, false));
     std::fs::remove_dir_all(&dir).ok();
 }
 

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -783,6 +783,102 @@ fn regenerate_reuses_provided_url_css_on_content_edit() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+#[cfg(feature = "napi")]
+#[test]
+fn async_snapshot_carries_reusable_render_cache() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let template = write_temp_template("css-static-async", ".icon { font-family: {{fontName}}; }");
+    let result = generate_with_templates(vec![a.clone(), b.clone()], true, Some(template), None);
+    result.generate_css_pure(None).unwrap();
+
+    let state = result.take_regeneration_state().unwrap();
+    let mut replacement = result.snapshot_for_regeneration(state);
+    write_icon(&dir, "b", D_CHANGED);
+    replacement
+        .regenerate(&[a, b.clone()], &[(b, GlyphChange::Changed { name: None })])
+        .unwrap();
+
+    assert!(replacement.has_carried_css_no_urls_for_test());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "napi")]
+#[test]
+fn consecutive_async_snapshots_invalidate_codepoint_dependent_css() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let template = write_temp_template(
+        "css-codepoints-async",
+        "{{#each codepoints}}{{this}}{{/each}}",
+    );
+    let result = generate_with_templates(vec![a.clone(), b.clone()], true, Some(template), None);
+    result.generate_css_pure(None).unwrap();
+
+    let state = result.take_regeneration_state().unwrap();
+    let mut first = result.snapshot_for_regeneration(state);
+    write_icon(&dir, "b", D_CHANGED);
+    first
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+    assert!(first.has_carried_css_no_urls_for_test());
+
+    let state = first.take_regeneration_state().unwrap();
+    let mut second = first.snapshot_for_regeneration(state);
+    let c = write_icon(&dir, "c", D3);
+    second
+        .regenerate(
+            &[a, b, c.clone()],
+            &[(c, GlyphChange::Added { name: None })],
+        )
+        .unwrap();
+    assert!(!second.has_carried_css_no_urls_for_test());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[cfg(feature = "napi")]
+#[test]
+fn consecutive_async_snapshots_invalidate_name_dependent_html() {
+    let dir = temp_dir();
+    let a = write_icon(&dir, "a", D1);
+    let b = write_icon(&dir, "b", D2);
+    let template = write_temp_template("html-names-async", "{{#each names}}{{this}}{{/each}}");
+    let result = generate_with_templates(vec![a.clone(), b.clone()], true, None, Some(template));
+    result.generate_html_pure(None).unwrap();
+
+    let state = result.take_regeneration_state().unwrap();
+    let mut first = result.snapshot_for_regeneration(state);
+    write_icon(&dir, "b", D_CHANGED);
+    first
+        .regenerate(
+            &[a.clone(), b.clone()],
+            &[(b.clone(), GlyphChange::Changed { name: None })],
+        )
+        .unwrap();
+    assert!(first.has_carried_html_no_urls_for_test());
+
+    let state = first.take_regeneration_state().unwrap();
+    let mut second = first.snapshot_for_regeneration(state);
+    second
+        .regenerate(
+            &[a, b.clone()],
+            &[(
+                b,
+                GlyphChange::Changed {
+                    name: Some("renamed".to_owned()),
+                },
+            )],
+        )
+        .unwrap();
+    assert!(!second.has_carried_html_no_urls_for_test());
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 #[test]
 fn regenerate_rerenders_default_css_on_content_edit() {
     let dir = temp_dir();

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -103,12 +103,12 @@ use write::write_generate_webfonts_result;
 
 pub use types::{
     CssContext, FontType, FormatOptions, GenerateWebfontsOptions, GenerateWebfontsResult,
-    GlyphChange, GlyphChangeEntry, HtmlContext, SvgFormatOptions, TtfFormatOptions,
-    Woff2FormatOptions, WoffFormatOptions,
+    GlyphChange, GlyphChangeEntry, HtmlContext, RegenerateError, SvgFormatOptions,
+    TtfFormatOptions, Woff2FormatOptions, WoffFormatOptions,
 };
 use types::{
-    DEFAULT_FONT_ORDER, FontOutputs, LoadedSvgFile, ResolvedGenerateWebfontsOptions,
-    resolved_font_types,
+    DEFAULT_FONT_ORDER, FontOutputs, LoadedSvgFile, RegenerationState,
+    ResolvedGenerateWebfontsOptions, resolved_font_types,
 };
 
 #[cfg(feature = "bench")]
@@ -287,7 +287,9 @@ pub mod bench_support {
 
     /// Clear retained WOFF1 payloads so benchmarks can compare warm vs cold compression cache.
     pub fn clear_woff1_payload_cache(result: &mut GenerateWebfontsResult) {
-        if let Some(cache) = result.ttf_cache.as_mut() {
+        if let Some(state) = result.regeneration_state.lock().unwrap().as_mut()
+            && let Some(cache) = state.ttf_cache.as_mut()
+        {
             cache.clear_woff1_payloads();
         }
     }
@@ -417,7 +419,7 @@ pub async fn generate_webfonts(
         && let Some(written) = write_generate_webfonts_result(&result).await?
     {
         // Only incremental results can call `regenerate`, so only they need write-skip state.
-        result.written_outputs = written;
+        result.seed_written_outputs(written);
     }
 
     Ok(result)
@@ -438,7 +440,7 @@ pub async fn generate(
     let mut resolved_options = resolve_generate_webfonts_options(options)?;
     finalize_generate_webfonts_options(&mut resolved_options, &source_files)?;
 
-    let mut result =
+    let result =
         tokio::task::spawn_blocking(move || generate_webfonts_sync(resolved_options, source_files))
             .await
             .map_err(std::io::Error::other)??;
@@ -447,7 +449,7 @@ pub async fn generate(
         && let Some(written) = write_generate_webfonts_result(&result).await?
     {
         // Only incremental results can call `regenerate`, so only they need write-skip state.
-        result.written_outputs = written;
+        result.seed_written_outputs(written);
     }
 
     Ok(result)
@@ -646,18 +648,22 @@ fn generate_webfonts_sync(
         (prepare_svg_font(&svg_options, &source_files)?, None, None)
     };
     let fonts = build_font_outputs(&options, &svg_options, &prepared, ttf_cache.as_mut())?;
+    let regeneration_state = glyph_cache.map(|glyph_cache| RegenerationState {
+        caches_dirty: false,
+        glyph_cache,
+        ttf_cache,
+        written_outputs: std::collections::HashMap::new(),
+    });
 
     Ok(GenerateWebfontsResult {
         cached: std::sync::OnceLock::new(),
         carried_render: None,
         css_context: None,
         fonts,
-        glyph_cache,
         html_context: None,
-        options,
-        source_files,
-        ttf_cache,
-        written_outputs: std::collections::HashMap::new(),
+        options: std::sync::Arc::new(options),
+        regeneration_state: std::sync::Arc::new(std::sync::Mutex::new(regeneration_state)),
+        source_files: std::sync::Arc::new(source_files),
     })
 }
 

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -384,6 +384,13 @@ pub(crate) struct RenderCache {
     html_last_result: Option<String>,
 }
 
+#[derive(Clone)]
+pub(crate) struct CarriedRenderCache {
+    cache: RenderCache,
+    css_dependencies: TemplateDependencies,
+    html_dependencies: TemplateDependencies,
+}
+
 pub(crate) struct CachedTemplateData {
     pub shared: SharedTemplateData,
     pub css_context: Map<String, Value>,
@@ -502,7 +509,7 @@ pub struct GenerateWebfontsResult {
     /// Render-cache entries carried across an incremental `regenerate` to seed the rebuilt
     /// [`CachedTemplateData`], so CSS/HTML that
     /// doesn't depend on what changed isn't re-rendered. `None` for a normal build.
-    pub(crate) carried_render: Option<RenderCache>,
+    pub(crate) carried_render: Option<CarriedRenderCache>,
     pub(crate) css_context: Option<Map<String, Value>>,
     pub(crate) fonts: FontOutputs,
     pub(crate) html_context: Option<Map<String, Value>>,
@@ -514,10 +521,10 @@ pub struct GenerateWebfontsResult {
 // Pure Rust getters (always available)
 impl GenerateWebfontsResult {
     #[cfg(any(feature = "napi", feature = "bench"))]
-    fn snapshot_for_regeneration(&self, state: RegenerationState) -> Self {
+    pub(crate) fn snapshot_for_regeneration(&self, state: RegenerationState) -> Self {
         Self {
             cached: OnceLock::new(),
-            carried_render: None,
+            carried_render: self.render_cache_source(),
             css_context: self.css_context.clone(),
             fonts: self.fonts.clone(),
             html_context: self.html_context.clone(),
@@ -589,14 +596,14 @@ impl GenerateWebfontsResult {
     pub(crate) fn has_carried_css_no_urls_for_test(&self) -> bool {
         self.carried_render
             .as_ref()
-            .is_some_and(|cache| cache.css_no_urls.is_some())
+            .is_some_and(|carried| carried.cache.css_no_urls.is_some())
     }
 
     #[cfg(test)]
     pub(crate) fn has_carried_html_no_urls_for_test(&self) -> bool {
         self.carried_render
             .as_ref()
-            .is_some_and(|cache| cache.html_no_urls.is_some())
+            .is_some_and(|carried| carried.cache.html_no_urls.is_some())
     }
 
     /// Returns the EOT font bytes, if generated.
@@ -658,7 +665,12 @@ impl GenerateWebfontsResult {
                     html_registry,
                     // Seed with entries carried across a regenerate;
                     // these are renders that don't depend on what changed, so reusing them is safe.
-                    render_cache: Mutex::new(self.carried_render.clone().unwrap_or_default()),
+                    render_cache: Mutex::new(
+                        self.carried_render
+                            .as_ref()
+                            .map(|carried| carried.cache.clone())
+                            .unwrap_or_default(),
+                    ),
                 })
             })
             .as_ref()
@@ -669,29 +681,29 @@ impl GenerateWebfontsResult {
         &self,
         names_unchanged: bool,
         codepoints_unchanged: bool,
-    ) -> Option<RenderCache> {
-        self.cached
-            .get()
-            .and_then(|cached| cached.as_ref().ok())
-            .map(|cached| {
-                let css_deps = cached.shared.css_template_dependencies;
-                let css_no_urls_unchanged =
-                    css_deps.can_reuse_css_no_urls(names_unchanged, codepoints_unchanged);
-                let css_with_urls_unchanged =
-                    css_deps.can_reuse_css_with_urls(names_unchanged, codepoints_unchanged);
-                let html_no_urls_unchanged = cached.html_template_dependencies.can_reuse_html(
-                    names_unchanged,
-                    codepoints_unchanged,
-                    css_no_urls_unchanged,
-                );
-                let html_with_urls_unchanged = cached.html_template_dependencies.can_reuse_html(
-                    names_unchanged,
-                    codepoints_unchanged,
-                    css_with_urls_unchanged,
-                );
+    ) -> Option<CarriedRenderCache> {
+        self.render_cache_source().map(|carried| {
+            let css_deps = carried.css_dependencies;
+            let css_no_urls_unchanged =
+                css_deps.can_reuse_css_no_urls(names_unchanged, codepoints_unchanged);
+            let css_with_urls_unchanged =
+                css_deps.can_reuse_css_with_urls(names_unchanged, codepoints_unchanged);
+            let html_no_urls_unchanged = carried.html_dependencies.can_reuse_html(
+                names_unchanged,
+                codepoints_unchanged,
+                css_no_urls_unchanged,
+            );
+            let html_with_urls_unchanged = carried.html_dependencies.can_reuse_html(
+                names_unchanged,
+                codepoints_unchanged,
+                css_with_urls_unchanged,
+            );
 
-                let rc = cached.render_cache.lock().unwrap();
-                RenderCache {
+            let rc = carried.cache;
+            CarriedRenderCache {
+                css_dependencies: carried.css_dependencies,
+                html_dependencies: carried.html_dependencies,
+                cache: RenderCache {
                     css_no_urls: css_no_urls_unchanged
                         .then(|| rc.css_no_urls.clone())
                         .flatten(),
@@ -710,8 +722,21 @@ impl GenerateWebfontsResult {
                     html_last_result: html_with_urls_unchanged
                         .then(|| rc.html_last_result.clone())
                         .flatten(),
-                }
+                },
+            }
+        })
+    }
+
+    fn render_cache_source(&self) -> Option<CarriedRenderCache> {
+        self.cached
+            .get()
+            .and_then(|cached| cached.as_ref().ok())
+            .map(|cached| CarriedRenderCache {
+                cache: cached.render_cache.lock().unwrap().clone(),
+                css_dependencies: cached.shared.css_template_dependencies,
+                html_dependencies: cached.html_template_dependencies,
             })
+            .or_else(|| self.carried_render.clone())
     }
 
     /// Generate a CSS string for this webfont result.

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -398,7 +398,7 @@ pub(crate) struct CachedTemplateData {
 /// Rendered bytes for each requested output format. Held by [`GenerateWebfontsResult`] and
 /// produced by the generator's format pipeline; grouping them lets an incremental regenerate
 /// refresh every format in a single assignment.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct FontOutputs {
     pub(crate) svg_font: Option<Arc<String>>,
     pub(crate) ttf_font: Option<Arc<Vec<u8>>>,
@@ -407,34 +407,184 @@ pub(crate) struct FontOutputs {
     pub(crate) eot_font: Option<Arc<Vec<u8>>>,
 }
 
+pub(crate) struct RegenerationState {
+    pub(crate) caches_dirty: bool,
+    pub(crate) glyph_cache: GlyphCache,
+    pub(crate) ttf_cache: Option<TtfGlyphCache>,
+    pub(crate) written_outputs: HashMap<String, [u8; 16]>,
+}
+
+pub(crate) struct RegenerationStateLease {
+    slot: Arc<Mutex<Option<RegenerationState>>>,
+    state: Option<RegenerationState>,
+    keep_caches: bool,
+}
+
+/// Failure from asynchronous regeneration. Ordinary regeneration errors retain the input result
+/// so callers can recover it with [`RegenerateError::into_result`] and retry.
+pub struct RegenerateError {
+    result: Option<Box<GenerateWebfontsResult>>,
+    source: std::io::Error,
+}
+
+impl RegenerateError {
+    pub(crate) fn new(result: Option<GenerateWebfontsResult>, source: std::io::Error) -> Self {
+        Self {
+            result: result.map(Box::new),
+            source,
+        }
+    }
+
+    /// Return the result that was consumed by the failed operation. This is `None` only if the
+    /// blocking task was cancelled by the runtime before it could return the result.
+    pub fn into_result(self) -> Option<GenerateWebfontsResult> {
+        self.result.map(|result| *result)
+    }
+
+    /// Return both the recoverable result and the underlying I/O error.
+    pub fn into_parts(self) -> (Option<GenerateWebfontsResult>, std::io::Error) {
+        (self.result.map(|result| *result), self.source)
+    }
+}
+
+impl std::fmt::Debug for RegenerateError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RegenerateError")
+            .field("recoverable", &self.result.is_some())
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+impl std::fmt::Display for RegenerateError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl std::error::Error for RegenerateError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl RegenerationStateLease {
+    pub(crate) fn state_mut(&mut self) -> &mut RegenerationState {
+        self.state.as_mut().unwrap()
+    }
+
+    pub(crate) fn commit(mut self) {
+        self.keep_caches = true;
+    }
+}
+
+impl Drop for RegenerationStateLease {
+    fn drop(&mut self) {
+        let mut state = self.state.take().unwrap();
+        if !self.keep_caches && state.caches_dirty {
+            state.glyph_cache = GlyphCache::default();
+            if state.ttf_cache.is_some() {
+                state.ttf_cache = Some(TtfGlyphCache::default());
+            }
+        }
+        state.caches_dirty = false;
+        *self.slot.lock().unwrap() = Some(state);
+    }
+}
+
 /// Result of a successful `generateWebfonts` call. Exposes the generated
 /// font bytes (or `null` for formats that were not requested) and methods to
 /// render the CSS and HTML preview.
 #[cfg_attr(feature = "napi", napi)]
 pub struct GenerateWebfontsResult {
     pub(crate) cached: OnceLock<Result<CachedTemplateData, String>>,
-    /// Render-cache entries carried across an incremental `regenerate` (set by
-    /// [`reset_render_cache`]) to seed the rebuilt [`CachedTemplateData`], so CSS/HTML that
+    /// Render-cache entries carried across an incremental `regenerate` to seed the rebuilt
+    /// [`CachedTemplateData`], so CSS/HTML that
     /// doesn't depend on what changed isn't re-rendered. `None` for a normal build.
     pub(crate) carried_render: Option<RenderCache>,
     pub(crate) css_context: Option<Map<String, Value>>,
     pub(crate) fonts: FontOutputs,
-    /// Parsed-glyph cache for incremental `regenerate`; `Some` only when `incremental` is set.
-    pub(crate) glyph_cache: Option<GlyphCache>,
     pub(crate) html_context: Option<Map<String, Value>>,
-    pub(crate) options: ResolvedGenerateWebfontsOptions,
-    pub(crate) source_files: Vec<LoadedSvgFile>,
-    /// Compiled TTF outline cache for incremental TTF-derived output rebuilds.
-    pub(crate) ttf_cache: Option<TtfGlyphCache>,
-    /// Hash per CSS/HTML output path of what was last written to disk. Seeded by the initial write
-    /// when `write_files` is enabled, then updated by incremental `regenerate` writes so unchanged
-    /// rendered companion files are not rewritten. Font outputs are written directly after real
-    /// rebuilds because they almost always change and hashing them is slower than writing them.
-    pub(crate) written_outputs: HashMap<String, [u8; 16]>,
+    pub(crate) options: Arc<ResolvedGenerateWebfontsOptions>,
+    pub(crate) regeneration_state: Arc<Mutex<Option<RegenerationState>>>,
+    pub(crate) source_files: Arc<Vec<LoadedSvgFile>>,
 }
 
 // Pure Rust getters (always available)
 impl GenerateWebfontsResult {
+    #[cfg(any(feature = "napi", feature = "bench"))]
+    fn snapshot_for_regeneration(&self, state: RegenerationState) -> Self {
+        Self {
+            cached: OnceLock::new(),
+            carried_render: None,
+            css_context: self.css_context.clone(),
+            fonts: self.fonts.clone(),
+            html_context: self.html_context.clone(),
+            options: self.options.clone(),
+            regeneration_state: Arc::new(Mutex::new(Some(state))),
+            source_files: self.source_files.clone(),
+        }
+    }
+
+    pub(crate) fn take_regeneration_state(&self) -> std::io::Result<RegenerationState> {
+        if !self.options.incremental {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "regenerate requires the font to be generated with `incremental` enabled.",
+            ));
+        }
+        self.regeneration_state
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "This result is already regenerating or has been replaced.",
+                )
+            })
+    }
+
+    pub(crate) fn take_regeneration_state_lease(&self) -> std::io::Result<RegenerationStateLease> {
+        Ok(RegenerationStateLease {
+            slot: Arc::clone(&self.regeneration_state),
+            state: Some(self.take_regeneration_state()?),
+            keep_caches: false,
+        })
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn restore_regeneration_state(&self, state: RegenerationState) {
+        *self.regeneration_state.lock().unwrap() = Some(state);
+    }
+
+    pub(crate) fn seed_written_outputs(&self, written_outputs: HashMap<String, [u8; 16]>) {
+        if let Some(state) = self.regeneration_state.lock().unwrap().as_mut() {
+            state.written_outputs = written_outputs;
+        }
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "bench")]
+    pub fn regenerate_owned_for_bench(
+        &self,
+        files: &[String],
+        changes: &[(String, GlyphChange)],
+    ) -> std::io::Result<Self> {
+        let state = self.take_regeneration_state()?;
+        let mut replacement = self.snapshot_for_regeneration(state);
+        match replacement.regenerate(files, changes) {
+            Ok(()) => Ok(replacement),
+            Err(error) => {
+                if let Ok(state) = replacement.take_regeneration_state() {
+                    self.restore_regeneration_state(state);
+                }
+                Err(error)
+            }
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn has_carried_css_no_urls_for_test(&self) -> bool {
         self.carried_render
@@ -506,7 +656,7 @@ impl GenerateWebfontsResult {
                     html_hbs_context: Mutex::new(html_hbs_context),
                     html_template_dependencies,
                     html_registry,
-                    // Seed with any entries carried across a regenerate (see reset_render_cache);
+                    // Seed with entries carried across a regenerate;
                     // these are renders that don't depend on what changed, so reusing them is safe.
                     render_cache: Mutex::new(self.carried_render.clone().unwrap_or_default()),
                 })
@@ -515,12 +665,12 @@ impl GenerateWebfontsResult {
             .map_err(to_io_err)
     }
 
-    /// Reset the lazily-built template/render cache after an incremental `regenerate`. Template
-    /// data (font hash, `src`, contexts) is rebuilt fresh, but rendered strings that provably do
-    /// not depend on changed template inputs are carried forward into the next cache.
-    pub(crate) fn reset_render_cache(&mut self, names_unchanged: bool, codepoints_unchanged: bool) {
-        let carried = self
-            .cached
+    pub(crate) fn reusable_render_cache(
+        &self,
+        names_unchanged: bool,
+        codepoints_unchanged: bool,
+    ) -> Option<RenderCache> {
+        self.cached
             .get()
             .and_then(|cached| cached.as_ref().ok())
             .map(|cached| {
@@ -561,11 +711,7 @@ impl GenerateWebfontsResult {
                         .then(|| rc.html_last_result.clone())
                         .flatten(),
                 }
-            });
-        self.cached = OnceLock::new();
-        self.css_context = None;
-        self.html_context = None;
-        self.carried_render = carried;
+            })
     }
 
     /// Generate a CSS string for this webfont result.
@@ -776,30 +922,83 @@ impl GenerateWebfontsResult {
         files: Vec<String>,
         changes: Option<Vec<GlyphChangeEntry>>,
     ) -> napi::Result<()> {
-        let Some(changes) = changes else {
-            return self
-                .regenerate_all(&files)
-                .map_err(crate::util::to_napi_err);
-        };
-        let changes = changes
-            .into_iter()
-            .map(|entry| {
-                let change = match entry.change_type.as_str() {
-                    "added" => GlyphChange::Added { name: entry.name },
-                    "changed" => GlyphChange::Changed { name: entry.name },
-                    "removed" => GlyphChange::Removed,
-                    other => {
-                        return Err(napi::Error::from_reason(format!(
-                            "Unknown changeType '{other}'; expected 'added', 'changed', or 'removed'."
-                        )));
-                    }
-                };
-                Ok((entry.path, change))
-            })
-            .collect::<napi::Result<Vec<_>>>()?;
-        self.regenerate(&files, &changes)
-            .map_err(crate::util::to_napi_err)
+        let changes = parse_glyph_changes(changes)?;
+        match changes {
+            Some(changes) => self.regenerate(&files, &changes),
+            None => self.regenerate_all(&files),
+        }
+        .map_err(crate::util::to_napi_err)
     }
+
+    /// Rebuild off the Node.js event loop and resolve with a replacement result. The receiver
+    /// remains readable and unchanged while regeneration runs and after failure. Assign the
+    /// resolved result before starting another regeneration. Overlapping calls on the same result
+    /// lineage are rejected, and disk writes remain non-transactional.
+    #[napi(js_name = "regenerateAsync")]
+    pub async fn regenerate_async_from_js(
+        &self,
+        files: Vec<String>,
+        changes: Option<Vec<GlyphChangeEntry>>,
+    ) -> napi::Result<GenerateWebfontsResult> {
+        let changes = parse_glyph_changes(changes)?;
+        let state = self
+            .take_regeneration_state()
+            .map_err(crate::util::to_napi_err)?;
+        let original_state = Arc::clone(&self.regeneration_state);
+        let mut replacement = self.snapshot_for_regeneration(state);
+        tokio::task::spawn_blocking(move || -> std::io::Result<GenerateWebfontsResult> {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match changes {
+                Some(changes) => replacement.regenerate(&files, &changes),
+                None => replacement.regenerate_all(&files),
+            }));
+            match result {
+                Ok(Ok(())) => Ok(replacement),
+                Ok(Err(error)) => {
+                    if let Ok(state) = replacement.take_regeneration_state() {
+                        *original_state.lock().unwrap() = Some(state);
+                    }
+                    Err(error)
+                }
+                Err(payload) => {
+                    if let Ok(state) = replacement.take_regeneration_state() {
+                        *original_state.lock().unwrap() = Some(state);
+                    }
+                    std::panic::resume_unwind(payload)
+                }
+            }
+        })
+        .await
+        .map_err(|error| {
+            napi::Error::from_reason(format!("Native webfont regeneration task failed: {error}"))
+        })?
+        .map_err(crate::util::to_napi_err)
+    }
+}
+
+#[cfg(feature = "napi")]
+fn parse_glyph_changes(
+    changes: Option<Vec<GlyphChangeEntry>>,
+) -> napi::Result<Option<Vec<(String, GlyphChange)>>> {
+    changes
+        .map(|changes| {
+            changes
+                .into_iter()
+                .map(|entry| {
+                    let change = match entry.change_type.as_str() {
+                        "added" => GlyphChange::Added { name: entry.name },
+                        "changed" => GlyphChange::Changed { name: entry.name },
+                        "removed" => GlyphChange::Removed,
+                        other => {
+                            return Err(napi::Error::from_reason(format!(
+                                "Unknown changeType '{other}'; expected 'added', 'changed', or 'removed'."
+                            )));
+                        }
+                    };
+                    Ok((entry.path, change))
+                })
+                .collect()
+        })
+        .transpose()
 }
 
 #[cfg(feature = "napi")]
@@ -884,12 +1083,10 @@ mod tests {
             carried_render: None,
             css_context: None,
             fonts: FontOutputs::default(),
-            glyph_cache: None,
             html_context: None,
-            options: resolved,
-            source_files,
-            ttf_cache: None,
-            written_outputs: Default::default(),
+            options: Arc::new(resolved),
+            regeneration_state: Arc::new(Mutex::new(None)),
+            source_files: Arc::new(source_files),
         };
 
         if let Some(dir) = cleanup_dir {
@@ -1157,12 +1354,10 @@ mod tests {
             carried_render: None,
             css_context: None,
             fonts: FontOutputs::default(),
-            glyph_cache: None,
             html_context: None,
-            options: resolved,
-            source_files,
-            ttf_cache: None,
-            written_outputs: Default::default(),
+            options: Arc::new(resolved),
+            regeneration_state: Arc::new(Mutex::new(None)),
+            source_files: Arc::new(source_files),
         }
     }
 

--- a/packages/webfont-generator/src/write.rs
+++ b/packages/webfont-generator/src/write.rs
@@ -165,14 +165,14 @@ fn output_hash(bytes: &[u8]) -> [u8; 16] {
 /// Font outputs are written directly after a real rebuild; only CSS/HTML are hash-checked because
 /// they often remain byte-identical after a geometry-only edit.
 pub(crate) fn write_generate_webfonts_result_sync(
-    result: &mut GenerateWebfontsResult,
+    result: &GenerateWebfontsResult,
+    written: &mut HashMap<String, [u8; 16]>,
 ) -> std::io::Result<()> {
     let outputs = collect_write_outputs(result)?;
 
     // Write everything, updating `written_outputs` in place. Updating in place (rather than
     // taking the map and restoring it at the end) means a mid-write failure keeps the hashes of the
     // outputs already written, so a retry doesn't needlessly rewrite them.
-    let written = &mut result.written_outputs;
     for output in outputs {
         if output.skip_unchanged {
             write_output_file_if_changed(written, output.path, output.contents.as_bytes())?;

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -708,3 +708,91 @@ describe('regenerate (incremental)', () => {
         expect(() => result.regenerate([a], [{ path: a, changeType: 'changed' }])).toThrow(/incremental/);
     });
 });
+
+describe('regenerateAsync (incremental)', () => {
+    it('is byte-identical to synchronous regeneration', async () => {
+        const dir = await createTempDir('regen-async-parity-');
+        const [a, b] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b')]);
+        const options = { ...regenBaseOpts(dir, [a, b]), incremental: true };
+        const [syncResult, asyncSource] = await Promise.all([generateWebfonts(options), generateWebfonts(options)]);
+
+        await writeFile(b, regenIcon(REGEN_PATHS.changed));
+        const changes = [{ path: b, changeType: 'changed' as const }];
+        syncResult.regenerate([a, b], changes);
+        const asyncResult = await asyncSource.regenerateAsync([a, b], changes);
+
+        expect(asyncResult).toEqualFont(syncResult);
+        expect(asyncResult).toEqualCss(syncResult);
+        expect(asyncResult.generateHtml()).toBe(syncResult.generateHtml());
+    });
+
+    it('returns a replacement while leaving the original unchanged', async () => {
+        const dir = await createTempDir('regen-async-');
+        const [a, b] = await Promise.all([writeRegenIcon(dir, 'a', 'a'), writeRegenIcon(dir, 'b', 'b')]);
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a, b]), incremental: true });
+        const before = result.svg;
+
+        await writeFile(b, regenIcon(REGEN_PATHS.changed));
+        const replacement = await result.regenerateAsync([a, b], [{ path: b, changeType: 'changed' }]);
+
+        expect(result.svg).toBe(before);
+        expect(replacement.svg).not.toBe(before);
+        expect(replacement).toEqualFont(await generateWebfonts(regenBaseOpts(dir, [a, b])));
+        await expect(result.regenerateAsync([a, b])).rejects.toThrow(/replaced/);
+    });
+
+    it('keeps the original readable after a failed rebuild', async () => {
+        const dir = await createTempDir('regen-async-fail-');
+        const a = await writeRegenIcon(dir, 'a', 'a');
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a]), incremental: true });
+        const before = result.svg;
+
+        await rm(a);
+        await expect(result.regenerateAsync([a], [{ path: a, changeType: 'changed' }])).rejects.toThrow(/No such file|ENOENT/);
+        expect(result.svg).toBe(before);
+
+        await writeRegenIcon(dir, 'a', 'a');
+        const replacement = await result.regenerateAsync([a], [{ path: a, changeType: 'changed' }]);
+        expect(replacement).toEqualFont(await generateWebfonts(regenBaseOpts(dir, [a])));
+    });
+
+    it('rejects overlapping rebuilds on the same result lineage', async () => {
+        const dir = await createTempDir('regen-async-overlap-');
+        const a = await writeRegenIcon(dir, 'a', 'a');
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, [a]), incremental: true });
+        const replacement = await result.regenerateAsync([a]);
+
+        const first = replacement.regenerateAsync([a]);
+        await expect(replacement.regenerateAsync([a])).rejects.toThrow(/regenerating|replaced/);
+        await first;
+    });
+
+    it('does not block the event loop during a rebuild', async () => {
+        const dir = await createTempDir('regen-async-responsive-');
+        const files = await Promise.all(Array.from({ length: 64 }, (_, index) => writeRegenIcon(dir, `icon-${index}`, 'a')));
+        const result = await generateWebfonts({ ...regenBaseOpts(dir, files), incremental: true });
+
+        await writeFile(files[0], regenIcon(REGEN_PATHS.changed));
+        const regeneration = result.regenerateAsync(files, [{ path: files[0], changeType: 'changed' }]);
+        const published = {
+            svg: result.svg,
+            ttf: result.ttf,
+            eot: result.eot,
+            woff: result.woff,
+            woff2: result.woff2,
+            css: result.generateCss(),
+            html: result.generateHtml(),
+        };
+        expect(result.svg).toBe(published.svg);
+        expect(result.ttf).toEqual(published.ttf);
+        expect(result.eot).toEqual(published.eot);
+        expect(result.woff).toEqual(published.woff);
+        expect(result.woff2).toEqual(published.woff2);
+        expect(result.generateCss()).toBe(published.css);
+        expect(result.generateHtml()).toBe(published.html);
+        const firstSettled = await Promise.race([regeneration.then(() => 'regeneration'), new Promise(resolve => setTimeout(() => resolve('timer'), 0))]);
+
+        expect(firstSettled).toBe('timer');
+        await regeneration;
+    });
+});

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -748,7 +748,7 @@ describe('regenerateAsync (incremental)', () => {
         const before = result.svg;
 
         await rm(a);
-        await expect(result.regenerateAsync([a], [{ path: a, changeType: 'changed' }])).rejects.toThrow(/No such file|ENOENT/);
+        await expect(result.regenerateAsync([a], [{ path: a, changeType: 'changed' }])).rejects.toThrow(/No such file|ENOENT|cannot find the file/i);
         expect(result.svg).toBe(before);
 
         await writeRegenIcon(dir, 'a', 'a');
@@ -762,14 +762,17 @@ describe('regenerateAsync (incremental)', () => {
         const result = await generateWebfonts({ ...regenBaseOpts(dir, [a]), incremental: true });
         const replacement = await result.regenerateAsync([a]);
 
-        const first = replacement.regenerateAsync([a]);
-        await expect(replacement.regenerateAsync([a])).rejects.toThrow(/regenerating|replaced/);
-        await first;
+        const outcomes = await Promise.allSettled([replacement.regenerateAsync([a]), replacement.regenerateAsync([a])]);
+
+        expect(outcomes.filter(outcome => outcome.status === 'fulfilled')).toHaveLength(1);
+        expect(outcomes.filter(outcome => outcome.status === 'rejected')).toEqual([
+            expect.objectContaining({ reason: expect.objectContaining({ message: expect.stringMatching(/regenerating|replaced/) }) }),
+        ]);
     });
 
     it('does not block the event loop during a rebuild', async () => {
         const dir = await createTempDir('regen-async-responsive-');
-        const files = await Promise.all(Array.from({ length: 64 }, (_, index) => writeRegenIcon(dir, `icon-${index}`, 'a')));
+        const files = await Promise.all(Array.from({ length: 600 }, (_, index) => writeRegenIcon(dir, `icon-${index}`, 'a')));
         const result = await generateWebfonts({ ...regenBaseOpts(dir, files), incremental: true });
 
         await writeFile(files[0], regenIcon(REGEN_PATHS.changed));

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -770,9 +770,9 @@ describe('regenerateAsync (incremental)', () => {
         ]);
     });
 
-    it('does not block the event loop during a rebuild', async () => {
+    it('returns a pending promise while rebuilding', async () => {
         const dir = await createTempDir('regen-async-responsive-');
-        const files = await Promise.all(Array.from({ length: 600 }, (_, index) => writeRegenIcon(dir, `icon-${index}`, 'a')));
+        const files = await Promise.all(Array.from({ length: 64 }, (_, index) => writeRegenIcon(dir, `icon-${index}`, 'a')));
         const result = await generateWebfonts({ ...regenBaseOpts(dir, files), incremental: true });
 
         await writeFile(files[0], regenIcon(REGEN_PATHS.changed));
@@ -793,9 +793,9 @@ describe('regenerateAsync (incremental)', () => {
         expect(result.woff2).toEqual(published.woff2);
         expect(result.generateCss()).toBe(published.css);
         expect(result.generateHtml()).toBe(published.html);
-        const firstSettled = await Promise.race([regeneration.then(() => 'regeneration'), new Promise(resolve => setTimeout(() => resolve('timer'), 0))]);
+        const firstSettled = await Promise.race([regeneration.then(() => 'regeneration'), Promise.resolve('microtask')]);
 
-        expect(firstSettled).toBe('timer');
+        expect(firstSettled).toBe('microtask');
         await regeneration;
     });
 });

--- a/tests/webfonts-generator.bench.ts
+++ b/tests/webfonts-generator.bench.ts
@@ -356,16 +356,19 @@ describe.each([100, 300, 600])('changed event with unchanged contents — %i gly
 
 const contentEditFiles = new Map<number, string[]>();
 const contentEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
+const asyncContentEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
 const rediffContentEditFiles = new Map<number, string[]>();
 const rediffContentEditResults = new Map<number, Awaited<ReturnType<typeof generateWebfonts>>>();
 await Promise.all(
     [100, 300, 600].map(async numGlyphs => {
         const files = await makeNEditableFiles(1, numGlyphs, 'regen-content');
         const result = await generateWebfonts(baseOpts(files, { incremental: true, ...DEV_FORMAT }));
+        const asyncResult = await generateWebfonts(baseOpts(files, { incremental: true, ...DEV_FORMAT }));
         const rediffFiles = await makeNEditableFiles(1, numGlyphs, 'regen-content-rediff');
         const rediffResult = await generateWebfonts(baseOpts(rediffFiles, { incremental: true, ...DEV_FORMAT }));
         contentEditFiles.set(numGlyphs, files);
         contentEditResults.set(numGlyphs, result);
+        asyncContentEditResults.set(numGlyphs, asyncResult);
         rediffContentEditFiles.set(numGlyphs, rediffFiles);
         rediffContentEditResults.set(numGlyphs, rediffResult);
     }),
@@ -376,10 +379,14 @@ describe.each([100, 300, 600])('rebuild after a 1-file content edit — %i glyph
     const opts = baseOpts(files, DEV_FORMAT);
     const benchOpts: BenchOptions = numGlyphs >= 300 ? { time: 8_000, warmupTime: 1_000, warmupIterations: 10 } : { time: 4_000, warmupTime: 500, warmupIterations: 20 };
     const result = contentEditResults.get(numGlyphs)!;
+    const asyncFiles = files;
+    let asyncResult = asyncContentEditResults.get(numGlyphs)!;
     const rediffFiles = rediffContentEditFiles.get(numGlyphs)!;
     const rediffResult = rediffContentEditResults.get(numGlyphs)!;
     const change = [{ path: files[0]!, changeType: 'changed' as const }];
+    const asyncChange = [{ path: asyncFiles[0]!, changeType: 'changed' as const }];
     let toggle = false;
+    let asyncToggle = false;
     let rediffToggle = false;
 
     bench('upstream — full regen', () => expect(upstreamDirect(opts)).resolves.toBeDefined(), benchOpts);
@@ -390,6 +397,16 @@ describe.each([100, 300, 600])('rebuild after a 1-file content edit — %i glyph
             toggle = !toggle;
             writeFileSync(files[0]!, toggle ? EDIT_SVG_B : EDIT_SVG_A);
             expect(result.regenerate(files, change)).toBeUndefined();
+        },
+        benchOpts,
+    );
+    bench(
+        'new core — async incremental regenerate',
+        async () => {
+            asyncToggle = !asyncToggle;
+            writeFileSync(asyncFiles[0]!, asyncToggle ? EDIT_SVG_B : EDIT_SVG_A);
+            asyncResult = await asyncResult.regenerateAsync(asyncFiles, asyncChange);
+            expect(asyncResult).toBeDefined();
         },
         benchOpts,
     );


### PR DESCRIPTION
## Summary
- add non-blocking incremental regeneration for Node and consuming async regeneration APIs for Rust
- move glyph/TTF caches through an owned state slot instead of cloning them, while published outputs remain readable
- update the Vite plugin to await and atomically replace successful generations
- preserve rollback, retry, overlap rejection, and byte-identical sync/async output semantics
- document Node and Rust ownership, failure, and cancellation behavior

## Performance
- corrected Vitest comparisons show sync/async wall-time parity at 100, 300, and 600 glyphs while async keeps the event loop responsive
- shared-target Criterion comparison against `main` improves synchronous regeneration by 3.17% at 100 glyphs and 3.67% at 300 glyphs; 600 glyphs has no significant change

## Validation
- `vp run test`
- `vp check`
- `vp run @atlowchemi/webfont-generator#bench --no-run`
- `vp run @atlowchemi/vite-svg-webfont-docs#build`
- six Rust doc-tests covering sync/async `regenerate` and `regenerate_all`