### PR TITLE
perf(webfont-generator): cut SVG transient allocations by 64%

### DIFF
--- a/packages/webfont-generator/src/svg/serialize.rs
+++ b/packages/webfont-generator/src/svg/serialize.rs
@@ -85,38 +85,38 @@ pub(crate) fn append_path(target: &mut String, path: &TinyPath, round: f64) {
                 let _ = write!(
                     target,
                     "M {} {} ",
-                    round_to_string(f64::from(point.x), round),
-                    round_to_string(f64::from(point.y), round)
+                    RoundedCoordinate::new(point.x, round),
+                    RoundedCoordinate::new(point.y, round)
                 );
             }
             PathSegment::LineTo(point) => {
                 let _ = write!(
                     target,
                     "L {} {} ",
-                    round_to_string(f64::from(point.x), round),
-                    round_to_string(f64::from(point.y), round)
+                    RoundedCoordinate::new(point.x, round),
+                    RoundedCoordinate::new(point.y, round)
                 );
             }
             PathSegment::QuadTo(control, point) => {
                 let _ = write!(
                     target,
                     "Q {} {} {} {} ",
-                    round_to_string(f64::from(control.x), round),
-                    round_to_string(f64::from(control.y), round),
-                    round_to_string(f64::from(point.x), round),
-                    round_to_string(f64::from(point.y), round)
+                    RoundedCoordinate::new(control.x, round),
+                    RoundedCoordinate::new(control.y, round),
+                    RoundedCoordinate::new(point.x, round),
+                    RoundedCoordinate::new(point.y, round)
                 );
             }
             PathSegment::CubicTo(control1, control2, point) => {
                 let _ = write!(
                     target,
                     "C {} {} {} {} {} {} ",
-                    round_to_string(f64::from(control1.x), round),
-                    round_to_string(f64::from(control1.y), round),
-                    round_to_string(f64::from(control2.x), round),
-                    round_to_string(f64::from(control2.y), round),
-                    round_to_string(f64::from(point.x), round),
-                    round_to_string(f64::from(point.y), round)
+                    RoundedCoordinate::new(control1.x, round),
+                    RoundedCoordinate::new(control1.y, round),
+                    RoundedCoordinate::new(control2.x, round),
+                    RoundedCoordinate::new(control2.y, round),
+                    RoundedCoordinate::new(point.x, round),
+                    RoundedCoordinate::new(point.y, round)
                 );
             }
             PathSegment::Close => target.push_str("Z "),
@@ -124,18 +124,27 @@ pub(crate) fn append_path(target: &mut String, path: &TinyPath, round: f64) {
     }
 }
 
-#[inline]
-fn round_to_string(value: f64, round: f64) -> String {
-    let precision = if round.is_finite() && round > 0.0 {
-        round
-    } else {
-        DEFAULT_ROUNDING_PRECISION
-    };
-    let rounded = (value * precision).round() / precision;
-    if rounded.fract() == 0.0 {
-        format!("{rounded:.0}")
-    } else {
-        rounded.to_string()
+struct RoundedCoordinate(f64);
+
+impl RoundedCoordinate {
+    #[inline]
+    fn new(value: f32, round: f64) -> Self {
+        let precision = if round.is_finite() && round > 0.0 {
+            round
+        } else {
+            DEFAULT_ROUNDING_PRECISION
+        };
+        Self((f64::from(value) * precision).round() / precision)
+    }
+}
+
+impl std::fmt::Display for RoundedCoordinate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.fract() == 0.0 {
+            write!(formatter, "{:.0}", self.0)
+        } else {
+            self.0.fmt(formatter)
+        }
     }
 }
 
@@ -171,4 +180,61 @@ fn escape_xml(value: &str) -> String {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rounded_coordinate_matches_allocating_formatter() {
+        let values = [
+            -0.0,
+            0.0,
+            -1.5,
+            0.004_999_999_9,
+            0.005_000_000_4,
+            1.234_567_8,
+            16_777_216.0,
+            f32::MAX,
+            f32::MIN_POSITIVE,
+        ];
+        let precisions = [
+            1.0,
+            10.0,
+            100.0,
+            1_000.0,
+            DEFAULT_ROUNDING_PRECISION,
+            10e12,
+            1e40,
+            0.0,
+            -1.0,
+            f64::NAN,
+            f64::INFINITY,
+        ];
+
+        for value in values {
+            for precision in precisions {
+                let expected = round_to_string(value, precision);
+                assert_eq!(
+                    RoundedCoordinate::new(value, precision).to_string(),
+                    expected
+                );
+            }
+        }
+    }
+
+    fn round_to_string(value: f32, round: f64) -> String {
+        let precision = if round.is_finite() && round > 0.0 {
+            round
+        } else {
+            DEFAULT_ROUNDING_PRECISION
+        };
+        let rounded = (f64::from(value) * precision).round() / precision;
+        if rounded.fract() == 0.0 {
+            format!("{rounded:.0}")
+        } else {
+            rounded.to_string()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- format rounded SVG coordinates directly into the destination buffer instead of allocating one `String` per coordinate
- preserve existing rounding and serialized path output
- add old-versus-new coverage for negative zero, boundaries, large and tiny values, supported precisions, and fallback behavior

## Performance

Identical five-second `pipeline/svg/600` Allocations profiles against clean `main`:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Transient heap allocations | 4,055,317 | 1,468,019 | -63.8% |
| Transient heap bytes | 711,443,856 | 656,832,624 | -7.7% |
| 16-byte short-string allocations | 2,989,786 | 415,418 | -86.1% |
| 16-byte short-string bytes | 47,836,576 | 6,646,688 | -86.1% |

Criterion detected no latency regression for `pipeline/svg/600`: `+0.34%`, 95% CI `[-7.59%, +9.43%]`, `p = 0.93`.

## Release Note

SVG coordinate serialization now avoids temporary strings, reducing transient allocation count by 63.8%, transient heap bytes by 7.7%, and short-string allocations by 86.1% in the 600-glyph SVG workload.