### PR TITLE
perf(webfont-generator): remove two stored allocations per glyph

### DIFF
--- a/packages/webfont-generator/src/svg/mod.rs
+++ b/packages/webfont-generator/src/svg/mod.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{Error, ErrorKind};
 
 use parse::parse_svg_glyph;
-use process::{build_unicode_values, process_glyph};
+use process::process_glyph;
 pub(crate) use serialize::build_svg_font;
 use types::{
     CachedGlyph, CachedProcessedGlyph, GlyphCache, GlyphWorkItem, ParsedGlyph, PreparedSvgFont,
@@ -25,7 +25,6 @@ struct FinalizePlan {
     fixed_width: bool,
     center_horizontally: bool,
     center_vertically: bool,
-    ligature: bool,
     round: f64,
     max_glyph_height: f64,
     font_height: f64,
@@ -186,7 +185,6 @@ fn finalize_plan(options: &SvgOptions, glyphs: &[ParsedGlyph]) -> FinalizePlan {
         fixed_width: options.fixed_width.unwrap_or(false),
         center_horizontally: options.center_horizontally.unwrap_or(false),
         center_vertically: options.center_vertically.unwrap_or(false),
-        ligature: options.ligature,
         round: options.round.unwrap_or(10e12),
         max_glyph_height,
         font_height,
@@ -209,7 +207,6 @@ fn process_glyph_with_plan(
         plan.fixed_width,
         plan.center_horizontally,
         plan.center_vertically,
-        plan.ligature,
         plan.round,
         plan.max_glyph_height,
         plan.font_height,
@@ -451,11 +448,6 @@ fn finalize_glyphs_incremental(
                     index,
                     name: source_file.glyph_name.clone(),
                     path_data: cached.path_data.clone(),
-                    unicode_values: build_unicode_values(
-                        &source_file.glyph_name,
-                        codepoint,
-                        plan.ligature,
-                    ),
                     width: cached.width,
                 }
             }

--- a/packages/webfont-generator/src/svg/process.rs
+++ b/packages/webfont-generator/src/svg/process.rs
@@ -12,7 +12,6 @@ pub(crate) fn process_glyph(
     fixed_width: bool,
     center_horizontally: bool,
     center_vertically: bool,
-    ligature: bool,
     round: f64,
     max_glyph_height: f64,
     font_height: f64,
@@ -90,15 +89,12 @@ pub(crate) fn process_glyph(
         path_data
     };
 
-    let unicode_values = build_unicode_values(&glyph.name, glyph.codepoint, ligature);
-
     Ok(ProcessedGlyph {
         codepoint: glyph.codepoint,
         height: scaled_height,
         index: glyph.index,
         name: glyph.name,
         path_data,
-        unicode_values,
         width: scaled_width,
     })
 }
@@ -119,16 +115,4 @@ fn calculate_combined_bounds(paths: &[usvg::tiny_skia_path::Path]) -> Rect {
 
     Rect::from_ltrb(left, top, right, bottom)
         .unwrap_or_else(|| Rect::from_xywh(0.0, 0.0, 1.0, 1.0).expect("fallback rect"))
-}
-
-pub(crate) fn build_unicode_values(name: &str, codepoint: u32, ligature: bool) -> Vec<String> {
-    let mut values = vec![format!("&#x{:X};", codepoint)];
-    if ligature {
-        let ligature_value = name
-            .chars()
-            .map(|character| format!("&#x{:X};", u32::from(character)))
-            .collect::<String>();
-        values.push(ligature_value);
-    }
-    values
 }

--- a/packages/webfont-generator/src/svg/serialize.rs
+++ b/packages/webfont-generator/src/svg/serialize.rs
@@ -52,24 +52,29 @@ pub(crate) fn build_svg_font(options: &SvgOptions, prepared: &PreparedSvgFont) -
     svg_font.push_str(" />\n    <missing-glyph horiz-adv-x=\"0\" />\n");
 
     for glyph in processed_glyphs {
-        for (index, unicode) in glyph.unicode_values.iter().enumerate() {
-            if index == 0 {
-                _ = write!(
-                    svg_font,
-                    "    <glyph glyph-name=\"{}\"\n      unicode=\"{unicode}\"\n      horiz-adv-x=\"{}\" d=\"{}\" />\n",
-                    escape_xml(&glyph.name),
-                    glyph.width,
-                    escape_xml(&glyph.path_data),
-                );
-            } else {
-                _ = write!(
-                    svg_font,
-                    "    <glyph glyph-name=\"{}-{index}\"\n      unicode=\"{unicode}\"\n      horiz-adv-x=\"{}\" d=\"{}\" />\n",
-                    escape_xml(&glyph.name),
-                    glyph.width,
-                    escape_xml(&glyph.path_data),
-                );
+        _ = write!(
+            svg_font,
+            "    <glyph glyph-name=\"{}\"\n      unicode=\"&#x{:X};\"\n      horiz-adv-x=\"{}\" d=\"{}\" />\n",
+            escape_xml(&glyph.name),
+            glyph.codepoint,
+            glyph.width,
+            escape_xml(&glyph.path_data),
+        );
+        if options.ligature {
+            _ = write!(
+                svg_font,
+                "    <glyph glyph-name=\"{}-1\"\n      unicode=\"",
+                escape_xml(&glyph.name),
+            );
+            for character in glyph.name.chars() {
+                _ = write!(svg_font, "&#x{:X};", u32::from(character));
             }
+            _ = writeln!(
+                svg_font,
+                "\"\n      horiz-adv-x=\"{}\" d=\"{}\" />",
+                glyph.width,
+                escape_xml(&glyph.path_data),
+            );
         }
     }
 

--- a/packages/webfont-generator/src/svg/types.rs
+++ b/packages/webfont-generator/src/svg/types.rs
@@ -48,7 +48,6 @@ pub(crate) struct ProcessedGlyph {
     pub index: usize,
     pub name: String,
     pub path_data: String,
-    pub unicode_values: Vec<String>,
     pub width: f64,
 }
 

--- a/packages/webfont-generator/src/woff/mod.rs
+++ b/packages/webfont-generator/src/woff/mod.rs
@@ -506,7 +506,6 @@ mod tests {
                             8 + shape % 17,
                         )
                     },
-                    unicode_values: Vec::new(),
                     width: 16.0 + (shape % 5) as f64,
                 }
             })
@@ -521,7 +520,6 @@ mod tests {
             index,
             name: name.to_owned(),
             path_data: path_data.to_owned(),
-            unicode_values: Vec::new(),
             width,
         }
     }


### PR DESCRIPTION
## Summary

- remove the eagerly formatted `unicode_values: Vec<String>` from `ProcessedGlyph`
- write primary codepoint and optional ligature entities directly into the SVG output buffer
- stop rebuilding SVG-only Unicode strings during incremental cache reconstruction
- remove ligature state from geometry finalization

## Performance

With ligatures disabled, every glyph previously allocated:

1. one `String` for its formatted codepoint
2. one backing allocation for `Vec<String>`

Default, TTF-only, and WOFF2-only generation paid both allocations even though they never serialize an SVG font.

Allocations profiles covered all three formats at 100, 300, and 600 glyphs. Transient allocation count decreased in all nine comparisons by 5,652-9,318 allocations per fixed-duration profile.

Repeated Criterion comparisons classified no workload as a latency regression. The first pass shifted within the noise threshold; the immediate repeat was flat or slightly faster, identifying machine drift rather than a change-level regression.

The exact default and WOFF2-only benchmark cases were added only in a disposable measurement worktree; this PR does not change committed benchmark workloads.

## Release Note

SVG-only Unicode values are now formatted only when writing an SVG font. Binary font generation avoids one temporary `String` and one `Vec` allocation per glyph without changing output bytes or latency.