### PR TITLE
perf(webfont-generator): cut SVG parse-stage time by 10-13%

### DIFF
--- a/packages/webfont-generator/src/svg/mod.rs
+++ b/packages/webfont-generator/src/svg/mod.rs
@@ -90,6 +90,7 @@ pub(crate) fn parse_glyphs(
     }
 
     let preserve_aspect_ratio = options.preserve_aspect_ratio.unwrap_or(false);
+    let parser_options = usvg::Options::default();
 
     let mut work_items = Vec::with_capacity(source_files.len());
     for (index, source_file) in source_files.iter().enumerate() {
@@ -115,7 +116,7 @@ pub(crate) fn parse_glyphs(
 
     let mut glyphs = work_items
         .par_iter()
-        .map(|item| parse_svg_glyph(item, preserve_aspect_ratio))
+        .map(|item| parse_svg_glyph(item, preserve_aspect_ratio, &parser_options))
         .collect::<Result<Vec<_>, Error>>()
         .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
     glyphs.sort_by_key(|glyph| glyph.index);
@@ -296,6 +297,7 @@ fn parse_glyphs_incremental(
     }
 
     // Parse (in parallel) only files not already cached — a present entry is reused as-is.
+    let parser_options = usvg::Options::default();
     let parsed: Vec<(usize, ParsedGlyph)> = source_files
         .par_iter()
         .enumerate()
@@ -307,7 +309,8 @@ fn parse_glyphs_incremental(
                 name: &source_file.glyph_name,
                 source_file,
             };
-            parse_svg_glyph(&work, preserve_aspect_ratio).map(|glyph| (index, glyph))
+            parse_svg_glyph(&work, preserve_aspect_ratio, &parser_options)
+                .map(|glyph| (index, glyph))
         })
         .collect::<Result<Vec<_>, Error>>()
         .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;

--- a/packages/webfont-generator/src/svg/parse.rs
+++ b/packages/webfont-generator/src/svg/parse.rs
@@ -17,11 +17,12 @@ struct RootSvgMetrics {
 pub(crate) fn parse_svg_glyph(
     item: &GlyphWorkItem,
     preserve_aspect_ratio: bool,
+    options: &usvg::Options,
 ) -> Result<ParsedGlyph, Error> {
     let svg = item.source_file.contents.as_str();
-    let root_metrics = parse_root_svg_metrics(svg)?;
-    let options = usvg::Options::default();
-    let tree = usvg::Tree::from_str(svg, &options).map_err(|error| {
+    let document = parse_svg_document(svg)?;
+    let root_metrics = parse_root_svg_metrics(&document)?;
+    let tree = usvg::Tree::from_xmltree(&document, options).map_err(|error| {
         Error::new(
             ErrorKind::InvalidInput,
             format!(
@@ -111,8 +112,8 @@ fn collect_paths(
     Ok(())
 }
 
-fn parse_root_svg_metrics(svg: &str) -> Result<Option<RootSvgMetrics>, Error> {
-    let document = roxmltree::Document::parse_with_options(
+fn parse_svg_document(svg: &str) -> Result<roxmltree::Document<'_>, Error> {
+    roxmltree::Document::parse_with_options(
         svg,
         roxmltree::ParsingOptions {
             allow_dtd: true,
@@ -124,7 +125,12 @@ fn parse_root_svg_metrics(svg: &str) -> Result<Option<RootSvgMetrics>, Error> {
             ErrorKind::InvalidInput,
             format!("Failed to inspect SVG root element: {error}"),
         )
-    })?;
+    })
+}
+
+fn parse_root_svg_metrics(
+    document: &roxmltree::Document<'_>,
+) -> Result<Option<RootSvgMetrics>, Error> {
     let root = document.root_element();
     if !root.has_tag_name("svg") {
         return Ok(None);


### PR DESCRIPTION
## Summary

- parse each SVG into one `roxmltree::Document`
- inspect root metrics and build the `usvg::Tree` from that shared document
- reuse one immutable `usvg::Options` value across each Rayon parse batch
- preserve DTD support, error ordering, and existing error messages

## Performance

A temporary measurement benchmark used real `simple-icons` fixtures:

| Glyphs | Root inspection share of `parse_only` |
| ---: | ---: |
| 100 | 27.24% |
| 300 | 18.78% |
| 600 | 15.54% |

Fresh paired candidate comparisons:

| Glyphs | `parse_only` change |
| ---: | ---: |
| 100 | -9.6% to -11.5% |
| 300 | -9.6% to -12.4% |
| 600 | -9.9% to -12.6% |

SVG-only generation was slightly faster or within Criterion's noise threshold at every size. An earlier SVG/100 regression did not reproduce and reversed to a slight improvement in the immediate repeat.

Temporary measurement helpers are not included in this PR.

## Behavior

- keeps `roxmltree::ParsingOptions { allow_dtd: true, .. }`
- parses the document before root inspection, preserving malformed-XML error precedence
- inspects root metrics before `usvg::Tree::from_xmltree`, preserving existing viewBox errors
- keeps the existing usvg conversion error wrapper

## Release Note

SVG files are now parsed into a single shared XML document instead of twice, reducing SVG parse-stage time by approximately 10-13% without changing generated output.