### PR TITLE
perf(webfont-generator): preallocate SVG font output

### DIFF
--- a/packages/webfont-generator/src/svg/serialize.rs
+++ b/packages/webfont-generator/src/svg/serialize.rs
@@ -15,12 +15,25 @@ pub(crate) fn build_svg_font(options: &SvgOptions, prepared: &PreparedSvgFont) -
         metadata,
         processed_glyphs,
     } = prepared;
-    let mut svg_font = String::from(
-        r#"<?xml version="1.0" standalone="no"?>
+    let header = r#"<?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
-"#,
-    );
+"#;
+    let estimated_capacity = header.len()
+        + metadata.len()
+        + 256
+        + processed_glyphs
+            .iter()
+            .map(|glyph| {
+                glyph.name.len()
+                    + glyph.path_data.len()
+                    + 96
+                    + usize::from(options.ligature)
+                        * (glyph.name.len() * 11 + glyph.path_data.len() + 96)
+            })
+            .sum::<usize>();
+    let mut svg_font = String::with_capacity(estimated_capacity);
+    svg_font.push_str(header);
     if !metadata.is_empty() {
         _ = writeln!(svg_font, "<metadata>{metadata}</metadata>");
     }


### PR DESCRIPTION
## Summary
- reserve the SVG font buffer from known serialized content lengths
- include optional ligature output without retaining excessive spare capacity
- preserve byte-identical SVG output

## Performance
Exact-operation probe for one 600-glyph SVG serialization:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Allocation/reallocation calls | 1,214 | 1,203 | -11 |
| Allocated bytes | 983,105 | 558,225 | -43.2% |
| Spare output capacity | 22.3% | 2.8% | -19.5 pp |

End-to-end comparisons found no credible regression. A 600-glyph ABBA repeat averaged 1.49% faster, but pair direction reversed under 3.85% parent drift, so no latency improvement is claimed.

The temporary allocation probe is not part of production code.

## Stack
- depends on #355