### PR TITLE
perf(webfont-generator): share parsed glyph cache entries

### DIFF
--- a/packages/webfont-generator/src/svg/mod.rs
+++ b/packages/webfont-generator/src/svg/mod.rs
@@ -9,6 +9,7 @@ mod winding;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::io::{Error, ErrorKind};
+use std::sync::Arc;
 
 use parse::parse_svg_glyph;
 use process::process_glyph;
@@ -324,11 +325,11 @@ fn parse_glyphs_incremental(
     for (index, glyph) in &parsed {
         let source_file = &source_files[*index];
         let hash = source_content_hash(&source_file.contents);
-        let cached = CachedGlyph {
+        let cached = Arc::new(CachedGlyph {
             height: glyph.height,
             paths: glyph.paths.clone(),
             width: glyph.width,
-        };
+        });
         cache.by_content_hash.insert(hash, cached.clone());
         cache.content_hashes.insert(source_file.path.clone(), hash);
         cache.entries.insert(source_file.path.clone(), cached);

--- a/packages/webfont-generator/src/svg/types.rs
+++ b/packages/webfont-generator/src/svg/types.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
 
 use usvg::tiny_skia_path::Path as TinyPath;
 
@@ -72,7 +73,6 @@ pub(crate) struct PreparedSvgFont {
 /// The content-derived geometry of one parsed glyph (everything in [`ParsedGlyph`] except the
 /// assigned `codepoint`/`index`/`name`, which are reassigned on every build). Cached so an
 /// incremental rebuild can reuse a glyph whose SVG source didn't change.
-#[derive(Clone)]
 pub(crate) struct CachedGlyph {
     pub height: f64,
     pub paths: Vec<TinyPath>,
@@ -85,11 +85,11 @@ pub(crate) struct CachedGlyph {
 #[derive(Clone, Default)]
 pub(crate) struct GlyphCache {
     /// Parsed geometry keyed by path for the current/last known file set.
-    pub entries: HashMap<String, CachedGlyph>,
+    pub entries: HashMap<String, Arc<CachedGlyph>>,
     /// Last seen source hash per path, used to ignore no-op watcher events.
     pub content_hashes: HashMap<String, [u8; 16]>,
     /// Parsed geometry keyed by SVG source bytes so added/renamed duplicate icons can reuse it.
-    pub by_content_hash: HashMap<[u8; 16], CachedGlyph>,
+    pub by_content_hash: HashMap<[u8; 16], Arc<CachedGlyph>>,
     /// Processed path data keyed by path for unchanged files while metrics/options stay stable.
     pub processed_entries: HashMap<String, CachedProcessedGlyph>,
     pub processed_signature: Option<[u8; 16]>,


### PR DESCRIPTION
## Summary
- share parsed glyph geometry between the path and content-hash cache indexes
- remove one deep path-vector clone per cached glyph

## Results
- reduces 600-glyph result-owned live bytes by 8.1% (786,843 bytes)
- reduces cached path-vector storage by 50%
- leaves warm SVG preparation, no-op, and real-edit allocation counts effectively unchanged
- shows no significant latency regression in targeted ABBA measurements