### PR TITLE
test(webfont-generator): isolate warm SVG preparation

### DIFF
--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use webfont_generator::bench_support::{
-    BenchGlyphCache, BenchSvgSource, clear_woff1_payload_cache, prepare_svg_full,
-    prepare_svg_incremental,
+    clear_woff1_payload_cache, incremental_svg_input, prepare_svg_full, prepare_svg_incremental,
+    BenchGlyphCache, BenchSvgSource,
 };
 
 mod support;
@@ -208,22 +208,12 @@ fn bench_svg_prepare(c: &mut Criterion) {
             })
         });
 
+        let input =
+            incremental_svg_input(options(fixture.paths.clone(), true), &fixture.sources).unwrap();
         let mut cache = BenchGlyphCache::default();
-        prepare_svg_incremental(
-            options(fixture.paths.clone(), true),
-            &fixture.sources,
-            &mut cache,
-        )
-        .unwrap();
+        prepare_svg_incremental(&input, &mut cache).unwrap();
         group.bench_function(format!("incremental_warm/{size}"), |b| {
-            b.iter(|| {
-                prepare_svg_incremental(
-                    options(fixture.paths.clone(), true),
-                    &fixture.sources,
-                    &mut cache,
-                )
-                .unwrap()
-            })
+            b.iter(|| prepare_svg_incremental(&input, &mut cache).unwrap())
         });
     }
     group.finish();
@@ -801,6 +791,10 @@ fn bench_regenerate_by_format(c: &mut Criterion) {
             ("ttf", vec![FontType::Ttf]),
             ("woff", vec![FontType::Woff]),
             ("woff2", vec![FontType::Woff2]),
+            (
+                "all_except_woff2",
+                vec![FontType::Svg, FontType::Ttf, FontType::Eot, FontType::Woff],
+            ),
             (
                 "all_formats",
                 vec![

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -4,8 +4,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use webfont_generator::bench_support::{
-    BenchGlyphCache, BenchSvgSource, clear_woff1_payload_cache, incremental_svg_input,
-    prepare_svg_full, prepare_svg_incremental,
+    BenchGlyphCache, BenchSvgSource, clear_woff1_payload_cache, prepare_svg_full,
+    prepare_svg_incremental, svg_prepare_input,
 };
 
 mod support;
@@ -202,14 +202,12 @@ fn bench_svg_prepare(c: &mut Criterion) {
     let mut group = c.benchmark_group("svg_prepare");
     for size in SIZES {
         let fixture = fixtures(size);
+        let input =
+            svg_prepare_input(options(fixture.paths.clone(), false), &fixture.sources).unwrap();
         group.bench_function(format!("full/{size}"), |b| {
-            b.iter(|| {
-                prepare_svg_full(options(fixture.paths.clone(), false), &fixture.sources).unwrap()
-            })
+            b.iter(|| prepare_svg_full(&input).unwrap())
         });
 
-        let input =
-            incremental_svg_input(options(fixture.paths.clone(), true), &fixture.sources).unwrap();
         let mut cache = BenchGlyphCache::default();
         prepare_svg_incremental(&input, &mut cache).unwrap();
         group.bench_function(format!("incremental_warm/{size}"), |b| {

--- a/packages/webfont-generator/benches/incremental.rs
+++ b/packages/webfont-generator/benches/incremental.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use webfont_generator::bench_support::{
-    clear_woff1_payload_cache, incremental_svg_input, prepare_svg_full, prepare_svg_incremental,
-    BenchGlyphCache, BenchSvgSource,
+    BenchGlyphCache, BenchSvgSource, clear_woff1_payload_cache, incremental_svg_input,
+    prepare_svg_full, prepare_svg_incremental,
 };
 
 mod support;

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -139,6 +139,12 @@ pub mod bench_support {
     #[derive(Clone, Default)]
     pub struct BenchGlyphCache(GlyphCache);
 
+    /// Opaque loaded sources and resolved options for incremental SVG preparation benchmarks.
+    pub struct BenchIncrementalSvgInput {
+        options: super::ResolvedGenerateWebfontsOptions,
+        sources: Vec<LoadedSvgFile>,
+    }
+
     /// Opaque parsed glyph set used to isolate parse and finalize stages.
     #[derive(Clone)]
     pub struct BenchParsedGlyphs(Vec<ParsedGlyph>);
@@ -294,16 +300,23 @@ pub mod bench_support {
         }
     }
 
-    /// Run the incremental SVG preparation path and return the number of prepared glyphs.
-    pub fn prepare_svg_incremental(
+    /// Load sources and resolve options outside incremental SVG preparation measurements.
+    pub fn incremental_svg_input(
         options: GenerateWebfontsOptions,
         sources: &[BenchSvgSource],
-        cache: &mut BenchGlyphCache,
-    ) -> io::Result<usize> {
+    ) -> io::Result<BenchIncrementalSvgInput> {
         let sources = load_sources(sources);
         let options = resolve(options, &sources)?;
-        let svg_options = svg_options_from_options(&options);
-        let prepared = prepare_svg_font_incremental(&svg_options, &sources, &mut cache.0)?;
+        Ok(BenchIncrementalSvgInput { options, sources })
+    }
+
+    /// Run the incremental SVG preparation path and return the number of prepared glyphs.
+    pub fn prepare_svg_incremental(
+        input: &BenchIncrementalSvgInput,
+        cache: &mut BenchGlyphCache,
+    ) -> io::Result<usize> {
+        let svg_options = svg_options_from_options(&input.options);
+        let prepared = prepare_svg_font_incremental(&svg_options, &input.sources, &mut cache.0)?;
         Ok(prepared.processed_glyphs.len())
     }
 }

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -140,7 +140,7 @@ pub mod bench_support {
     pub struct BenchGlyphCache(GlyphCache);
 
     /// Opaque loaded sources and resolved options for incremental SVG preparation benchmarks.
-    pub struct BenchIncrementalSvgInput {
+    pub struct BenchSvgPrepareInput {
         options: super::ResolvedGenerateWebfontsOptions,
         sources: Vec<LoadedSvgFile>,
     }
@@ -185,14 +185,19 @@ pub mod bench_support {
     }
 
     /// Run the SVG parse+process preparation path and return the number of prepared glyphs.
-    pub fn prepare_svg_full(
+    pub fn svg_prepare_input(
         options: GenerateWebfontsOptions,
         sources: &[BenchSvgSource],
-    ) -> io::Result<usize> {
+    ) -> io::Result<BenchSvgPrepareInput> {
         let sources = load_sources(sources);
         let options = resolve(options, &sources)?;
-        let svg_options = svg_options_from_options(&options);
-        let prepared = prepare_svg_font(&svg_options, &sources)?;
+        Ok(BenchSvgPrepareInput { options, sources })
+    }
+
+    /// Run the full SVG preparation path and return the number of prepared glyphs.
+    pub fn prepare_svg_full(input: &BenchSvgPrepareInput) -> io::Result<usize> {
+        let svg_options = svg_options_from_options(&input.options);
+        let prepared = prepare_svg_font(&svg_options, &input.sources)?;
         Ok(prepared.processed_glyphs.len())
     }
 
@@ -300,19 +305,9 @@ pub mod bench_support {
         }
     }
 
-    /// Load sources and resolve options outside incremental SVG preparation measurements.
-    pub fn incremental_svg_input(
-        options: GenerateWebfontsOptions,
-        sources: &[BenchSvgSource],
-    ) -> io::Result<BenchIncrementalSvgInput> {
-        let sources = load_sources(sources);
-        let options = resolve(options, &sources)?;
-        Ok(BenchIncrementalSvgInput { options, sources })
-    }
-
     /// Run the incremental SVG preparation path and return the number of prepared glyphs.
     pub fn prepare_svg_incremental(
-        input: &BenchIncrementalSvgInput,
+        input: &BenchSvgPrepareInput,
         cache: &mut BenchGlyphCache,
     ) -> io::Result<usize> {
         let svg_options = svg_options_from_options(&input.options);


### PR DESCRIPTION
## Summary
- move source loading and option resolution outside timed warm SVG preparation
- add an all-formats-without-WOFF2 incremental edit workload

## Why
The warm benchmark included benchmark-adapter source conversions rather than isolating incremental preparation. This made ownership changes appear to allocate inside the warm path when the allocations occurred only while constructing benchmark inputs.