### PR TITLE
perf(webfont-generator): share loaded SVG contents

### DIFF
--- a/packages/webfont-generator/src/incremental/mod.rs
+++ b/packages/webfont-generator/src/incremental/mod.rs
@@ -397,7 +397,7 @@ fn upsert_source_file(
     name: Option<String>,
 ) {
     if let Some(file) = source_files.iter_mut().find(|file| file.path == path) {
-        file.contents = contents;
+        file.contents = contents.into();
         if let Some(name) = name {
             file.glyph_name = name;
         }
@@ -410,7 +410,7 @@ fn upsert_source_file(
                 .to_owned()
         });
         source_files.push(LoadedSvgFile {
-            contents,
+            contents: contents.into(),
             glyph_name,
             path: path.to_owned(),
         });

--- a/packages/webfont-generator/src/incremental/tests.rs
+++ b/packages/webfont-generator/src/incremental/tests.rs
@@ -66,7 +66,7 @@ fn load(paths: &[String]) -> Vec<LoadedSvgFile> {
     paths
         .iter()
         .map(|path| LoadedSvgFile {
-            contents: std::fs::read_to_string(path).unwrap(),
+            contents: std::fs::read_to_string(path).unwrap().into(),
             glyph_name: Path::new(path)
                 .file_stem()
                 .and_then(|stem| stem.to_str())

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -168,7 +168,7 @@ pub mod bench_support {
         sources
             .iter()
             .map(|source| LoadedSvgFile {
-                contents: source.contents.clone(),
+                contents: source.contents.clone().into(),
                 glyph_name: source.glyph_name.clone(),
                 path: source.path.clone(),
             })
@@ -854,7 +854,7 @@ async fn load_svg_files(
         .map(|(path, contents)| {
             let glyph_name = util::glyph_name_from_path(&path, rename)?;
             Ok(LoadedSvgFile {
-                contents,
+                contents: contents.into(),
                 glyph_name,
                 path,
             })
@@ -883,7 +883,7 @@ async fn load_svg_files_napi(
             util::default_glyph_name_from_path(&path).map_err(to_napi_err)?
         };
         source_files.push(LoadedSvgFile {
-            contents,
+            contents: contents.into(),
             glyph_name,
             path,
         });

--- a/packages/webfont-generator/src/svg/parse.rs
+++ b/packages/webfont-generator/src/svg/parse.rs
@@ -19,7 +19,7 @@ pub(crate) fn parse_svg_glyph(
     preserve_aspect_ratio: bool,
     options: &usvg::Options,
 ) -> Result<ParsedGlyph, Error> {
-    let svg = item.source_file.contents.as_str();
+    let svg = item.source_file.contents.as_ref();
     let document = parse_svg_document(svg)?;
     let root_metrics = parse_root_svg_metrics(&document)?;
     let tree = usvg::Tree::from_xmltree(&document, options).map_err(|error| {

--- a/packages/webfont-generator/src/svg/tests.rs
+++ b/packages/webfont-generator/src/svg/tests.rs
@@ -84,7 +84,8 @@ fn load_source_files(paths: &[String]) -> Vec<LoadedSvgFile> {
         .iter()
         .map(|path| LoadedSvgFile {
             contents: fs::read_to_string(path)
-                .unwrap_or_else(|error| panic!("failed to load source SVG '{}': {error}", path)),
+                .unwrap_or_else(|error| panic!("failed to load source SVG '{}': {error}", path))
+                .into(),
             glyph_name: Path::new(path)
                 .file_stem()
                 .and_then(|stem| stem.to_str())

--- a/packages/webfont-generator/src/templates/css.rs
+++ b/packages/webfont-generator/src/templates/css.rs
@@ -31,7 +31,7 @@ fn calc_hash(options: &ResolvedGenerateWebfontsOptions, source_files: &[LoadedSv
     let mut hash = Context::new();
 
     for source_file in source_files {
-        hash.consume(&source_file.contents);
+        hash.consume(source_file.contents.as_bytes());
     }
 
     let hashable = HashableGenerateWebfontsOptions::from(options);
@@ -812,7 +812,9 @@ mod tests {
 
         let options = resolve_options(options);
         let source_files = vec![LoadedSvgFile {
-            contents: fs::read_to_string(&options.files[0]).expect("fixture should load"),
+            contents: fs::read_to_string(&options.files[0])
+                .expect("fixture should load")
+                .into(),
             glyph_name: "add".to_owned(),
             path: options.files[0].clone(),
         }];
@@ -837,7 +839,9 @@ mod tests {
         };
         let options = resolve_options(options);
         let source_files = vec![LoadedSvgFile {
-            contents: fs::read_to_string(&options.files[0]).expect("fixture should load"),
+            contents: fs::read_to_string(&options.files[0])
+                .expect("fixture should load")
+                .into(),
             glyph_name: "add".to_owned(),
             path: options.files[0].clone(),
         }];
@@ -874,7 +878,9 @@ mod tests {
         };
         let options = resolve_options(options);
         let source_files = vec![LoadedSvgFile {
-            contents: fs::read_to_string(&options.files[0]).expect("fixture should load"),
+            contents: fs::read_to_string(&options.files[0])
+                .expect("fixture should load")
+                .into(),
             glyph_name: "add".to_owned(),
             path: options.files[0].clone(),
         }];
@@ -907,7 +913,9 @@ mod tests {
         };
         let options = resolve_options(options);
         let source_files = vec![LoadedSvgFile {
-            contents: fs::read_to_string(&options.files[0]).expect("fixture should load"),
+            contents: fs::read_to_string(&options.files[0])
+                .expect("fixture should load")
+                .into(),
             glyph_name: "add".to_owned(),
             path: options.files[0].clone(),
         }];
@@ -1075,7 +1083,9 @@ mod tests {
         };
         let options = resolve_options(options);
         let source_files = vec![LoadedSvgFile {
-            contents: fs::read_to_string(&options.files[0]).expect("fixture should load"),
+            contents: fs::read_to_string(&options.files[0])
+                .expect("fixture should load")
+                .into(),
             glyph_name: "add".to_owned(),
             path: options.files[0].clone(),
         }];

--- a/packages/webfont-generator/src/test_helpers.rs
+++ b/packages/webfont-generator/src/test_helpers.rs
@@ -22,7 +22,9 @@ pub fn write_temp_template(prefix: &str, contents: &str) -> String {
 
 pub fn fixture_source_files(options: &ResolvedGenerateWebfontsOptions) -> Vec<LoadedSvgFile> {
     vec![LoadedSvgFile {
-        contents: fs::read_to_string(&options.files[0]).expect("fixture should load"),
+        contents: fs::read_to_string(&options.files[0])
+            .expect("fixture should load")
+            .into(),
         glyph_name: Path::new(&options.files[0])
             .file_stem()
             .and_then(|s| s.to_str())

--- a/packages/webfont-generator/src/ttf/mod.rs
+++ b/packages/webfont-generator/src/ttf/mod.rs
@@ -206,7 +206,7 @@ pub(crate) fn generate_ttf_font_bytes(options: GenerateWebfontsOptions) -> Resul
         .iter()
         .map(|path| {
             Ok(LoadedSvgFile {
-                contents: std::fs::read_to_string(path)?,
+                contents: std::fs::read_to_string(path)?.into(),
                 glyph_name: std::path::Path::new(path)
                     .file_stem()
                     .and_then(|stem| stem.to_str())

--- a/packages/webfont-generator/src/types.rs
+++ b/packages/webfont-generator/src/types.rs
@@ -362,7 +362,7 @@ pub(crate) struct ResolvedGenerateWebfontsOptions {
 
 #[derive(Clone)]
 pub(crate) struct LoadedSvgFile {
-    pub contents: String,
+    pub contents: Arc<str>,
     pub glyph_name: String,
     pub path: String,
 }
@@ -1091,7 +1091,7 @@ mod tests {
             .files
             .iter()
             .map(|path| LoadedSvgFile {
-                contents: std::fs::read_to_string(path).unwrap(),
+                contents: std::fs::read_to_string(path).unwrap().into(),
                 glyph_name: std::path::Path::new(path)
                     .file_stem()
                     .unwrap()
@@ -1362,7 +1362,7 @@ mod tests {
             .files
             .iter()
             .map(|path| LoadedSvgFile {
-                contents: std::fs::read_to_string(path).unwrap(),
+                contents: std::fs::read_to_string(path).unwrap().into(),
                 glyph_name: std::path::Path::new(path)
                     .file_stem()
                     .unwrap()

--- a/packages/webfont-generator/src/util.rs
+++ b/packages/webfont-generator/src/util.rs
@@ -164,7 +164,7 @@ mod tests {
 
     fn loaded_svg_file(path: &str) -> LoadedSvgFile {
         LoadedSvgFile {
-            contents: "<svg />".to_owned(),
+            contents: "<svg />".into(),
             glyph_name: Path::new(path)
                 .file_stem()
                 .and_then(|stem| stem.to_str())
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn errors_when_any_source_file_has_no_usable_file_stem() {
         let source_files = vec![LoadedSvgFile {
-            contents: "<svg />".to_owned(),
+            contents: "<svg />".into(),
             glyph_name: String::new(),
             path: "/tmp/icons/..".to_owned(),
         }];


### PR DESCRIPTION
Depends on #359.

## Summary
- store loaded SVG contents as `Arc<str>`
- share unchanged source payloads across defensive regeneration snapshots

## Results
- improves 300/600-glyph no-op regeneration by 23-27%
- reduces edit allocations without WOFF2 by 5.2-5.7% and peak live bytes by about 10%
- leaves corrected warm-preparation allocations unchanged
- shows no significant real-edit wall-time regression in targeted ABBA measurements
- leaves steady retained memory unchanged because one source payload per glyph remains required