### PR TITLE
perf(webfont-generator): share processed SVG paths

### DIFF
--- a/packages/webfont-generator/src/svg/process.rs
+++ b/packages/webfont-generator/src/svg/process.rs
@@ -94,7 +94,7 @@ pub(crate) fn process_glyph(
         height: scaled_height,
         index: glyph.index,
         name: glyph.name,
-        path_data,
+        path_data: path_data.into(),
         width: scaled_width,
     })
 }

--- a/packages/webfont-generator/src/svg/tests.rs
+++ b/packages/webfont-generator/src/svg/tests.rs
@@ -688,7 +688,7 @@ fn winding_glyph_path_data(file: &str) -> String {
     finalize_generate_webfonts_options(&mut resolved, &source_files).unwrap();
     let svg_options = svg_options_from_options(&resolved);
     let prepared = prepare_svg_font(&svg_options, &source_files).unwrap();
-    prepared.processed_glyphs[0].path_data.clone()
+    prepared.processed_glyphs[0].path_data.to_string()
 }
 
 /// Signed-area sign of each subpath in serialized path data (`M`/`L`/`Q`/`C`/`Z`, absolute coords),

--- a/packages/webfont-generator/src/svg/types.rs
+++ b/packages/webfont-generator/src/svg/types.rs
@@ -48,14 +48,14 @@ pub(crate) struct ProcessedGlyph {
     pub height: f64,
     pub index: usize,
     pub name: String,
-    pub path_data: String,
+    pub path_data: Arc<str>,
     pub width: f64,
 }
 
 #[derive(Clone)]
 pub(crate) struct CachedProcessedGlyph {
     pub height: f64,
-    pub path_data: String,
+    pub path_data: Arc<str>,
     pub width: f64,
 }
 

--- a/packages/webfont-generator/src/woff/mod.rs
+++ b/packages/webfont-generator/src/woff/mod.rs
@@ -514,7 +514,7 @@ mod tests {
                     } else {
                         format!("glyph-{index}")
                     },
-                    path_data: if empty {
+                    path_data: (if empty {
                         String::new()
                     } else {
                         let inset = shape % 5;
@@ -524,7 +524,8 @@ mod tests {
                             8 + shape % 13,
                             8 + shape % 17,
                         )
-                    },
+                    })
+                    .into(),
                     width: 16.0 + (shape % 5) as f64,
                 }
             })
@@ -538,7 +539,7 @@ mod tests {
             height,
             index,
             name: name.to_owned(),
-            path_data: path_data.to_owned(),
+            path_data: path_data.into(),
             width,
         }
     }


### PR DESCRIPTION
Depends on #360.

## Summary
- store processed SVG path data as `Arc<str>`
- share immutable paths between processed-cache entries and prepared generations

## Results
- reduces warm preparation allocations by 57-60%
- reduces warm peak live bytes by 50-53%
- improves warm preparation latency by 5-9%
- avoids about 2.86 MB and 599 allocations per 600-glyph edit
- shows no initial-generation or real-edit regression over 5%