### PR TITLE
perf(webfont-generator): batch rename callbacks

### DIFF
--- a/packages/webfont-generator/binding.d.ts
+++ b/packages/webfont-generator/binding.d.ts
@@ -122,12 +122,12 @@ export interface FormatOptions {
  * holding the font bytes and template-rendering methods.
  *
  * Optional callbacks:
- * - `rename(path)` — derive a custom glyph name from each SVG file path.
+ * - `rename(paths)` — derive custom glyph names for the batch of SVG file paths.
  * - `cssContext(ctx)` — mutate the Handlebars context before CSS rendering;
  *   return the (possibly mutated) context.
  * - `htmlContext(ctx)` — same, but for the HTML preview.
  */
-export declare function generateWebfonts(options: GenerateWebfontsOptions, rename?: (((arg: string) => string)) | undefined | null, cssContext?: (((arg: Record<string, any>) => Record<string, any>)) | undefined | null, htmlContext?: (((arg: Record<string, any>) => Record<string, any>)) | undefined | null): Promise<GenerateWebfontsResult>
+export declare function generateWebfonts(options: GenerateWebfontsOptions, rename?: (((arg: Array<string>) => Array<string>)) | undefined | null, cssContext?: (((arg: Record<string, any>) => Record<string, any>)) | undefined | null, htmlContext?: (((arg: Record<string, any>) => Record<string, any>)) | undefined | null): Promise<GenerateWebfontsResult>
 
 /**
  * Top-level options controlling webfont generation. Only `dest` and `files`

--- a/packages/webfont-generator/index.js
+++ b/packages/webfont-generator/index.js
@@ -30,7 +30,14 @@ async function generateWebfonts(options) {
 
     return generateNativeBinding(
         nativeOptions,
-        rename,
+        rename
+            ? paths =>
+                  paths.map(path => {
+                      const name = rename(path);
+                      if (typeof name !== 'string') throw new TypeError('rename callback must return a string');
+                      return name;
+                  })
+            : undefined,
         cssContext
             ? context => {
                   cssContext(context);

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -334,7 +334,7 @@ extern "C" fn napi_call_threadsafe_function(
 /// holding the font bytes and template-rendering methods.
 ///
 /// Optional callbacks:
-/// - `rename(path)` — derive a custom glyph name from each SVG file path.
+/// - `rename(paths)` — derive custom glyph names for the batch of SVG file paths.
 /// - `cssContext(ctx)` — mutate the Handlebars context before CSS rendering;
 ///   return the (possibly mutated) context.
 /// - `htmlContext(ctx)` — same, but for the HTML preview.
@@ -343,7 +343,7 @@ extern "C" fn napi_call_threadsafe_function(
 #[allow(clippy::type_complexity)] // NAPI proc macro requires the verbose ThreadsafeFunction type
 pub async fn generate_webfonts(
     options: GenerateWebfontsOptions,
-    rename: Option<ThreadsafeFunction<String, String, String, Status, false>>,
+    rename: Option<ThreadsafeFunction<Vec<String>, Vec<String>, Vec<String>, Status, false>>,
     css_context: Option<
         ThreadsafeFunction<
             serde_json::Map<String, serde_json::Value>,
@@ -867,27 +867,43 @@ async fn load_svg_files(
 
 /// NAPI version: resolve glyph names via async ThreadsafeFunction callback.
 #[cfg(feature = "napi")]
+#[allow(clippy::type_complexity)]
 async fn load_svg_files_napi(
     paths: &[String],
     rename: Option<
-        &napi::threadsafe_function::ThreadsafeFunction<String, String, String, Status, false>,
+        &napi::threadsafe_function::ThreadsafeFunction<
+            Vec<String>,
+            Vec<String>,
+            Vec<String>,
+            Status,
+            false,
+        >,
     >,
 ) -> napi::Result<Vec<LoadedSvgFile>> {
     let raw = load_svg_contents(paths).await.map_err(to_napi_err)?;
-    let mut source_files = Vec::with_capacity(raw.len());
-
-    for (path, contents) in raw {
-        let glyph_name = if let Some(rename) = rename {
-            rename.call_async(path.clone()).await?
-        } else {
-            util::default_glyph_name_from_path(&path).map_err(to_napi_err)?
-        };
-        source_files.push(LoadedSvgFile {
+    let glyph_names = if let Some(rename) = rename {
+        let glyph_names = rename.call_async_catch(paths.to_vec()).await?;
+        if glyph_names.len() != raw.len() {
+            return Err(NapiError::new(
+                Status::InvalidArg,
+                "rename callback returned an unexpected number of glyph names".to_owned(),
+            ));
+        }
+        glyph_names
+    } else {
+        raw.iter()
+            .map(|(path, _)| util::default_glyph_name_from_path(path).map_err(to_napi_err))
+            .collect::<napi::Result<_>>()?
+    };
+    let source_files = raw
+        .into_iter()
+        .zip(glyph_names)
+        .map(|((path, contents), glyph_name)| LoadedSvgFile {
             contents: contents.into(),
             glyph_name,
             path,
-        });
-    }
+        })
+        .collect::<Vec<_>>();
 
     validate_glyph_names(&source_files).map_err(to_napi_err)?;
     Ok(source_files)

--- a/packages/webfont-generator/tests/generator.test.ts
+++ b/packages/webfont-generator/tests/generator.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { afterEach, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { generateWebfonts as generateNativeBinding } from '../binding.js';
 import { type FontType, generateWebfonts, type GenerateWebfontsInputOptions } from '../index.js';
 
 const fixturesRoot = join(import.meta.dirname, '..', 'src', 'svg', 'fixtures');
@@ -22,6 +23,84 @@ async function createTempDir(prefix: string) {
 }
 
 describe('generateWebfonts', () => {
+    const renameFiles = ['plus.svg', 'minus.svg', 'close.svg'].map(file => join(fixturesRoot, 'icons', 'cleanicons', file));
+    const renameOptions = {
+        css: false,
+        dest: tmpdir(),
+        files: renameFiles,
+        fontName: 'renamed',
+        html: false,
+        types: ['svg'] as FontType[],
+        writeFiles: false,
+    };
+
+    it('applies rename callbacks in file order', async () => {
+        const calls: string[] = [];
+        const result = await generateWebfonts({
+            ...renameOptions,
+            rename(path) {
+                calls.push(path);
+                return `renamed-${calls.length}`;
+            },
+        });
+
+        expect(calls).toEqual(renameFiles);
+        expect(
+            Buffer.from(result.svg)
+                .toString('utf8')
+                .match(/glyph-name="renamed-\d"/g),
+        ).toEqual(['glyph-name="renamed-1"', 'glyph-name="renamed-2"', 'glyph-name="renamed-3"']);
+    });
+
+    it('stops rename callbacks at the first exception', async () => {
+        const calls: string[] = [];
+        await expect(
+            generateWebfonts({
+                ...renameOptions,
+                rename(path) {
+                    calls.push(path);
+                    if (calls.length === 2) throw new Error('rename failed');
+                    return `renamed-${calls.length}`;
+                },
+            }),
+        ).rejects.toThrow('rename failed');
+        expect(calls).toEqual(renameFiles.slice(0, 2));
+    });
+
+    it('stops rename callbacks at the first invalid return', async () => {
+        const calls: string[] = [];
+        await expect(
+            generateWebfonts({
+                ...renameOptions,
+                rename(path) {
+                    calls.push(path);
+                    return undefined as never;
+                },
+            }),
+        ).rejects.toThrow('rename callback must return a string');
+        expect(calls).toEqual(renameFiles.slice(0, 1));
+    });
+
+    it('calls every rename callback before rejecting duplicate names', async () => {
+        const calls: string[] = [];
+        await expect(
+            generateWebfonts({
+                ...renameOptions,
+                rename(path) {
+                    calls.push(path);
+                    return 'duplicate';
+                },
+            }),
+        ).rejects.toThrow('The glyph name "duplicate" must be unique.');
+        expect(calls).toEqual(renameFiles);
+    });
+
+    it('rejects an invalid raw rename batch length', async () => {
+        await expect(generateNativeBinding({ ...renameOptions, types: undefined }, paths => paths.slice(1))).rejects.toThrow(
+            'rename callback returned an unexpected number of glyph names',
+        );
+    });
+
     it('generates a ttf font and writes it to disk when ttf is requested', async () => {
         const dest = await createTempDir('vite-ttf-native-');
         const result = await generateWebfonts({


### PR DESCRIPTION
## Summary

- batch rename paths into one NAPI `ThreadsafeFunction` crossing per generation
- preserve the public per-path `rename(path) => name` API in the JavaScript wrapper
- validate callback return values, ordering, batch length, duplicate names, and thrown exceptions
- use `call_async_catch` so JavaScript exceptions reject instead of reaching NAPI-RS's fatal-exception path

## Performance

Order-alternating paired runs normalized rename generation against callback-free controls in the same process:

| Glyphs | Rename generation | Callback wait |
| ---: | ---: | ---: |
| 100 | 6.5% faster | 92% lower |
| 300 | 5.3% faster | 96% lower |
| 600 | 3.4% faster | 97% lower |

The supported package API remains `rename(path) => name`. The generated raw binding callback changes to the internal batched `(paths) => names` contract and is not exported by `package.json`.

## Validation

- `vp check`
- `vp run test` (329 tests)
- focused rename order/error/invalid-return/duplicate/raw-length tests
- default, CLI, and NAPI Cargo tests
- Clippy for default, CLI, and NAPI features
- `cargo fmt -- --check`
- `cargo bench --features bench --no-run`