### PR TITLE
perf(webfont-generator): reuse structured path hashes

### DIFF
--- a/packages/webfont-generator/src/ttf/mod.rs
+++ b/packages/webfont-generator/src/ttf/mod.rs
@@ -203,7 +203,10 @@ fn compiled_glyph_cache_key(glyph: &ProcessedGlyph, advance_width: u16) -> u64 {
     // here. Not persisted across runs, so hasher stability across versions is
     // a non-concern.
     let mut hasher = FxHasher::default();
-    hash_glyph_path(&mut hasher, glyph);
+    match glyph.ttf_path_hash {
+        Some(path_hash) => hasher.write_u64(path_hash),
+        None => hasher.write(glyph.path_data.as_bytes()),
+    }
     hasher.write_u16(advance_width);
     hasher.finish()
 }
@@ -1074,16 +1077,6 @@ fn glyph_paths_equal(left: &ProcessedGlyph, right: &ProcessedGlyph) -> bool {
     match (&left.ttf_path, &right.ttf_path) {
         (Some(left), Some(right)) => left.elements() == right.elements(),
         _ => left.path_data == right.path_data,
-    }
-}
-
-fn hash_glyph_path(hasher: &mut FxHasher, glyph: &ProcessedGlyph) {
-    if let Some(path) = &glyph.ttf_path {
-        for element in path.elements() {
-            hash_path_element(hasher, *element);
-        }
-    } else {
-        hasher.write(glyph.path_data.as_bytes());
     }
 }
 


### PR DESCRIPTION
## Summary

- reuse each processed glyph's existing structured-path hash for compiled-glyph cache keys
- avoid traversing and hashing every structured path again during incremental TTF generation
- preserve the serialized-path fallback and one-shot compilation behavior

## Investigation

PR #367 CI reported incremental TTF edits 9-11% slower. A clean same-machine rerun against PR #365 did not reproduce that regression: changes were +1.1%, -0.1%, and -1.0% at 100/300/600 glyphs, all statistically insignificant.

Inspection still found redundant incremental-only work: `ttf_path_hash` is computed during SVG processing, but compiled-glyph cache lookup traversed the same `BezPath` and recomputed it. This change consumes the stored hash instead.

## Performance

Compared with merged PR #367:

| Glyphs | Incremental TTF edit |
| ---: | ---: |
| 100 | -4.9% trend, not significant |
| 300 | -0.3%, flat |
| 600 | -5.7%, `p = 0.01` |

The fix is not used by one-shot TTF compilation; paired one-shot results remained within run noise.

## Validation

- `vp check`
- `cargo test`
- `cargo test --features cli`
- `cargo test --features napi`
- `vp run @atlowchemi/webfont-generator#bench --no-run`