### PR TITLE
refactor(webfont-generator): centralize endian byte handling

### DIFF
--- a/.agents/opencode-agents/rust-check-runner.md
+++ b/.agents/opencode-agents/rust-check-runner.md
@@ -6,7 +6,7 @@ permission:
     edit: deny
     bash:
         '*': deny
-        'vp run @atlowchemi/webfont-generator#check*': allow
+        'vp run @atlowchemi/webfont-generator#check': allow
 ---
 
 Run `vp run @atlowchemi/webfont-generator#check` from the repository root.

--- a/.agents/opencode-agents/test-runner.md
+++ b/.agents/opencode-agents/test-runner.md
@@ -7,6 +7,7 @@ permission:
     bash:
         '*': deny
         'vp run test*': allow
+        'vp run @atlowchemi/webfont-generator#test': allow
 ---
 
 Run `vp run test` from the repository root.

--- a/packages/webfont-generator/src/byte_helpers/big_endian/mod.rs
+++ b/packages/webfont-generator/src/byte_helpers/big_endian/mod.rs
@@ -1,0 +1,115 @@
+use std::io::{Error, ErrorKind};
+
+pub(crate) struct BigEndian<T>(T);
+
+impl<T> BigEndian<T> {
+    pub(crate) fn new(bytes: T) -> Self {
+        Self(bytes)
+    }
+}
+
+impl<T: AsRef<[u8]>> BigEndian<T> {
+    pub(crate) fn read_u16(&self, offset: usize) -> Result<u16, Error> {
+        let bytes = self.0.as_ref().get(offset..offset + 2).ok_or_else(|| {
+            Error::new(
+                ErrorKind::UnexpectedEof,
+                "Unexpected EOF while reading u16.",
+            )
+        })?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+
+    pub(crate) fn read_u32(&self, offset: usize) -> Result<u32, Error> {
+        let bytes = self.0.as_ref().get(offset..offset + 4).ok_or_else(|| {
+            Error::new(
+                ErrorKind::UnexpectedEof,
+                "Unexpected EOF while reading u32.",
+            )
+        })?;
+        Ok(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+}
+
+impl<T: AsMut<[u8]>> BigEndian<T> {
+    pub(crate) fn write_i16_at(&mut self, offset: usize, value: i16) {
+        self.0.as_mut()[offset..offset + 2].copy_from_slice(&value.to_be_bytes());
+    }
+
+    pub(crate) fn write_u16_at(&mut self, offset: usize, value: u16) {
+        self.0.as_mut()[offset..offset + 2].copy_from_slice(&value.to_be_bytes());
+    }
+
+    pub(crate) fn write_u32_at(&mut self, offset: usize, value: u32) {
+        self.0.as_mut()[offset..offset + 4].copy_from_slice(&value.to_be_bytes());
+    }
+}
+
+impl BigEndian<&mut Vec<u8>> {
+    pub(crate) fn push_i16(&mut self, value: i16) {
+        self.0.extend_from_slice(&value.to_be_bytes());
+    }
+
+    pub(crate) fn push_u16(&mut self, value: u16) {
+        self.0.extend_from_slice(&value.to_be_bytes());
+    }
+
+    pub(crate) fn push_u32(&mut self, value: u32) {
+        self.0.extend_from_slice(&value.to_be_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::ErrorKind;
+
+    use super::BigEndian;
+
+    #[test]
+    fn reads_u16_and_u32_at_offsets() {
+        let reader = BigEndian::new([0x12, 0x34, 0x56, 0x78, 0x9a]);
+
+        assert_eq!(reader.read_u16(1).unwrap(), 0x3456);
+        assert_eq!(reader.read_u32(1).unwrap(), 0x3456_789a);
+    }
+
+    #[test]
+    fn rejects_reads_past_the_end() {
+        let reader = BigEndian::new([0; 4]);
+
+        assert_eq!(
+            reader.read_u16(3).unwrap_err().kind(),
+            ErrorKind::UnexpectedEof
+        );
+        assert_eq!(
+            reader.read_u32(1).unwrap_err().kind(),
+            ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[test]
+    fn writes_at_offsets_and_appends() {
+        let mut bytes = [0; 6];
+        {
+            let mut writer = BigEndian::new(&mut bytes);
+            writer.write_u16_at(0, 0x1234);
+            writer.write_u32_at(2, 0x5678_9abc);
+        }
+        assert_eq!(bytes, [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+
+        let mut output = Vec::new();
+        {
+            let mut writer = BigEndian::new(&mut output);
+            writer.push_u16(0x1234);
+            writer.push_u32(0x5678_9abc);
+        }
+        assert_eq!(output, bytes);
+
+        let mut signed = [0; 2];
+        BigEndian::new(&mut signed).write_i16_at(0, -2);
+        assert_eq!(signed, [0xff, 0xfe]);
+
+        let mut signed = Vec::new();
+        BigEndian::new(&mut signed).push_i16(-2);
+        assert_eq!(signed, [0xff, 0xfe]);
+    }
+}

--- a/packages/webfont-generator/src/byte_helpers/little_endian/mod.rs
+++ b/packages/webfont-generator/src/byte_helpers/little_endian/mod.rs
@@ -1,0 +1,34 @@
+pub(crate) struct LittleEndian<T>(T);
+
+impl<T> LittleEndian<T> {
+    pub(crate) fn new(bytes: T) -> Self {
+        Self(bytes)
+    }
+}
+
+impl<T: AsMut<[u8]>> LittleEndian<T> {
+    pub(crate) fn write_u16_at(&mut self, offset: usize, value: u16) {
+        self.0.as_mut()[offset..offset + 2].copy_from_slice(&value.to_le_bytes());
+    }
+
+    pub(crate) fn write_u32_at(&mut self, offset: usize, value: u32) {
+        self.0.as_mut()[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LittleEndian;
+
+    #[test]
+    fn writes_u16_and_u32_at_offsets() {
+        let mut bytes = [0; 6];
+        {
+            let mut writer = LittleEndian::new(&mut bytes);
+            writer.write_u16_at(0, 0x1234);
+            writer.write_u32_at(2, 0x5678_9abc);
+        }
+
+        assert_eq!(bytes, [0x34, 0x12, 0xbc, 0x9a, 0x78, 0x56]);
+    }
+}

--- a/packages/webfont-generator/src/byte_helpers/mod.rs
+++ b/packages/webfont-generator/src/byte_helpers/mod.rs
@@ -1,0 +1,5 @@
+mod big_endian;
+mod little_endian;
+
+pub(crate) use big_endian::BigEndian;
+pub(crate) use little_endian::LittleEndian;

--- a/packages/webfont-generator/src/eot/mod.rs
+++ b/packages/webfont-generator/src/eot/mod.rs
@@ -1,5 +1,6 @@
 use std::io::{Error, ErrorKind};
 
+use crate::byte_helpers::{BigEndian, LittleEndian};
 use crate::sfnt::SerializedFontTables;
 
 const EOT_PREFIX_SIZE: usize = 82;
@@ -57,61 +58,64 @@ pub(crate) fn tables_to_eot(tables: &SerializedFontTables) -> Result<Vec<u8>, Er
     };
 
     let mut prefix = vec![0_u8; EOT_PREFIX_SIZE];
-    write_u32_le(&mut prefix, EOT_FONT_LENGTH_OFFSET, ttf.len() as u32)?;
-    write_u32_le(&mut prefix, EOT_VERSION_OFFSET, EOT_VERSION)?;
+    {
+        let mut writer = LittleEndian::new(&mut prefix);
+        writer.write_u32_at(EOT_FONT_LENGTH_OFFSET, ttf.len() as u32);
+        writer.write_u32_at(EOT_VERSION_OFFSET, EOT_VERSION);
+        writer.write_u16_at(EOT_MAGIC_OFFSET, EOT_MAGIC);
+    }
     prefix[EOT_CHARSET_OFFSET] = EOT_CHARSET;
-    write_u16_le(&mut prefix, EOT_MAGIC_OFFSET, EOT_MAGIC)?;
 
     let mut family_name = vec![0_u8];
     let mut subfamily_name = vec![0_u8];
     let mut full_name = vec![0_u8];
     let mut version_string = vec![0_u8];
 
-    let os2_version = read_u16_be(os2, 0)?;
+    let os2_reader = BigEndian::new(os2);
+    let os2_version = os2_reader.read_u16(0)?;
     prefix[EOT_FONT_PANOSE_OFFSET..EOT_FONT_PANOSE_OFFSET + 10].copy_from_slice(
         os2.get(OS2_PANOSE_OFFSET..OS2_PANOSE_OFFSET + 10)
             .ok_or_else(|| Error::new(ErrorKind::InvalidData, "Malformed OS/2 table."))?,
     );
-    prefix[EOT_ITALIC_OFFSET] = (read_u16_be(os2, OS2_FS_SELECTION_OFFSET)? & 0x01) as u8;
-    write_u32_le(
-        &mut prefix,
-        EOT_WEIGHT_OFFSET,
-        u32::from(read_u16_be(os2, OS2_WEIGHT_OFFSET)?),
-    )?;
-    for range_index in 0..4 {
-        write_u32_le(
-            &mut prefix,
-            EOT_UNICODE_RANGE_OFFSET + range_index * 4,
-            read_u32_be(os2, OS2_UNICODE_RANGE_OFFSET + range_index * 4)?,
-        )?;
-    }
-    if os2_version >= 1 {
-        for range_index in 0..2 {
-            write_u32_le(
-                &mut prefix,
-                EOT_CODEPAGE_RANGE_OFFSET + range_index * 4,
-                read_u32_be(os2, OS2_CODEPAGE_RANGE_OFFSET + range_index * 4)?,
-            )?;
+    prefix[EOT_ITALIC_OFFSET] = (os2_reader.read_u16(OS2_FS_SELECTION_OFFSET)? & 0x01) as u8;
+    {
+        let mut writer = LittleEndian::new(&mut prefix);
+        writer.write_u32_at(
+            EOT_WEIGHT_OFFSET,
+            u32::from(os2_reader.read_u16(OS2_WEIGHT_OFFSET)?),
+        );
+        for range_index in 0..4 {
+            writer.write_u32_at(
+                EOT_UNICODE_RANGE_OFFSET + range_index * 4,
+                os2_reader.read_u32(OS2_UNICODE_RANGE_OFFSET + range_index * 4)?,
+            );
         }
+        if os2_version >= 1 {
+            for range_index in 0..2 {
+                writer.write_u32_at(
+                    EOT_CODEPAGE_RANGE_OFFSET + range_index * 4,
+                    os2_reader.read_u32(OS2_CODEPAGE_RANGE_OFFSET + range_index * 4)?,
+                );
+            }
+        }
+        writer.write_u32_at(
+            EOT_CHECKSUM_ADJUSTMENT_OFFSET,
+            BigEndian::new(head).read_u32(HEAD_CHECKSUM_ADJUSTMENT_OFFSET)?,
+        );
     }
 
-    write_u32_le(
-        &mut prefix,
-        EOT_CHECKSUM_ADJUSTMENT_OFFSET,
-        read_u32_be(head, HEAD_CHECKSUM_ADJUSTMENT_OFFSET)?,
-    )?;
-
-    let name_count = read_u16_be(name, NAME_TABLE_COUNT_OFFSET)? as usize;
-    let string_offset = read_u16_be(name, NAME_TABLE_STRING_OFFSET_OFFSET)? as usize;
+    let name_reader = BigEndian::new(name);
+    let name_count = name_reader.read_u16(NAME_TABLE_COUNT_OFFSET)? as usize;
+    let string_offset = name_reader.read_u16(NAME_TABLE_STRING_OFFSET_OFFSET)? as usize;
 
     for record_index in 0..name_count {
         let record_offset = NAME_TABLE_HEADER_SIZE + record_index * NAME_RECORD_SIZE;
-        let platform_id = read_u16_be(name, record_offset + NAME_PLATFORM_ID_OFFSET)?;
-        let encoding_id = read_u16_be(name, record_offset + NAME_ENCODING_ID_OFFSET)?;
-        let language_id = read_u16_be(name, record_offset + NAME_LANGUAGE_ID_OFFSET)?;
-        let name_id = read_u16_be(name, record_offset + NAME_NAME_ID_OFFSET)?;
-        let name_length = read_u16_be(name, record_offset + NAME_LENGTH_OFFSET)? as usize;
-        let name_offset = read_u16_be(name, record_offset + NAME_OFFSET_OFFSET)? as usize;
+        let platform_id = name_reader.read_u16(record_offset + NAME_PLATFORM_ID_OFFSET)?;
+        let encoding_id = name_reader.read_u16(record_offset + NAME_ENCODING_ID_OFFSET)?;
+        let language_id = name_reader.read_u16(record_offset + NAME_LANGUAGE_ID_OFFSET)?;
+        let name_id = name_reader.read_u16(record_offset + NAME_NAME_ID_OFFSET)?;
+        let name_length = name_reader.read_u16(record_offset + NAME_LENGTH_OFFSET)? as usize;
+        let name_offset = name_reader.read_u16(record_offset + NAME_OFFSET_OFFSET)? as usize;
 
         if platform_id == 3 && encoding_id == 1 && language_id == LANGUAGE_ENGLISH {
             let value = name
@@ -148,7 +152,7 @@ pub(crate) fn tables_to_eot(tables: &SerializedFontTables) -> Result<Vec<u8>, Er
     eot.extend_from_slice(&[0, 0]);
     eot.extend_from_slice(ttf);
     let eot_length = eot.len() as u32;
-    write_u32_le(&mut eot, EOT_LENGTH_OFFSET, eot_length)?;
+    LittleEndian::new(&mut eot).write_u32_at(EOT_LENGTH_OFFSET, eot_length);
 
     Ok(eot)
 }
@@ -168,7 +172,7 @@ fn strbuf(utf16be: &[u8]) -> Result<Vec<u8>, Error> {
         ));
     }
     let mut output = vec![0_u8; utf16be.len() + 4];
-    write_u16_le(&mut output, 0, utf16be.len() as u16)?;
+    LittleEndian::new(&mut output).write_u16_at(0, utf16be.len() as u16);
 
     for (index, chunk) in utf16be.as_chunks::<2>().0.iter().enumerate() {
         output[2 + index * 2] = chunk[1];
@@ -178,54 +182,72 @@ fn strbuf(utf16be: &[u8]) -> Result<Vec<u8>, Error> {
     Ok(output)
 }
 
-fn read_u16_be(data: &[u8], offset: usize) -> Result<u16, Error> {
-    let bytes = data.get(offset..offset + 2).ok_or_else(|| {
-        Error::new(
-            ErrorKind::UnexpectedEof,
-            "Unexpected EOF while reading u16.",
-        )
-    })?;
-    Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
-}
-
-fn read_u32_be(data: &[u8], offset: usize) -> Result<u32, Error> {
-    let bytes = data.get(offset..offset + 4).ok_or_else(|| {
-        Error::new(
-            ErrorKind::UnexpectedEof,
-            "Unexpected EOF while reading u32.",
-        )
-    })?;
-    Ok(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
-}
-
-fn write_u16_le(data: &mut [u8], offset: usize, value: u16) -> Result<(), Error> {
-    let bytes = value.to_le_bytes();
-    let slice = data.get_mut(offset..offset + 2).ok_or_else(|| {
-        Error::new(
-            ErrorKind::UnexpectedEof,
-            "Unexpected EOF while writing u16.",
-        )
-    })?;
-    slice.copy_from_slice(&bytes);
-    Ok(())
-}
-
-fn write_u32_le(data: &mut [u8], offset: usize, value: u32) -> Result<(), Error> {
-    let bytes = value.to_le_bytes();
-    let slice = data.get_mut(offset..offset + 4).ok_or_else(|| {
-        Error::new(
-            ErrorKind::UnexpectedEof,
-            "Unexpected EOF while writing u32.",
-        )
-    })?;
-    slice.copy_from_slice(&bytes);
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{EOT_VERSION, tables_to_eot};
+    use std::io::ErrorKind;
+
+    use super::{EOT_PREFIX_SIZE, EOT_VERSION, tables_to_eot};
+    use crate::byte_helpers::BigEndian;
+    use crate::sfnt::SerializedFontTables;
     use crate::test_helpers::fixture_font_tables;
+
+    fn name_table(records: &[(u16, u16, u16, u16, &str)]) -> Vec<u8> {
+        let string_offset = 6 + records.len() * 12;
+        let mut table = Vec::with_capacity(string_offset);
+        table.extend_from_slice(&0_u16.to_be_bytes());
+        table.extend_from_slice(&(records.len() as u16).to_be_bytes());
+        table.extend_from_slice(&(string_offset as u16).to_be_bytes());
+
+        let mut strings = Vec::new();
+        for &(platform, encoding, language, name_id, value) in records {
+            let encoded = value
+                .encode_utf16()
+                .flat_map(u16::to_be_bytes)
+                .collect::<Vec<_>>();
+            table.extend_from_slice(&platform.to_be_bytes());
+            table.extend_from_slice(&encoding.to_be_bytes());
+            table.extend_from_slice(&language.to_be_bytes());
+            table.extend_from_slice(&name_id.to_be_bytes());
+            table.extend_from_slice(&(encoded.len() as u16).to_be_bytes());
+            table.extend_from_slice(&(strings.len() as u16).to_be_bytes());
+            strings.extend_from_slice(&encoded);
+        }
+        table.extend_from_slice(&strings);
+        table
+    }
+
+    fn font_tables(os2: Vec<u8>, head: Vec<u8>, name: Vec<u8>) -> SerializedFontTables {
+        SerializedFontTables::new(vec![(*b"OS/2", os2), (*b"head", head), (*b"name", name)])
+            .expect("test tables should serialize")
+    }
+
+    fn valid_os2() -> Vec<u8> {
+        let mut os2 = vec![0; 86];
+        os2[32..42].copy_from_slice(&[2, 11, 6, 4, 2, 2, 2, 2, 2, 4]);
+        {
+            let mut writer = BigEndian::new(&mut os2);
+            writer.write_u16_at(0, 1);
+            writer.write_u16_at(4, 700);
+            for (index, value) in [1, 2, 4, 8].into_iter().enumerate() {
+                writer.write_u32_at(42 + index * 4, value);
+            }
+            writer.write_u16_at(62, 1);
+            writer.write_u32_at(78, 0x1122_3344);
+            writer.write_u32_at(82, 0x5566_7788);
+        }
+        os2
+    }
+
+    fn eot_name(value: &str) -> Vec<u8> {
+        let encoded = value
+            .encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+        let mut result = (encoded.len() as u16).to_le_bytes().to_vec();
+        result.extend_from_slice(&encoded);
+        result.extend_from_slice(&[0, 0]);
+        result
+    }
 
     #[test]
     fn generates_an_eot_buffer_with_expected_header() {
@@ -237,5 +259,111 @@ mod tests {
             u32::from_le_bytes(result[8..12].try_into().unwrap()),
             EOT_VERSION
         );
+    }
+
+    #[test]
+    fn copies_ttf_metadata_and_english_windows_names() {
+        let tables = font_tables(
+            valid_os2(),
+            vec![0; 12],
+            name_table(&[
+                (3, 1, 0x0409, 1, "Family"),
+                (3, 1, 0x0409, 2, "Bold"),
+                (3, 1, 0x0409, 4, "Family Bold"),
+                (3, 1, 0x0409, 5, "Version 1"),
+                (3, 1, 0x0409, 99, "Ignored ID"),
+                (3, 1, 0x0411, 1, "Ignored language"),
+            ]),
+        );
+        let ttf = tables.ttf().to_vec();
+        let checksum_adjustment = tables
+            .tables()
+            .iter()
+            .find(|table| table.tag == *b"head")
+            .expect("head table should exist")
+            .bytes[8..12]
+            .try_into()
+            .map(u32::from_be_bytes)
+            .expect("checksum adjustment should be four bytes");
+
+        let result = tables_to_eot(&tables).expect("expected EOT generation to succeed");
+
+        assert_eq!(
+            u32::from_le_bytes(result[0..4].try_into().unwrap()) as usize,
+            result.len()
+        );
+        assert_eq!(
+            u32::from_le_bytes(result[4..8].try_into().unwrap()) as usize,
+            ttf.len()
+        );
+        assert_eq!(&result[16..26], &[2, 11, 6, 4, 2, 2, 2, 2, 2, 4]);
+        assert_eq!(result[26], 1);
+        assert_eq!(result[27], 1);
+        assert_eq!(u32::from_le_bytes(result[28..32].try_into().unwrap()), 700);
+        for (index, value) in [1, 2, 4, 8].into_iter().enumerate() {
+            assert_eq!(
+                u32::from_le_bytes(result[36 + index * 4..40 + index * 4].try_into().unwrap()),
+                value
+            );
+        }
+        assert_eq!(&result[52..56], &0x1122_3344_u32.to_le_bytes());
+        assert_eq!(&result[56..60], &0x5566_7788_u32.to_le_bytes());
+        assert_eq!(&result[60..64], &checksum_adjustment.to_le_bytes());
+
+        let mut suffix = Vec::new();
+        for value in ["Family", "Bold", "Version 1", "Family Bold"] {
+            suffix.extend_from_slice(&eot_name(value));
+        }
+        suffix.extend_from_slice(&[0, 0]);
+        suffix.extend_from_slice(&ttf);
+        assert_eq!(&result[EOT_PREFIX_SIZE..], suffix);
+    }
+
+    #[test]
+    fn rejects_missing_or_malformed_required_tables() {
+        let missing = SerializedFontTables::new(vec![]).unwrap();
+        let error = tables_to_eot(&missing).expect_err("missing tables should fail");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("Required TTF sections"));
+
+        let cases = [
+            (
+                font_tables(vec![0; 63], vec![0; 12], name_table(&[])),
+                ErrorKind::UnexpectedEof,
+                "reading u16",
+            ),
+            (
+                font_tables(valid_os2(), vec![0; 11], name_table(&[])),
+                ErrorKind::UnexpectedEof,
+                "reading u32",
+            ),
+            (
+                font_tables(valid_os2(), vec![0; 12], vec![0; 5]),
+                ErrorKind::UnexpectedEof,
+                "reading u16",
+            ),
+        ];
+        for (tables, kind, message) in cases {
+            let error = tables_to_eot(&tables).expect_err("malformed table should fail");
+            assert_eq!(error.kind(), kind);
+            assert!(error.to_string().contains(message));
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_name_record_ranges_and_utf16() {
+        let mut outside = name_table(&[(3, 1, 0x0409, 1, "A")]);
+        outside.truncate(18);
+        let error = tables_to_eot(&font_tables(valid_os2(), vec![0; 12], outside))
+            .expect_err("out-of-range name should fail");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("Malformed name table record"));
+
+        let mut odd = name_table(&[(3, 1, 0x0409, 1, "A")]);
+        odd[14..16].copy_from_slice(&1_u16.to_be_bytes());
+        let error = tables_to_eot(&font_tables(valid_os2(), vec![0; 12], odd))
+            .expect_err("odd UTF-16BE name should fail");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("Malformed UTF-16BE"));
     }
 }

--- a/packages/webfont-generator/src/lib.rs
+++ b/packages/webfont-generator/src/lib.rs
@@ -59,6 +59,7 @@
 //!   Not enabled by default — use `cargo install webfont-generator --features cli`.
 //! - **`napi`**: Enables Node.js NAPI bindings for use as a native addon.
 
+mod byte_helpers;
 mod eot;
 mod incremental;
 mod sfnt;

--- a/packages/webfont-generator/src/sfnt.rs
+++ b/packages/webfont-generator/src/sfnt.rs
@@ -1,6 +1,7 @@
 use std::io::{Error, ErrorKind};
 use std::sync::{Arc, OnceLock};
 
+use crate::byte_helpers::BigEndian;
 use write_fonts::read::tables::compute_checksum;
 
 const CHECKSUM_ADJUSTMENT: u32 = 0xb1b0_afba;
@@ -111,8 +112,8 @@ fn apply_checksum_adjustment(tables: &mut [SerializedTable]) {
     if let Some(head) = tables.iter_mut().find(|table| table.tag == HEAD_TAG)
         && head.bytes.len() >= HEAD_CHECKSUM_ADJUSTMENT_OFFSET + 4
     {
-        head.bytes[HEAD_CHECKSUM_ADJUSTMENT_OFFSET..HEAD_CHECKSUM_ADJUSTMENT_OFFSET + 4]
-            .copy_from_slice(&checksum_adjustment.to_be_bytes());
+        BigEndian::new(&mut head.bytes)
+            .write_u32_at(HEAD_CHECKSUM_ADJUSTMENT_OFFSET, checksum_adjustment);
     }
 }
 
@@ -152,17 +153,21 @@ fn sfnt_directory(tables: &[SerializedTable]) -> Vec<u8> {
     let mut directory =
         Vec::with_capacity(SFNT_HEADER_SIZE + records.len() * SFNT_TABLE_ENTRY_SIZE);
     directory.extend_from_slice(&TT_SFNT_VERSION);
-    write_u16_be(&mut directory, tables.len() as u16);
-    let (search_range, entry_selector, range_shift) =
-        search_range(tables.len(), SFNT_TABLE_ENTRY_SIZE);
-    write_u16_be(&mut directory, search_range);
-    write_u16_be(&mut directory, entry_selector);
-    write_u16_be(&mut directory, range_shift);
+    {
+        let mut dir_writer = BigEndian::new(&mut directory);
+        dir_writer.push_u16(tables.len() as u16);
+        let (search_range, entry_selector, range_shift) =
+            search_range(tables.len(), SFNT_TABLE_ENTRY_SIZE);
+        dir_writer.push_u16(search_range);
+        dir_writer.push_u16(entry_selector);
+        dir_writer.push_u16(range_shift);
+    }
     for (tag, checksum, offset, length) in records {
         directory.extend_from_slice(&tag);
-        write_u32_be(&mut directory, checksum);
-        write_u32_be(&mut directory, offset as u32);
-        write_u32_be(&mut directory, length as u32);
+        let mut dir_writer = BigEndian::new(&mut directory);
+        dir_writer.push_u32(checksum);
+        dir_writer.push_u32(offset as u32);
+        dir_writer.push_u32(length as u32);
     }
     directory
 }
@@ -188,12 +193,4 @@ fn align4(bytes: &mut Vec<u8>) {
 
 fn align4_len(len: usize) -> usize {
     (len + 3) & !3
-}
-
-fn write_u16_be(output: &mut Vec<u8>, value: u16) {
-    output.extend_from_slice(&value.to_be_bytes());
-}
-
-fn write_u32_be(output: &mut Vec<u8>, value: u32) {
-    output.extend_from_slice(&value.to_be_bytes());
 }

--- a/packages/webfont-generator/src/woff/mod.rs
+++ b/packages/webfont-generator/src/woff/mod.rs
@@ -1,6 +1,7 @@
 use std::hash::Hasher;
 use std::io::{Error, ErrorKind, Write};
 
+use crate::byte_helpers::BigEndian;
 use crate::sfnt::SerializedFontTables;
 use crate::ttf::{Woff1PayloadCache, Woff2TransformCache};
 use flate2::Compression;
@@ -94,11 +95,11 @@ fn inject_woff_metadata(woff: &mut Vec<u8>, metadata: &str) -> Result<(), Error>
 
     let total_length = woff.len() as u32;
 
-    woff[LENGTH_POS..LENGTH_POS + 4].copy_from_slice(&total_length.to_be_bytes());
-    woff[META_OFFSET_POS..META_OFFSET_POS + 4].copy_from_slice(&meta_offset.to_be_bytes());
-    woff[META_LENGTH_POS..META_LENGTH_POS + 4].copy_from_slice(&meta_length.to_be_bytes());
-    woff[META_ORIG_LENGTH_POS..META_ORIG_LENGTH_POS + 4]
-        .copy_from_slice(&meta_orig_length.to_be_bytes());
+    let mut writer = BigEndian::new(woff);
+    writer.write_u32_at(LENGTH_POS, total_length);
+    writer.write_u32_at(META_OFFSET_POS, meta_offset);
+    writer.write_u32_at(META_LENGTH_POS, meta_length);
+    writer.write_u32_at(META_ORIG_LENGTH_POS, meta_orig_length);
 
     Ok(())
 }
@@ -164,24 +165,28 @@ fn encode_woff1(
     let mut woff = Vec::with_capacity(total_length);
     woff.extend_from_slice(&WOFF_SIGNATURE);
     woff.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
-    write_u32_be(&mut woff, total_length as u32);
-    write_u16_be(&mut woff, table_count as u16);
-    write_u16_be(&mut woff, 0);
-    write_u32_be(&mut woff, total_sfnt_size(tables));
-    write_u16_be(&mut woff, 1);
-    write_u16_be(&mut woff, 0);
-    write_u32_be(&mut woff, 0);
-    write_u32_be(&mut woff, 0);
-    write_u32_be(&mut woff, 0);
-    write_u32_be(&mut woff, 0);
-    write_u32_be(&mut woff, 0);
+    {
+        let mut woff_writer = BigEndian::new(&mut woff);
+        woff_writer.push_u32(total_length as u32);
+        woff_writer.push_u16(table_count as u16);
+        woff_writer.push_u16(0);
+        woff_writer.push_u32(total_sfnt_size(tables));
+        woff_writer.push_u16(1);
+        woff_writer.push_u16(0);
+        woff_writer.push_u32(0);
+        woff_writer.push_u32(0);
+        woff_writer.push_u32(0);
+        woff_writer.push_u32(0);
+        woff_writer.push_u32(0);
+    }
 
     for (tag, offset, comp_length, orig_length, checksum) in entries {
         woff.extend_from_slice(&tag);
-        write_u32_be(&mut woff, offset);
-        write_u32_be(&mut woff, comp_length);
-        write_u32_be(&mut woff, orig_length);
-        write_u32_be(&mut woff, checksum);
+        let mut woff_writer = BigEndian::new(&mut woff);
+        woff_writer.push_u32(offset);
+        woff_writer.push_u32(comp_length);
+        woff_writer.push_u32(orig_length);
+        woff_writer.push_u32(checksum);
     }
 
     align4(&mut woff);
@@ -223,14 +228,6 @@ fn align4(bytes: &mut Vec<u8>) {
 
 fn align4_len(len: usize) -> usize {
     (len + 3) & !3
-}
-
-fn write_u16_be(output: &mut Vec<u8>, value: u16) {
-    output.extend_from_slice(&value.to_be_bytes());
-}
-
-fn write_u32_be(output: &mut Vec<u8>, value: u32) {
-    output.extend_from_slice(&value.to_be_bytes());
 }
 
 #[cfg(test)]

--- a/packages/webfont-generator/src/woff/woff2.rs
+++ b/packages/webfont-generator/src/woff/woff2.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::hash::Hasher;
 use std::io::{Cursor, Error, ErrorKind};
 
+use crate::byte_helpers::BigEndian;
 use crate::sfnt::{SerializedFontTables, SerializedTable};
 use crate::ttf::{Woff2TransformCache, Woff2TransformPayload};
 use brotli::enc::backward_references::BrotliEncoderMode;
@@ -325,8 +326,9 @@ fn transform_glyf_loca(
             )
         {
             set_bitmap_bit(&mut streams.bbox_bitmap, usize::from(glyph_id));
+            let mut writer = BigEndian::new(&mut streams.bboxes);
             for value in [glyph.x_min(), glyph.y_min(), glyph.x_max(), glyph.y_max()] {
-                streams.bboxes.extend_from_slice(&value.to_be_bytes());
+                writer.push_i16(value);
             }
         }
     }
@@ -335,14 +337,14 @@ fn transform_glyf_loca(
         i16::from(source_index_format == 1 || normalized_glyf.len() / 2 > usize::from(u16::MAX));
     let mut normalized_loca =
         Vec::with_capacity(offsets.len() * if loca_format == 0 { 2 } else { 4 });
+    let mut writer = BigEndian::new(&mut normalized_loca);
     for offset in offsets {
         if loca_format == 0 {
-            normalized_loca.extend_from_slice(&((offset / 2) as u16).to_be_bytes());
+            writer.push_u16((offset / 2) as u16);
         } else {
-            normalized_loca.extend_from_slice(
-                &u32::try_from(offset)
-                    .map_err(|_| invalid_data("normalized glyf size exceeds u32"))?
-                    .to_be_bytes(),
+            writer.push_u32(
+                u32::try_from(offset)
+                    .map_err(|_| invalid_data("normalized glyf size exceeds u32"))?,
             );
         }
     }
@@ -374,14 +376,17 @@ fn write_normalized_simple_glyph(
     if contour_count <= 0 {
         return Err(invalid_data("non-empty zero-contour glyph is malformed"));
     }
-    output.extend_from_slice(&contour_count.to_be_bytes());
-    for value in [glyph.x_min(), glyph.y_min(), glyph.x_max(), glyph.y_max()] {
-        output.extend_from_slice(&value.to_be_bytes());
+    {
+        let mut writer = BigEndian::new(&mut *output);
+        writer.push_i16(contour_count);
+        for value in [glyph.x_min(), glyph.y_min(), glyph.x_max(), glyph.y_max()] {
+            writer.push_i16(value);
+        }
+        for end_point in glyph.end_pts_of_contours() {
+            writer.push_u16(end_point.get());
+        }
+        writer.push_u16(glyph.instruction_length());
     }
-    for end_point in glyph.end_pts_of_contours() {
-        output.extend_from_slice(&end_point.get().to_be_bytes());
-    }
-    output.extend_from_slice(&glyph.instruction_length().to_be_bytes());
     output.extend_from_slice(glyph.instructions());
 
     scratch.flags.clear();
@@ -438,10 +443,9 @@ fn write_normalized_coordinate(
         }
         output.push(delta.unsigned_abs() as u8);
     } else {
-        output.extend_from_slice(
-            &i16::try_from(delta)
-                .map_err(|_| invalid_data("simple glyph coordinate delta exceeds i16"))?
-                .to_be_bytes(),
+        BigEndian::new(output).push_i16(
+            i16::try_from(delta)
+                .map_err(|_| invalid_data("simple glyph coordinate delta exceeds i16"))?,
         );
     }
     Ok(())
@@ -462,8 +466,9 @@ fn normalized_head(
     let mut bytes = head.bytes.clone();
     bytes[8..12].fill(0);
     let flags = u16::from_be_bytes(bytes[16..18].try_into().unwrap()) | (1 << 11);
-    bytes[16..18].copy_from_slice(&flags.to_be_bytes());
-    bytes[50..52].copy_from_slice(&normalized.loca_format.to_be_bytes());
+    let mut writer = BigEndian::new(&mut bytes);
+    writer.write_u16_at(16, flags);
+    writer.write_i16_at(50, normalized.loca_format);
     let head_checksum = compute_checksum(&bytes);
 
     let table_count =
@@ -511,7 +516,7 @@ fn normalized_head(
             .checked_add((table_len + 3) & !3)
             .ok_or_else(|| invalid_data("SFNT size overflow"))?;
     }
-    bytes[8..12].copy_from_slice(&0xb1b0_afba_u32.wrapping_sub(checksum).to_be_bytes());
+    BigEndian::new(&mut bytes).write_u32_at(8, 0xb1b0_afba_u32.wrapping_sub(checksum));
     Ok(bytes)
 }
 
@@ -555,16 +560,18 @@ fn finish_glyf_transform(
         .and_then(|size| size.checked_add(streams.overlap_bitmap.len()))
         .ok_or_else(|| invalid_data("transformed glyf size overflow"))?;
     let mut output = Vec::with_capacity(payload_len);
-    output.extend_from_slice(&0_u16.to_be_bytes());
-    output.extend_from_slice(&u16::from(!streams.overlap_bitmap.is_empty()).to_be_bytes());
-    output.extend_from_slice(&num_glyphs.to_be_bytes());
-    output.extend_from_slice(&(transformed_index_format as u16).to_be_bytes());
-    for length in lengths {
-        output.extend_from_slice(
-            &u32::try_from(length)
-                .map_err(|_| invalid_data("transformed glyf stream exceeds u32"))?
-                .to_be_bytes(),
-        );
+    {
+        let mut writer = BigEndian::new(&mut output);
+        writer.push_u16(0);
+        writer.push_u16(u16::from(!streams.overlap_bitmap.is_empty()));
+        writer.push_u16(num_glyphs);
+        writer.push_i16(transformed_index_format);
+        for length in lengths {
+            writer.push_u32(
+                u32::try_from(length)
+                    .map_err(|_| invalid_data("transformed glyf stream exceeds u32"))?,
+            );
+        }
     }
     output.extend_from_slice(&streams.contours);
     output.extend_from_slice(&streams.points);
@@ -671,14 +678,17 @@ fn assemble(prepared: &PreparedWoff2, compressed: &[u8]) -> Result<Vec<u8>, Erro
 
     let mut output = Vec::with_capacity(length as usize);
     output.extend_from_slice(b"wOF2");
-    output.extend_from_slice(&0x0001_0000_u32.to_be_bytes());
-    output.extend_from_slice(&length.to_be_bytes());
-    output.extend_from_slice(&prepared.table_count.to_be_bytes());
-    output.extend_from_slice(&0_u16.to_be_bytes());
-    output.extend_from_slice(&prepared.total_sfnt_size.to_be_bytes());
-    output.extend_from_slice(&compressed_size.to_be_bytes());
-    output.extend_from_slice(&1_u16.to_be_bytes());
-    output.extend_from_slice(&0_u16.to_be_bytes());
+    {
+        let mut writer = BigEndian::new(&mut output);
+        writer.push_u32(0x0001_0000);
+        writer.push_u32(length);
+        writer.push_u16(prepared.table_count);
+        writer.push_u16(0);
+        writer.push_u32(prepared.total_sfnt_size);
+        writer.push_u32(compressed_size);
+        writer.push_u16(1);
+        writer.push_u16(0);
+    }
     output.extend_from_slice(&[0; 20]);
     output.extend_from_slice(&prepared.directory);
     output.extend_from_slice(compressed);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ importers:
         version: 0.11.12
     packageManagerDependencies:
       pnpm:
-        specifier: 12.0.0-rc.7
-        version: 12.0.0-rc.7
+        specifier: 12.0.0-rc.8
+        version: 12.0.0-rc.8
 
 packages:
 
@@ -59,55 +59,55 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.7':
-    resolution: {integrity: sha512-IVRQGs1GB5YcVivwGewvdHkdCBrTYoInSnvJMslYa/BDTXDxQ352gVwpw0x7JvyfEKLrYcPQERxLBkPrjj2abA==}
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.8':
+    resolution: {integrity: sha512-XYgZKxljZDstk+AWEL9c7VVtOYXy2axsNuovybAiZdn3Te2UtpijeaflwVhoHGDuyNKn1Kx/732efkDuAmaVvQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.7':
-    resolution: {integrity: sha512-L1tyIoFaAyOFYKxIboJx3yaVhdzjW0kEtrgxqAIbYosCO97jdrd5uLDFhY7kh8UbdTNy5Je1mVj+6e7YOJmbzQ==}
+  '@pnpm/exe.darwin-x64@12.0.0-rc.8':
+    resolution: {integrity: sha512-Sp7QH8SE4oUyq1H27vEN2EwMu71Ai2hnaD7I51RDb9XgoyzkCqPvOS4ArTacF6PHzem83DikM96ri8UALNnBYg==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.7':
-    resolution: {integrity: sha512-nDTlQXIwySKDkM9pkUazRs08xzdhZAdhBpd5afn/v/ECvcrSMPgGqDqDOY8xxchdv0BkX+OTjyEGZI3MYbSlSg==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.8':
+    resolution: {integrity: sha512-zDykZQZSheZqwJhtFXOXB6jJdzYM7/e63TM4yDwFGulu1wglsXzlxUbGXe4h/JoARaTxi3aNNrY/vjPA3qE0RA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.7':
-    resolution: {integrity: sha512-bs2dlLs+gVjs7gmM4zrhHC20ca20EAjluvkpBIoQJe+rf6gXEKtaMo7WcbnpsQChCEv3GhM//hVoRnbRZhR/jw==}
+  '@pnpm/exe.linux-arm64@12.0.0-rc.8':
+    resolution: {integrity: sha512-cB4h4MuzTCUGJ+jwOTLq+Mn6v5ACqmr63OuFhbfjXtaGGsevEdNkOpDZPVTECtrL9QafgxHwSwXOHDuX+khXSg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.7':
-    resolution: {integrity: sha512-fGdJQx0pXAbMYE36SiCHbHVvaOWyPKyBuVMlNTHU3XWfX94kiOx7pEzfAlODTYEFyk9vZABSLyyQZ2EvVSNKiA==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.8':
+    resolution: {integrity: sha512-nATQIAF7FhZURrb5pchSxGln+Oo2AIQk/pLmiPY4CImQpqQA3kfCFA3cIpR0B5Wd+YLSztXnOfbmtIi2JqC+tw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.7':
-    resolution: {integrity: sha512-NZ16HBgXA6CPL4qCm5fku/C5paHZSLT243bG/27hCGysAXkN+ZJy+rZZKx6SKGUzVimi+9t0owPUNZ6XLSkWzQ==}
+  '@pnpm/exe.linux-x64@12.0.0-rc.8':
+    resolution: {integrity: sha512-hyl3+mcTHO29oAM7nlsSlZBDaVQa1EOKIJk6UP89w0YvEcW7QlFmqrIkyVU/WdVi4/zfMnlokvz5+Goa+plPzg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.7':
-    resolution: {integrity: sha512-JKrB3taWXcN1OtZq95X5Sfe/Dk2JYkwgd+qXNmjK/RHpiS+G1pE45L5u77KXVhQQ8MoctLthK1CMA5TbXX3bIg==}
+  '@pnpm/exe.win32-arm64@12.0.0-rc.8':
+    resolution: {integrity: sha512-C8zZEjUT/c4XgWdSAxga7hd+ycCbYFG+odYUxBNajgcAvihT9K0jkLQy1ZjjFnioSjOelTU1hBBcTvNE4rmHdw==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.7':
-    resolution: {integrity: sha512-AVEC3/Q+opA1npNqM+yqirXvufRpftoLwWs9OlRE7Euhx76FGHGkB72fi2VyNiFBkfovcwOfwOPM0h1geVFYaw==}
+  '@pnpm/exe.win32-x64@12.0.0-rc.8':
+    resolution: {integrity: sha512-qMIjnUQZvADhJd8dIlvJ9P6TJwwp2umZfD2/JMJ9ioMx53dCOtvsjMMOQTHabsDuJNWz/xZPQBa7BkPpiOzXeA==}
     cpu: [x64]
     os: [win32]
 
   '@pnpm/pacquet@0.11.12':
     resolution: {integrity: sha512-/1mL6IEu3EiVhGc5vpispCjkmtTlOgLrTOuS4H6qcngoyB5ISHDg8Ops19nPU7vbl3aF2ER8+EVj4nZ4oPw+WA==}
 
-  pnpm@12.0.0-rc.7:
-    resolution: {integrity: sha512-HZZwaee7QL7qTi67X01s+qsJkRlZPNK/0mUW9MbhUaOH2bOiBfjWKSZNa9dks15b/bOPqc95jmJSAzU7xvuyVA==}
+  pnpm@12.0.0-rc.8:
+    resolution: {integrity: sha512-mmOJqeXlh1fc2f4BG6gmN9tGQOD9+zc+wzVuXK9s+cvWrXaQsDD2eRU7M9QMJKm+blPnU0/B8Q3cqFXn8dci1g==}
     engines: {node: '>=18.*'}
     hasBin: true
 
@@ -137,28 +137,28 @@ snapshots:
   '@pacquet/win32-x64@0.11.12':
     optional: true
 
-  '@pnpm/exe.darwin-arm64@12.0.0-rc.7':
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.8':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-rc.7':
+  '@pnpm/exe.darwin-x64@12.0.0-rc.8':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.7':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.8':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-rc.7':
+  '@pnpm/exe.linux-arm64@12.0.0-rc.8':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-rc.7':
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.8':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-rc.7':
+  '@pnpm/exe.linux-x64@12.0.0-rc.8':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-rc.7':
+  '@pnpm/exe.win32-arm64@12.0.0-rc.8':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-rc.7':
+  '@pnpm/exe.win32-x64@12.0.0-rc.8':
     optional: true
 
   '@pnpm/pacquet@0.11.12':
@@ -172,16 +172,16 @@ snapshots:
       '@pacquet/win32-arm64': 0.11.12
       '@pacquet/win32-x64': 0.11.12
 
-  pnpm@12.0.0-rc.7:
+  pnpm@12.0.0-rc.8:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-rc.7
-      '@pnpm/exe.darwin-x64': 12.0.0-rc.7
-      '@pnpm/exe.linux-arm64': 12.0.0-rc.7
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.7
-      '@pnpm/exe.linux-x64': 12.0.0-rc.7
-      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.7
-      '@pnpm/exe.win32-arm64': 12.0.0-rc.7
-      '@pnpm/exe.win32-x64': 12.0.0-rc.7
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.8
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.8
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.8
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.8
+      '@pnpm/exe.linux-x64': 12.0.0-rc.8
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.8
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.8
+      '@pnpm/exe.win32-x64': 12.0.0-rc.8
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
## Summary

- add reusable big- and little-endian byte helpers with focused unit coverage
- migrate EOT, SFNT, WOFF, and WOFF2 serialization to the shared helpers
- expand EOT coverage for metadata conversion and malformed table handling
- allow package-scoped Rust verification commands in the runner agents
- refresh the pnpm lockfile to 12.0.0-rc.8