### PR TITLE
test(webfont-generator): cover writing and SVG parsing

### DIFF
--- a/packages/webfont-generator/src/svg/parse.rs
+++ b/packages/webfont-generator/src/svg/parse.rs
@@ -278,3 +278,143 @@ fn parse_number_prefix(value: &str) -> Option<f64> {
 
     trimmed[..end].parse::<f64>().ok()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::types::LoadedSvgFile;
+
+    fn parse(svg: &str, preserve_aspect_ratio: bool) -> Result<ParsedGlyph, Error> {
+        let source_file = LoadedSvgFile {
+            contents: Arc::from(svg),
+            glyph_name: "inline".to_owned(),
+            path: "inline.svg".to_owned(),
+        };
+        parse_svg_glyph(
+            &GlyphWorkItem {
+                codepoint: 0xe001,
+                index: 0,
+                name: "inline",
+                source_file: &source_file,
+            },
+            preserve_aspect_ratio,
+            &usvg::Options::default(),
+        )
+    }
+
+    fn parse_error(svg: &str) -> Error {
+        match parse(svg, false) {
+            Err(error) => error,
+            Ok(_) => panic!("expected SVG parsing to fail"),
+        }
+    }
+
+    #[test]
+    fn reports_xml_viewbox_and_usvg_errors_distinctly() {
+        let error = match parse_svg_document("<svg><") {
+            Err(error) => error,
+            Ok(_) => panic!("expected XML inspection to fail"),
+        };
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to inspect SVG root element")
+        );
+
+        let error =
+            parse_error(r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 nope 10"/>"#);
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to parse the SVG viewBox")
+        );
+
+        let error = parse_error("<html/>");
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to parse SVG fixture 'inline.svg'")
+        );
+    }
+
+    #[test]
+    fn parses_viewboxes_and_dimension_prefixes() {
+        assert_eq!(parse_view_box("1, 2, 30, 40"), Some((1.0, 2.0, 30.0, 40.0)));
+        assert_eq!(parse_view_box("0 0 10"), None);
+        assert_eq!(parse_view_box("0 0 ten 10"), None);
+
+        assert_eq!(parse_number_prefix("250px"), Some(250.0));
+        assert_eq!(parse_number_prefix(" -1.5e2pt"), Some(-150.0));
+        assert_eq!(parse_number_prefix("none"), None);
+        assert_eq!(parse_number_prefix("."), None);
+    }
+
+    #[test]
+    fn parses_filled_paths_without_a_viewbox() {
+        let glyph = parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10">
+                <path d="M0 0H20V10H0Z"/>
+            </svg>"#,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(glyph.codepoint, 0xe001);
+        assert_eq!(glyph.name, "inline");
+        assert_eq!((glyph.width, glyph.height), (20.0, 10.0));
+        assert_eq!(glyph.paths.len(), 1);
+    }
+
+    #[test]
+    fn builds_only_the_required_root_viewbox_correction() {
+        let metrics = RootSvgMetrics {
+            current_preserve_aspect_ratio: true,
+            view_box_height: 100.0,
+            view_box_width: 100.0,
+            view_box_x: 0.0,
+            view_box_y: 0.0,
+            viewport_height: 100.0,
+            viewport_width: 200.0,
+        };
+
+        assert!(
+            build_root_viewbox_correction(&metrics, true)
+                .unwrap()
+                .is_none()
+        );
+        let correction = build_root_viewbox_correction(&metrics, false)
+            .unwrap()
+            .expect("stretching should require a correction");
+        assert!(transforms_close(
+            correction,
+            Transform::from_row(2.0, 0.0, 0.0, 1.0, -100.0, 0.0)
+        ));
+    }
+
+    #[test]
+    fn collects_stroke_caps_joins_and_dashes_but_ignores_images() {
+        let glyph = parse(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+                <path d="M10 10H90" fill="none" stroke="black" stroke-width="4" stroke-linecap="butt"/>
+                <path d="M10 20H90" fill="none" stroke="black" stroke-width="4" stroke-linecap="round"/>
+                <path d="M10 30H90" fill="none" stroke="black" stroke-width="4" stroke-linecap="square"/>
+                <path d="M10 45L50 35L90 45" fill="none" stroke="black" stroke-width="4" stroke-linejoin="miter"/>
+                <path d="M10 55L50 45L90 55" fill="none" stroke="black" stroke-width="4" stroke-linejoin="miter-clip"/>
+                <path d="M10 65L50 55L90 65" fill="none" stroke="black" stroke-width="4" stroke-linejoin="round"/>
+                <path d="M10 75L50 65L90 75" fill="none" stroke="black" stroke-width="4" stroke-linejoin="bevel"/>
+                <path d="M10 90H90" fill="none" stroke="black" stroke-width="4" stroke-dasharray="8 4" stroke-dashoffset="2"/>
+                <image width="1" height="1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="/>
+            </svg>"#,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(glyph.paths.len(), 8);
+        assert!(glyph.paths.iter().all(|path| path.bounds().width() > 0.0));
+    }
+}

--- a/packages/webfont-generator/src/write.rs
+++ b/packages/webfont-generator/src/write.rs
@@ -126,12 +126,14 @@ pub(crate) async fn write_generate_webfonts_result(
     }
 
     while let Some(result) = tasks.join_next().await {
-        result.map_err(|error| {
-            std::io::Error::other(format!("Native write task failed: {error}"))
-        })??;
+        result.map_err(native_write_task_error)??;
     }
 
     Ok(written)
+}
+
+fn native_write_task_error(error: tokio::task::JoinError) -> std::io::Error {
+    std::io::Error::other(format!("Native write task failed: {error}"))
 }
 
 fn record_written_output(
@@ -208,4 +210,180 @@ fn write_output_file_if_changed(
     std::fs::write(&path, bytes)?;
     written.insert(path, hash);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Mutex, OnceLock};
+
+    use super::*;
+    use crate::test_helpers::{resolve_options, webfont_fixture};
+    use crate::types::FontOutputs;
+    use crate::{FontType, GenerateWebfontsOptions};
+
+    fn temp_root(name: &str) -> std::path::PathBuf {
+        static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+        std::env::temp_dir().join(format!(
+            "webfont-write-{name}-{}-{}",
+            std::process::id(),
+            NEXT_ID.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn output_contents_exposes_shared_text_shared_bytes_and_owned_bytes() {
+        let bytes = Arc::new(vec![1, 2, 3]);
+        let text = Arc::new("css".to_owned());
+
+        assert_eq!(OutputContents::Bytes(bytes).as_bytes(), &[1, 2, 3]);
+        assert_eq!(OutputContents::Text(text).as_bytes(), b"css");
+        assert_eq!(OutputContents::Owned(vec![4, 5, 6]).as_bytes(), &[4, 5, 6]);
+    }
+
+    #[test]
+    fn records_output_hash_only_for_incremental_writes() {
+        let mut untracked = None;
+        record_written_output(&mut untracked, "icons.css", b"css");
+        assert!(untracked.is_none());
+
+        let mut tracked = Some(HashMap::new());
+        record_written_output(&mut tracked, "icons.css", b"css");
+        assert_eq!(tracked.unwrap()["icons.css"], output_hash(b"css"));
+    }
+
+    #[tokio::test]
+    async fn async_writer_creates_parents_and_reports_filesystem_errors() {
+        let root = temp_root("async");
+        let output = root.join("nested/font.woff2");
+
+        write_output_file(output.to_string_lossy().into_owned(), b"font")
+            .await
+            .unwrap();
+        assert_eq!(std::fs::read(&output).unwrap(), b"font");
+
+        let blocker = root.join("blocker");
+        std::fs::write(&blocker, b"file").unwrap();
+        assert!(
+            write_output_file(
+                blocker.join("child").to_string_lossy().into_owned(),
+                b"font"
+            )
+            .await
+            .is_err()
+        );
+
+        let directory = root.join("directory");
+        std::fs::create_dir(&directory).unwrap();
+        assert!(
+            write_output_file(directory.to_string_lossy().into_owned(), b"font")
+                .await
+                .is_err()
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn async_writer_dispatches_every_font_format() {
+        let root = temp_root("formats");
+        let options = resolve_options(GenerateWebfontsOptions {
+            css: Some(false),
+            dest: root.to_string_lossy().into_owned(),
+            files: vec![webfont_fixture("add.svg")],
+            font_name: Some("icons".to_owned()),
+            html: Some(false),
+            incremental: Some(true),
+            types: Some(vec![
+                FontType::Svg,
+                FontType::Ttf,
+                FontType::Woff,
+                FontType::Woff2,
+                FontType::Eot,
+            ]),
+            ..Default::default()
+        });
+        let result = GenerateWebfontsResult {
+            cached: OnceLock::new(),
+            carried_render: None,
+            css_context: None,
+            fonts: FontOutputs {
+                svg_font: Some(Arc::new("svg".to_owned())),
+                ttf_font: Some(Arc::new(b"ttf".to_vec())),
+                woff_font: Some(Arc::new(b"woff".to_vec())),
+                woff2_font: Some(Arc::new(b"woff2".to_vec())),
+                eot_font: Some(Arc::new(b"eot".to_vec())),
+            },
+            html_context: None,
+            options: Arc::new(options),
+            regeneration_state: Arc::new(Mutex::new(None)),
+            source_files: Arc::new(Vec::new()),
+        };
+
+        assert!(
+            write_generate_webfonts_result(&result)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_empty()
+        );
+        for (extension, expected) in [
+            ("svg", b"svg".as_slice()),
+            ("ttf", b"ttf".as_slice()),
+            ("woff", b"woff".as_slice()),
+            ("woff2", b"woff2".as_slice()),
+            ("eot", b"eot".as_slice()),
+        ] {
+            assert_eq!(
+                std::fs::read(root.join(format!("icons.{extension}"))).unwrap(),
+                expected
+            );
+        }
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_panicking_write_tasks_as_io_errors() {
+        let error = tokio::spawn(async { panic!("write task panic") })
+            .await
+            .unwrap_err();
+        let error = native_write_task_error(error);
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(error.to_string().contains("Native write task failed"));
+        assert!(error.to_string().contains("write task panic"));
+    }
+
+    #[test]
+    fn sync_writer_skips_known_content_and_preserves_hash_after_failure() {
+        let root = temp_root("sync");
+        let font = root.join("fonts/icons.woff2");
+        write_output_file_sync(font.to_string_lossy().into_owned(), b"font").unwrap();
+        assert_eq!(std::fs::read(font).unwrap(), b"font");
+
+        let output = root.join("nested/icons.css");
+        let path = output.to_string_lossy().into_owned();
+        let mut written = HashMap::new();
+
+        write_output_file_if_changed(&mut written, path.clone(), b"first").unwrap();
+        assert_eq!(written.get(&path), Some(&output_hash(b"first")));
+
+        std::fs::write(&output, b"sentinel").unwrap();
+        write_output_file_if_changed(&mut written, path.clone(), b"first").unwrap();
+        assert_eq!(std::fs::read(&output).unwrap(), b"sentinel");
+
+        write_output_file_if_changed(&mut written, path.clone(), b"second").unwrap();
+        assert_eq!(std::fs::read(&output).unwrap(), b"second");
+        assert_eq!(written.get(&path), Some(&output_hash(b"second")));
+
+        let directory = root.join("directory");
+        std::fs::create_dir(&directory).unwrap();
+        let directory = directory.to_string_lossy().into_owned();
+        written.insert(directory.clone(), output_hash(b"old"));
+        assert!(write_output_file_if_changed(&mut written, directory.clone(), b"new").is_err());
+        assert_eq!(written.get(&directory), Some(&output_hash(b"old")));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- cover async and sync output writes, format dispatch, hash tracking, and filesystem failures
- verify Tokio task panics are converted to I/O errors
- cover malformed SVGs, viewBox parsing and correction, path strokes, and SVGs without a viewBox