### PR TITLE
ci: upload JavaScript and Rust coverage to Codecov

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,12 @@ jobs:
             - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
               with:
                   components: clippy, rustfmt
+            - name: Install cargo-llvm-cov
+              uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  tool: cargo-llvm-cov
             - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: |
@@ -32,7 +38,15 @@ jobs:
                   run-install: true
                   cache: true
             - run: vp check
-            - run: vp run @atlowchemi/webfont-generator#test
+            - name: Run Rust coverage
+              run: vp run @atlowchemi/webfont-generator#test:coverage
+            - name: Upload Rust coverage reports to Codecov
+              uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+              with:
+                  disable_search: true
+                  files: packages/webfont-generator/rust-lcov.info
+                  flags: rust
+                  token: ${{ secrets.CODECOV_TOKEN }}
 
     build:
         name: Build cross-platform bindings
@@ -201,7 +215,21 @@ jobs:
                   esac
             - name: Run coverage
               if: ${{ matrix.primary }}
-              run: vp test --coverage
+              run: vp test --coverage --reporter=default --reporter=junit --outputFile.junit=junit.xml
+            - name: Upload coverage reports to Codecov
+              if: ${{ matrix.primary }}
+              uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+              with:
+                  flags: javascript
+                  token: ${{ secrets.CODECOV_TOKEN }}
+            - name: Upload test results to Codecov
+              if: ${{ matrix.primary && !cancelled() }}
+              uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+              with:
+                  disable_search: true
+                  files: junit.xml
+                  report_type: test_results
+                  token: ${{ secrets.CODECOV_TOKEN }}
             - name: Run tests
               if: ${{ !matrix.primary }}
               run: vp test

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ target/
 packages/webfont-generator/*.node
 packages/webfont-generator/artifacts/
 packages/webfont-generator/npm/
+packages/webfont-generator/rust-lcov.info
 packages/webfont-generator/target/
 packages/vite-svg-2-webfont/src/fixtures/webfont-test/artifacts/*
 packages/docs/.vitepress/cache

--- a/packages/webfont-generator/vite.config.ts
+++ b/packages/webfont-generator/vite.config.ts
@@ -11,6 +11,12 @@ export default defineProject({
                 dependsOn: ['check'],
                 env: ['UPDATE_SVG_FIXTURES'],
             },
+            'test:coverage': {
+                command:
+                    'cargo llvm-cov clean --workspace && cargo llvm-cov --no-report && cargo llvm-cov --no-report --features cli && cargo llvm-cov --no-report --features napi && cargo llvm-cov report --lcov --output-path rust-lcov.info',
+                dependsOn: ['check'],
+                env: ['UPDATE_SVG_FIXTURES'],
+            },
             build: {
                 command: 'napi build --platform --esm --js binding.js --dts binding.d.ts -- --features napi',
             },


### PR DESCRIPTION
## Summary

- upload Vitest coverage and JUnit test results to Codecov
- add a Rust coverage task using `cargo-llvm-cov`
- upload JavaScript and Rust coverage under separate Codecov flags