### PR TITLE
test: add public API type coverage

### DIFF
--- a/packages/vite-svg-2-webfont/src/fixtures/vite-env.d.ts
+++ b/packages/vite-svg-2-webfont/src/fixtures/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite-plus/client" />

--- a/packages/vite-svg-2-webfont/src/index.test-d.ts
+++ b/packages/vite-svg-2-webfont/src/index.test-d.ts
@@ -1,0 +1,47 @@
+import { expectTypeOf, it } from 'vite-plus/test';
+import type { Plugin } from 'vite';
+import viteSvgToWebfont, { templates, type GeneratedWebfont, type PublicApi, viteSvgToWebfont as namedExport } from './index.js';
+
+it('exports the plugin and its public API', () => {
+    expectTypeOf(namedExport).toEqualTypeOf(viteSvgToWebfont);
+    expectTypeOf(templates).toEqualTypeOf<{ html: string; css: string; scss: string }>();
+    expectTypeOf<GeneratedWebfont>().toEqualTypeOf<{ type: 'svg' | 'ttf' | 'eot' | 'woff' | 'woff2'; href: string }>();
+    expectTypeOf<PublicApi['getGeneratedWebfonts']>().returns.toEqualTypeOf<GeneratedWebfont[]>();
+});
+
+it('preserves selected formats and plugin API types', () => {
+    const plugin = viteSvgToWebfont({
+        context: 'icons',
+        types: ['woff', 'woff2'],
+        preloadFormats: 'woff2',
+        formatOptions: { woff: { metadata: '<metadata />' }, woff2: { compressionQuality: 10 } },
+        cssContext(context) {
+            expectTypeOf(context.fontName).toBeString();
+            expectTypeOf(context.codepoints).toEqualTypeOf<Record<string, string>>();
+        },
+        shouldProcessHtml(context) {
+            expectTypeOf(context).toExtend<{ path: string; filename: string; originalUrl?: string }>();
+            return true;
+        },
+    });
+
+    expectTypeOf(plugin).toExtend<Plugin<PublicApi>>();
+    expectTypeOf(plugin.api).toEqualTypeOf<PublicApi | undefined>();
+});
+
+it('rejects unsupported or unselected formats', () => {
+    expectTypeOf(viteSvgToWebfont).toBeFunction();
+
+    viteSvgToWebfont({
+        context: 'icons',
+        types: ['woff2'],
+        // @ts-expect-error only generated formats can be preloaded
+        preloadFormats: 'svg',
+    });
+
+    viteSvgToWebfont({
+        context: 'icons',
+        // @ts-expect-error not a supported font format
+        types: ['otf'],
+    });
+});

--- a/packages/vite-svg-2-webfont/vite.config.ts
+++ b/packages/vite-svg-2-webfont/vite.config.ts
@@ -55,7 +55,7 @@ const config: UserProjectConfigExport = defineProject({
         experimental: {
             fsModuleCache: true,
         },
-        typecheck: { enabled: true },
+        typecheck: { enabled: true, ignoreSourceErrors: true },
         projects: [
             {
                 test: {

--- a/packages/vite-svg-2-webfont/vite.config.ts
+++ b/packages/vite-svg-2-webfont/vite.config.ts
@@ -55,6 +55,7 @@ const config: UserProjectConfigExport = defineProject({
         experimental: {
             fsModuleCache: true,
         },
+        typecheck: { enabled: true, ignoreSourceErrors: true },
         projects: [
             {
                 test: {

--- a/packages/vite-svg-2-webfont/vite.config.ts
+++ b/packages/vite-svg-2-webfont/vite.config.ts
@@ -55,7 +55,7 @@ const config: UserProjectConfigExport = defineProject({
         experimental: {
             fsModuleCache: true,
         },
-        typecheck: { enabled: true, ignoreSourceErrors: true },
+        typecheck: { enabled: true },
         projects: [
             {
                 test: {

--- a/packages/webfont-generator/tests/index.test-d.ts
+++ b/packages/webfont-generator/tests/index.test-d.ts
@@ -1,0 +1,82 @@
+import { expectTypeOf, it } from 'vite-plus/test';
+import { GenerateWebfontsResult as NativeGenerateWebfontsResult, generateWebfonts as generateNativeWebfonts } from '../binding.js';
+import { generateWebfonts, templates, type CssContext, type FormatOptions, type GenerateWebfontsInputOptions, type GlyphChangeEntry, type HtmlContext } from '../index.js';
+
+it('exports the public generator API', () => {
+    expectTypeOf(generateWebfonts).toBeFunction();
+    expectTypeOf(templates).toEqualTypeOf<{ html: string; css: string; scss: string }>();
+    expectTypeOf<GenerateWebfontsInputOptions>().toExtend<{ dest: string; files: string[] }>();
+    expectTypeOf<FormatOptions>().toExtend<{
+        svg?: { centerVertically?: boolean };
+        ttf?: { ts?: number };
+        woff?: { metadata?: string };
+        woff2?: { compressionQuality?: number };
+    }>();
+    expectTypeOf<GlyphChangeEntry>().toEqualTypeOf<{
+        path: string;
+        changeType: 'added' | 'changed' | 'removed';
+        name?: string;
+    }>();
+});
+
+it('narrows generated formats from the input', async () => {
+    const result = await generateWebfonts({
+        dest: 'fonts',
+        files: ['icon.svg'],
+        types: ['svg', 'woff2'],
+        order: ['woff2', 'svg'],
+        rename(name) {
+            expectTypeOf(name).toBeString();
+            return name;
+        },
+        cssContext(context) {
+            expectTypeOf(context).toEqualTypeOf<CssContext>();
+        },
+        htmlContext(context) {
+            expectTypeOf(context).toEqualTypeOf<HtmlContext>();
+        },
+    });
+
+    expectTypeOf(result.svg).toBeString();
+    expectTypeOf(result.woff2).toEqualTypeOf<Uint8Array>();
+    expectTypeOf(result.eot).toBeNull();
+    expectTypeOf(result.ttf).toBeNull();
+    expectTypeOf(result.woff).toBeNull();
+    expectTypeOf(result.generateCss({ svg: '/font.svg' })).toBeString();
+    expectTypeOf(result.generateHtml()).toBeString();
+    expectTypeOf(result.regenerateAsync(['icon.svg'])).resolves.toEqualTypeOf<typeof result>();
+});
+
+it('rejects invalid format combinations and callbacks', () => {
+    expectTypeOf(generateWebfonts).toBeFunction();
+
+    void generateWebfonts({
+        dest: 'fonts',
+        files: ['icon.svg'],
+        types: ['woff2'],
+        // @ts-expect-error order is restricted to selected formats
+        order: ['svg'],
+    });
+
+    void generateWebfonts({
+        dest: 'fonts',
+        files: ['icon.svg'],
+        // @ts-expect-error rename must return a glyph name
+        rename: () => 1,
+    });
+});
+
+it('keeps the generated NAPI declarations compatible', () => {
+    expectTypeOf(generateNativeWebfonts).parameters.toEqualTypeOf<
+        [
+            options: import('../binding.js').GenerateWebfontsOptions,
+            rename?: ((paths: string[]) => string[]) | null,
+            cssContext?: ((context: Record<string, any>) => Record<string, any>) | null,
+            htmlContext?: ((context: Record<string, any>) => Record<string, any>) | null,
+        ]
+    >();
+    expectTypeOf<NativeGenerateWebfontsResult['svg']>().toEqualTypeOf<string | null>();
+    expectTypeOf<NativeGenerateWebfontsResult['woff2']>().toEqualTypeOf<Uint8Array | null>();
+    expectTypeOf<NativeGenerateWebfontsResult['regenerate']>().parameters.toEqualTypeOf<[files: string[], changes?: GlyphChangeEntry[] | null]>();
+    expectTypeOf<NativeGenerateWebfontsResult['regenerateAsync']>().returns.toEqualTypeOf<Promise<NativeGenerateWebfontsResult>>();
+});

--- a/packages/webfont-generator/tests/index.test-d.ts
+++ b/packages/webfont-generator/tests/index.test-d.ts
@@ -6,6 +6,7 @@ it('exports the public generator API', () => {
     expectTypeOf(generateWebfonts).toBeFunction();
     expectTypeOf(templates).toEqualTypeOf<{ html: string; css: string; scss: string }>();
     expectTypeOf<GenerateWebfontsInputOptions>().toExtend<{ dest: string; files: string[] }>();
+    expectTypeOf<keyof FormatOptions>().toEqualTypeOf<'svg' | 'ttf' | 'woff' | 'woff2'>();
     expectTypeOf<FormatOptions>().toExtend<{
         svg?: { centerVertically?: boolean };
         ttf?: { ts?: number };

--- a/packages/webfont-generator/vite.config.ts
+++ b/packages/webfont-generator/vite.config.ts
@@ -34,6 +34,7 @@ export default defineProject({
         experimental: {
             fsModuleCache: true,
         },
+        typecheck: { enabled: true },
         projects: [
             {
                 test: {

--- a/packages/webfont-generator/vite.config.ts
+++ b/packages/webfont-generator/vite.config.ts
@@ -1,23 +1,32 @@
 import { defineProject } from 'vite-plus';
 
+const cargoCache = {
+    input: [{ auto: true } as const, '!target/**'],
+    output: [{ auto: true } as const, '!target/**'],
+};
+
 export default defineProject({
     run: {
         tasks: {
             check: {
+                ...cargoCache,
                 command: 'cargo clippy -- -D warnings && cargo clippy --features cli -- -D warnings && cargo clippy --features napi -- -D warnings && cargo fmt -- --check',
             },
             test: {
+                ...cargoCache,
                 command: 'cargo t && cargo t --features cli && cargo t --features napi',
                 dependsOn: ['check'],
                 env: ['UPDATE_SVG_FIXTURES'],
             },
             'test:coverage': {
+                ...cargoCache,
                 command:
                     'cargo llvm-cov clean --workspace && cargo llvm-cov --no-report && cargo llvm-cov --no-report --features cli && cargo llvm-cov --no-report --features napi && cargo llvm-cov report --lcov --output-path rust-lcov.info',
                 dependsOn: ['check'],
                 env: ['UPDATE_SVG_FIXTURES'],
             },
             build: {
+                ...cargoCache,
                 command: 'napi build --platform --esm --js binding.js --dts binding.d.ts -- --features napi',
             },
             bench: {
@@ -25,6 +34,7 @@ export default defineProject({
                 command: 'cargo bench --features bench',
             },
             'build:release': {
+                ...cargoCache,
                 command: 'napi build --platform --esm --js binding.js --dts binding.d.ts --release -- --features napi',
                 dependsOn: ['test'],
             },


### PR DESCRIPTION
## Summary
- enable Vitest type checking for the plugin and generator projects
- lock plugin public exports, options, callbacks, and format constraints
- lock generator format inference and generated NAPI declaration compatibility