### PR TITLE
chore(deps): group related Renovate updates

### DIFF
--- a/packages/webfont-generator/vite.config.ts
+++ b/packages/webfont-generator/vite.config.ts
@@ -1,8 +1,10 @@
-import { defineProject } from 'vite-plus';
+import { defineProject, type UserWorkspaceConfig } from 'vite-plus';
 
-const cargoCache = {
-    input: [{ auto: true } as const, '!target/**'],
-    output: [{ auto: true } as const, '!target/**'],
+type TaskDefinition = Partial<Exclude<NonNullable<NonNullable<UserWorkspaceConfig['run']>['tasks']>[string], string | string[]>>;
+
+const cargoCache: TaskDefinition = {
+    input: [{ auto: true }, '!target/**'],
+    output: [{ auto: true }, '!target/**'],
 };
 
 export default defineProject({

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,23 @@
         },
         {
             "groupName": "vite-plus",
-            "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-core"]
+            "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-core", "voidzero-dev/setup-vp"]
+        },
+        {
+            "groupName": "pnpm",
+            "matchPackageNames": ["pnpm", "pnpm/setup"]
+        },
+        {
+            "groupName": "iconify-json",
+            "matchPackageNames": ["@iconify-json/logos", "@iconify-json/simple-icons"]
+        },
+        {
+            "groupName": "napi",
+            "matchPackageNames": ["/^@napi-rs\\//", "/^napi(?:-|$)/"]
+        },
+        {
+            "groupName": "vue and vitepress",
+            "matchPackageNames": ["/^@vue\\//", "/^vue(?:-|$)/", "/^vitepress(?:-|$)/"]
         }
     ],
     "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
## Summary
- type the webfont generator Cargo cache against the Vite+ workspace task definition
- group related pnpm, Iconify, NAPI, and Vue/VitePress Renovate updates
- include `voidzero-dev/setup-vp` in the Vite+ update group